### PR TITLE
add python2.6 retro-compatibility to download zipfile

### DIFF
--- a/subliminal/services/__init__.py
+++ b/subliminal/services/__init__.py
@@ -228,6 +228,15 @@ class ServiceBase(object):
                 else:
                     raise DownloadFailedError('No subtitles found in zip file')
             os.remove(zippath)
+        except AttributeError as e: # fall back for python 2.6 not handling ZipFile.__exit__
+            zipsub = zipfile.ZipFile(zippath)
+            for subfile in zipsub.namelist():
+                if os.path.splitext(subfile)[1] in EXTENSIONS:
+                    open(filepath, 'w').write(zipsub.open(subfile).read())
+                    break
+            else:
+                raise DownloadFailedError('No subtitles found in zip file')
+
         except Exception as e:
             logger.error(u'Download %s failed: %s' % (url, e))
             if os.path.exists(zippath):


### PR DESCRIPTION
error was ZipFile.**exit** attribute not existant as mentionned in issue #111.

The download get ignored when a sub is in a zipfile.
The exception was catched and program don't break but some subs provider are de facto not available.

When the exception is raise I use your old code 2.6 compatible.

I'm on debian 6.0.5 (stable) python v2.6.6.
