### PR TITLE
fix codec error when path contains non-ascii string

### DIFF
--- a/scripts/subliminal
+++ b/scripts/subliminal
@@ -75,7 +75,12 @@ def main():
     if args.compatibility:
         paths = args.paths
     else:
-        paths = [unicode(x) for x in args.paths]
+        try:
+            paths = [unicode(x) for x in args.paths]
+        except UnicodeDecodeError:
+            reload(sys)
+            sys.setdefaultencoding('utf8')
+            paths = [unicode(x) for x in args.paths]
 
     # Download subtitles
     with subliminal.Pool(args.workers) as p:


### PR DESCRIPTION
## Error Message:

> 'ascii' codec can't decode byte 0xe7 in position xx: ordinal not in range(xx)
## How to reproduce?

run cli with movie path contains Chinese like:

`subliminal -m -l zh -l en './Hunted.猎杀行动.2012/Hunted.S01E02.720p.WEB-DL.AAC.H.264.mkv'`
## Still get errors for some services.

not sure if it is related.

``` python
WARNING: root Some characters could not be decoded, and were replaced with REPLACEMENT CHARACTER.
ERROR: subliminal.async Exception raised in worker Thread-1
Traceback (most recent call last):
  File "/Library/Python/2.7/site-packages/subliminal-0.6.2-py2.7.egg/subliminal/async.py", line 46, in run
    result = consume_task(task, self.services)
  File "/Library/Python/2.7/site-packages/subliminal-0.6.2-py2.7.egg/subliminal/core.py", line 157, in consume_task
    result = service.list(task.video, task.languages)
  File "/Library/Python/2.7/site-packages/subliminal-0.6.2-py2.7.egg/subliminal/services/__init__.py", line 154, in list
    return self.list_checked(video, languages)
  File "/Library/Python/2.7/site-packages/subliminal-0.6.2-py2.7.egg/subliminal/services/tvsubtitles.py", line 113, in list_checked
    return self.query(video.path or video.release, languages, get_keywords(video.guess), video.series, video.season, video.episode)
  File "/Library/Python/2.7/site-packages/subliminal-0.6.2-py2.7.egg/subliminal/services/tvsubtitles.py", line 118, in query
    sid = self.get_likely_series_id(series.lower())
  File "/Library/Python/2.7/site-packages/subliminal-0.6.2-py2.7.egg/subliminal/cache.py", line 127, in cached
    result = function(*args)
  File "/Library/Python/2.7/site-packages/subliminal-0.6.2-py2.7.egg/subliminal/services/tvsubtitles.py", line 64, in get_likely_series_id
    result = results[0]
IndexError: list index out of range
```
