### PR TITLE
Use list(list) to copy instead of list.copy()

### DIFF
--- a/subliminal/core.py
+++ b/subliminal/core.py
@@ -261,7 +261,7 @@ def filter_services(services):
     :rtype: list
 
     """
-    filtered_services = services.copy()
+    filtered_services = list(services)
     for service_name in services:
         mod = __import__('services.' + service_name, globals=globals(), locals=locals(), fromlist=['Service'], level=-1)
         service = mod.Service


### PR DESCRIPTION
list.copy() was not available in my version of Python. Might be a Python3 feature? list(list) should copy the list though.
