### PR TITLE
Fixed UnicodeDecodeErrors in verbose mode

### DIFF
--- a/scripts/subliminal
+++ b/scripts/subliminal
@@ -75,7 +75,7 @@ def main():
     if args.compatibility:
         paths = args.paths
     else:
-        paths = [unicode(x) for x in args.paths]
+        paths = [unicode(x, 'utf8') for x in args.paths]
 
     # Download subtitles
     with subliminal.Pool(args.workers) as p:

--- a/subliminal/async.py
+++ b/subliminal/async.py
@@ -51,7 +51,7 @@ class Worker(threading.Thread):
             finally:
                 self.tasks.task_done()
         self.terminate()
-        logger.debug(u'Thread %s terminated' % self.name)
+        logger.debug('Thread %s terminated' % self.name)
 
     def terminate(self):
         """Terminate instantiated services"""

--- a/subliminal/cache.py
+++ b/subliminal/cache.py
@@ -55,7 +55,7 @@ class Cache(object):
 
             self.cache[service_name] = defaultdict(dict)
             filename = self.cache_location(service_name)
-            logger.debug(u'Cache: loading cache from %s' % filename)
+            logger.debug('Cache: loading cache from %s' % filename)
             try:
                 self.cache[service_name] = pickle.load(open(filename, 'rb'))
             except IOError:
@@ -66,7 +66,7 @@ class Cache(object):
 
     def save(self, service_name):
         filename = self.cache_location(service_name)
-        logger.debug(u'Cache: saving cache to %s' % filename)
+        logger.debug('Cache: saving cache to %s' % filename)
         with self.lock:
             pickle.dump(self.cache[service_name], open(filename, 'wb'))
 
@@ -121,7 +121,7 @@ def cachedmethod(function):
 
         if key in func_cache:
             result = func_cache[key]
-            logger.debug(u'Using cached value for %s(%s), returns: %s' % (func_key, key, result))
+            logger.debug('Using cached value for %s(%s), returns: %s' % (func_key, key, result))
             return result
 
         result = function(*args)

--- a/subliminal/core.py
+++ b/subliminal/core.py
@@ -55,7 +55,7 @@ def create_list_tasks(paths, languages, services, force, multi, cache_dir, max_d
     scan_result = []
     for p in paths:
         scan_result.extend(scan(p, max_depth, scan_filter))
-    logger.debug(u'Found %d videos in %r with maximum depth %d' % (len(scan_result), paths, max_depth))
+    logger.debug('Found %d videos in %r with maximum depth %d' % (len(scan_result), paths, max_depth))
     tasks = []
     config = ServiceConfig(multi, cache_dir)
     services = filter_services(services)
@@ -65,19 +65,19 @@ def create_list_tasks(paths, languages, services, force, multi, cache_dir, max_d
         if not force and multi:
             wanted_languages -= detected_languages
             if not wanted_languages:
-                logger.debug(u'No need to list multi subtitles %r for %r because %r detected' % (languages, video, detected_languages))
+                logger.debug('No need to list multi subtitles %r for %r because %r detected' % (languages, video, detected_languages))
                 continue
         if not force and not multi and Language('Undetermined') in detected_languages:
-            logger.debug(u'No need to list single subtitles %r for %r because one detected' % (languages, video))
+            logger.debug('No need to list single subtitles %r for %r because one detected' % (languages, video))
             continue
-        logger.debug(u'Listing subtitles %r for %r with services %r' % (wanted_languages, video, services))
+        logger.debug('Listing subtitles %r for %r with services %r' % (wanted_languages, video, services))
         for service_name in services:
             mod = __import__('services.' + service_name, globals=globals(), locals=locals(), fromlist=['Service'], level=-1)
             service = mod.Service
             if not service.check_validity(video, wanted_languages):
                 continue
             task = ListTask(video, wanted_languages & service.languages, service_name, config)
-            logger.debug(u'Created task %r' % task)
+            logger.debug('Created task %r' % task)
             tasks.append(task)
     return tasks
 
@@ -100,12 +100,12 @@ def create_download_tasks(subtitles_by_video, languages, multi):
             continue
         if not multi:
             task = DownloadTask(video, list(subtitles))
-            logger.debug(u'Created task %r' % task)
+            logger.debug('Created task %r' % task)
             tasks.append(task)
             continue
         for _, by_language in groupby(subtitles, lambda s: languages.index(s.language)):
             task = DownloadTask(video, list(by_language))
-            logger.debug(u'Created task %r' % task)
+            logger.debug('Created task %r' % task)
             tasks.append(task)
     return tasks
 
@@ -158,7 +158,7 @@ def matching_confidence(video, subtitle):
     guess = guessit.guess_file_info(subtitle.release, 'autodetect')
     video_keywords = get_keywords(video.guess)
     subtitle_keywords = get_keywords(guess) | subtitle.keywords
-    logger.debug(u'Video keywords %r - Subtitle keywords %r' % (video_keywords, subtitle_keywords))
+    logger.debug('Video keywords %r - Subtitle keywords %r' % (video_keywords, subtitle_keywords))
     replacement = {'keywords': len(video_keywords & subtitle_keywords)}
     if isinstance(video, Episode):
         replacement.update({'series': 0, 'season': 0, 'episode': 0})
@@ -181,9 +181,9 @@ def matching_confidence(video, subtitle):
             if 'year' in guess and guess['year'] == video.year:
                 replacement['year'] = 1
     else:
-        logger.debug(u'Not able to compute confidence for %r' % video)
+        logger.debug('Not able to compute confidence for %r' % video)
         return 0.0
-    logger.debug(u'Found %r' % replacement)
+    logger.debug('Found %r' % replacement)
     confidence = float(int(matching_format.format(**replacement), 2)) / float(int(best, 2))
     logger.info(u'Computed confidence %.4f for %r and %r' % (confidence, video, subtitle))
     return confidence

--- a/subliminal/services/__init__.py
+++ b/subliminal/services/__init__.py
@@ -80,7 +80,7 @@ class ServiceBase(object):
 
     def init(self):
         """Initialize connection"""
-        logger.debug(u'Initializing %s' % self.__class__.__name__)
+        logger.debug('Initializing %s' % self.__class__.__name__)
         self.session = requests.session(timeout=10, headers={'User-Agent': self.user_agent})
 
     def init_cache(self):
@@ -103,7 +103,7 @@ class ServiceBase(object):
 
     def terminate(self):
         """Terminate connection"""
-        logger.debug(u'Terminating %s' % self.__class__.__name__)
+        logger.debug('Terminating %s' % self.__class__.__name__)
 
     def get_code(self, language):
         """Get the service code for a :class:`~subliminal.language.Language`
@@ -175,10 +175,10 @@ class ServiceBase(object):
         """
         languages = (languages & cls.languages) - language_set(['Undetermined'])
         if not languages:
-            logger.debug(u'No language available for service %s' % cls.__name__.lower())
+            logger.debug('No language available for service %s' % cls.__name__.lower())
             return False
         if cls.require_video and not video.exists or not isinstance(video, tuple(cls.videos)):
-            logger.debug(u'%r is not valid for service %s' % (video, cls.__name__.lower()))
+            logger.debug('%r is not valid for service %s' % (video, cls.__name__.lower()))
             return False
         return True
 
@@ -199,7 +199,7 @@ class ServiceBase(object):
             if os.path.exists(filepath):
                 os.remove(filepath)
             raise DownloadFailedError(str(e))
-        logger.debug(u'Download finished')
+        logger.debug('Download finished')
 
     def download_zip_file(self, url, filepath):
         """Attempt to download a zip file and extract any subtitle file from it, if any.
@@ -235,7 +235,7 @@ class ServiceBase(object):
             if os.path.exists(filepath):
                 os.remove(filepath)
             raise DownloadFailedError(str(e))
-        logger.debug(u'Download finished')
+        logger.debug('Download finished')
 
 
 class ServiceConfig(object):

--- a/subliminal/services/addic7ed.py
+++ b/subliminal/services/addic7ed.py
@@ -63,12 +63,12 @@ class Addic7ed(ServiceBase):
         return self.query(video.path or video.release, languages, get_keywords(video.guess), video.series, video.season, video.episode)
 
     def query(self, filepath, languages, keywords, series, season, episode):
-        logger.debug(u'Getting subtitles for %s season %d episode %d with languages %r' % (series, season, episode, languages))
+        logger.debug('Getting subtitles for %s season %d episode %d with languages %r' % (series, season, episode, languages))
         self.init_cache()
         try:
             series_id = self.get_series_id(series.lower())
         except KeyError:
-            logger.debug(u'Could not find series id for %s' % series)
+            logger.debug('Could not find series id for %s' % series)
             return []
         r = self.session.get('%s/show/%d&season=%d' % (self.server_url, series_id, season))
         soup = BeautifulSoup(r.content, self.required_features)
@@ -78,20 +78,20 @@ class Addic7ed(ServiceBase):
             if int(cells[0].text.strip()) != season or int(cells[1].text.strip()) != episode:
                 continue
             if cells[6].text.strip():
-                logger.debug(u'Skipping hearing impaired')
+                logger.debug('Skipping hearing impaired')
                 continue
             sub_status = cells[5].text.strip()
             if sub_status != 'Completed':
-                logger.debug(u'Wrong subtitle status %s' % sub_status)
+                logger.debug('Wrong subtitle status %s' % sub_status)
                 continue
             sub_language = self.get_language(cells[3].text.strip())
             if sub_language not in languages:
-                logger.debug(u'Language %r not in wanted languages %r' % (sub_language, languages))
+                logger.debug('Language %r not in wanted languages %r' % (sub_language, languages))
                 continue
             sub_keywords = split_keyword(cells[4].text.strip().lower())
             #TODO: Maybe allow empty keywords here? (same in Subtitulos)
             if not keywords & sub_keywords:
-                logger.debug(u'None of subtitle keywords %r in %r' % (sub_keywords, keywords))
+                logger.debug('None of subtitle keywords %r in %r' % (sub_keywords, keywords))
                 continue
             sub_link = '%s/%s' % (self.server_url, cells[9].a['href'])
             sub_path = get_subtitle_path(filepath, sub_language, self.config.multi)
@@ -113,7 +113,7 @@ class Addic7ed(ServiceBase):
             if os.path.exists(subtitle.path):
                 os.remove(subtitle.path)
             raise DownloadFailedError(str(e))
-        logger.debug(u'Download finished')
+        logger.debug('Download finished')
         return subtitle
 
 

--- a/subliminal/services/bierdopje.py
+++ b/subliminal/services/bierdopje.py
@@ -51,12 +51,12 @@ class BierDopje(ServiceBase):
             return None
         soup = BeautifulSoup(r.content, self.required_features)
         if soup.status.contents[0] == 'false':
-            logger.debug(u'Could not find show %s' % series)
+            logger.debug('Could not find show %s' % series)
             return None
         return int(soup.showid.contents[0])
 
     def load_cache(self):
-        logger.debug(u'Loading showids from cache...')
+        logger.debug('Loading showids from cache...')
         with self.lock:
             with open(self.showids_cache, 'r') as f:
                 self.showids = pickle.load(f)
@@ -77,14 +77,14 @@ class BierDopje(ServiceBase):
             raise ServiceError('One or more parameter missing')
         subtitles = []
         for language in languages:
-            logger.debug(u'Getting subtitles for %s %d season %d episode %d with language %s' % (request_source, request_id, season, episode, language.alpha2))
+            logger.debug('Getting subtitles for %s %d season %d episode %d with language %s' % (request_source, request_id, season, episode, language.alpha2))
             r = self.session.get('%sGetAllSubsFor/%s/%s/%s/%s/%s' % (self.server_url, request_id, season, episode, language.alpha2, request_is_tvdbid))
             if r.status_code != 200:
                 logger.error(u'Request %s returned status code %d' % (r.url, r.status_code))
                 return []
             soup = BeautifulSoup(r.content, self.required_features)
             if soup.status.contents[0] == 'false':
-                logger.debug(u'Could not find subtitles for %s %d season %d episode %d with language %s' % (request_source, request_id, season, episode, language.alpha2))
+                logger.debug('Could not find subtitles for %s %d season %d episode %d with language %s' % (request_source, request_id, season, episode, language.alpha2))
                 continue
             path = get_subtitle_path(filepath, language, self.config.multi)
             for result in soup.results('result'):

--- a/subliminal/services/opensubtitles.py
+++ b/subliminal/services/opensubtitles.py
@@ -110,10 +110,10 @@ class OpenSubtitles(ServiceBase):
             raise ServiceError('One or more parameter missing')
         for search in searches:
             search['sublanguageid'] = ','.join(self.get_code(l) for l in languages)
-        logger.debug(u'Getting subtitles %r with token %s' % (searches, self.token))
+        logger.debug('Getting subtitles %r with token %s' % (searches, self.token))
         results = self.server.SearchSubtitles(self.token, searches)
         if not results['data']:
-            logger.debug(u'Could not find subtitles for %r with token %s' % (searches, self.token))
+            logger.debug('Could not find subtitles for %r with token %s' % (searches, self.token))
             return []
         subtitles = []
         for result in results['data']:

--- a/subliminal/services/podnapisi.py
+++ b/subliminal/services/podnapisi.py
@@ -71,7 +71,7 @@ class Podnapisi(ServiceBase):
             logger.error('Search failed with error code %d' % results['status'])
             return []
         if not results['results'] or not results['results'][moviehash]['subtitles']:
-            logger.debug(u'Could not find subtitles for %r with token %s' % (moviehash, self.token))
+            logger.debug('Could not find subtitles for %r with token %s' % (moviehash, self.token))
             return []
         subtitles = []
         for result in results['results'][moviehash]['subtitles']:

--- a/subliminal/services/subswiki.py
+++ b/subliminal/services/subswiki.py
@@ -54,19 +54,19 @@ class SubsWiki(ServiceBase):
             request_series = series.lower().replace(' ', '_')
             if isinstance(request_series, unicode):
                 request_series = request_series.encode('utf-8')
-            logger.debug(u'Getting subtitles for %s season %d episode %d with languages %r' % (series, season, episode, languages))
+            logger.debug('Getting subtitles for %s season %d episode %d with languages %r' % (series, season, episode, languages))
             r = self.session.get('%s/serie/%s/%s/%s/' % (self.server_url, urllib.quote(request_series), season, episode))
             if r.status_code == 404:
-                logger.debug(u'Could not find subtitles for %s season %d episode %d with languages %r' % (series, season, episode, languages))
+                logger.debug('Could not find subtitles for %s season %d episode %d with languages %r' % (series, season, episode, languages))
                 return []
         elif movie and year:
             request_movie = movie.title().replace(' ', '_')
             if isinstance(request_movie, unicode):
                 request_movie = request_movie.encode('utf-8')
-            logger.debug(u'Getting subtitles for %s (%d) with languages %r' % (movie, year, languages))
+            logger.debug('Getting subtitles for %s (%d) with languages %r' % (movie, year, languages))
             r = self.session.get('%s/film/%s_(%d)' % (self.server_url, urllib.quote(request_movie), year))
             if r.status_code == 404:
-                logger.debug(u'Could not find subtitles for %s (%d) with languages %r' % (movie, year, languages))
+                logger.debug('Could not find subtitles for %s (%d) with languages %r' % (movie, year, languages))
                 return []
         else:
             raise ServiceError('One or more parameter missing')
@@ -78,17 +78,17 @@ class SubsWiki(ServiceBase):
         for sub in soup('td', {'class': 'NewsTitle'}):
             sub_keywords = split_keyword(sub.b.string.lower())
             if not keywords & sub_keywords:
-                logger.debug(u'None of subtitle keywords %r in %r' % (sub_keywords, keywords))
+                logger.debug('None of subtitle keywords %r in %r' % (sub_keywords, keywords))
                 continue
             for html_language in sub.parent.parent.find_all('td', {'class': 'language'}):
                 language = self.get_language(html_language.string.strip())
                 if language not in languages:
-                    logger.debug(u'Language %r not in wanted languages %r' % (language, languages))
+                    logger.debug('Language %r not in wanted languages %r' % (language, languages))
                     continue
                 html_status = html_language.find_next_sibling('td')
                 status = html_status.strong.string.strip()
                 if status != 'Completado':
-                    logger.debug(u'Wrong subtitle status %s' % status)
+                    logger.debug('Wrong subtitle status %s' % status)
                     continue
                 path = get_subtitle_path(filepath, language, self.config.multi)
                 subtitle = ResultSubtitle(path, language, self.__class__.__name__.lower(), '%s%s' % (self.server_url, html_status.find_next('td').find('a')['href']))

--- a/subliminal/services/subtitulos.py
+++ b/subliminal/services/subtitulos.py
@@ -53,10 +53,10 @@ class Subtitulos(ServiceBase):
         request_series = series.lower().replace(' ', '_')
         if isinstance(request_series, unicode):
             request_series = unicodedata.normalize('NFKD', request_series).encode('ascii', 'ignore')
-        logger.debug(u'Getting subtitles for %s season %d episode %d with languages %r' % (series, season, episode, languages))
+        logger.debug('Getting subtitles for %s season %d episode %d with languages %r' % (series, season, episode, languages))
         r = self.session.get('%s/%s/%sx%.2d' % (self.server_url, urllib.quote(request_series), season, episode))
         if r.status_code == 404:
-            logger.debug(u'Could not find subtitles for %s season %d episode %d with languages %r' % (series, season, episode, languages))
+            logger.debug('Could not find subtitles for %s season %d episode %d with languages %r' % (series, season, episode, languages))
             return []
         if r.status_code != 200:
             logger.error(u'Request %s returned status code %d' % (r.url, r.status_code))
@@ -66,17 +66,17 @@ class Subtitulos(ServiceBase):
         for sub in soup('div', {'id': 'version'}):
             sub_keywords = split_keyword(self.release_pattern.search(sub.find('p', {'class': 'title-sub'}).contents[1]).group(1).lower())
             if not keywords & sub_keywords:
-                logger.debug(u'None of subtitle keywords %r in %r' % (sub_keywords, keywords))
+                logger.debug('None of subtitle keywords %r in %r' % (sub_keywords, keywords))
                 continue
             for html_language in sub.findAllNext('ul', {'class': 'sslist'}):
                 language = self.get_language(html_language.findNext('li', {'class': 'li-idioma'}).find('strong').contents[0].string.strip())
                 if language not in languages:
-                    logger.debug(u'Language %r not in wanted languages %r' % (language, languages))
+                    logger.debug('Language %r not in wanted languages %r' % (language, languages))
                     continue
                 html_status = html_language.findNext('li', {'class': 'li-estado green'})
                 status = html_status.contents[0].string.strip()
                 if status != 'Completado':
-                    logger.debug(u'Wrong subtitle status %s' % status)
+                    logger.debug('Wrong subtitle status %s' % status)
                     continue
                 path = get_subtitle_path(filepath, language, self.config.multi)
                 subtitle = ResultSubtitle(path, language, self.__class__.__name__.lower(), html_status.findNext('span', {'class': 'descargar green'}).find('a')['href'],

--- a/subliminal/services/thesubdb.py
+++ b/subliminal/services/thesubdb.py
@@ -42,7 +42,7 @@ class TheSubDB(ServiceBase):
     def query(self, filepath, moviehash, languages):
         r = self.session.get(self.server_url, params={'action': 'search', 'hash': moviehash})
         if r.status_code == 404:
-            logger.debug(u'Could not find subtitles for hash %s' % moviehash)
+            logger.debug('Could not find subtitles for hash %s' % moviehash)
             return []
         if r.status_code != 200:
             logger.error(u'Request %s returned status code %d' % (r.url, r.status_code))
@@ -50,7 +50,7 @@ class TheSubDB(ServiceBase):
         available_languages = language_set(r.content.split(','))
         languages &= available_languages
         if not languages:
-            logger.debug(u'Could not find subtitles for hash %s with languages %r (only %r available)' % (moviehash, languages, available_languages))
+            logger.debug('Could not find subtitles for hash %s with languages %r (only %r available)' % (moviehash, languages, available_languages))
             return []
         subtitles = []
         for language in languages:

--- a/subliminal/services/tvsubtitles.py
+++ b/subliminal/services/tvsubtitles.py
@@ -33,7 +33,7 @@ def match(pattern, string):
     try:
         return re.search(pattern, string).group(1)
     except AttributeError:
-        logger.debug(u'Could not match %r on %r' % (pattern, string))
+        logger.debug('Could not match %r on %r' % (pattern, string))
         return None
 
 
@@ -113,13 +113,13 @@ class TvSubtitles(ServiceBase):
         return self.query(video.path or video.release, languages, get_keywords(video.guess), video.series, video.season, video.episode)
 
     def query(self, filepath, languages, keywords, series, season, episode):
-        logger.debug(u'Getting subtitles for %s season %d episode %d with languages %r' % (series, season, episode, languages))
+        logger.debug('Getting subtitles for %s season %d episode %d with languages %r' % (series, season, episode, languages))
         self.init_cache()
         sid = self.get_likely_series_id(series.lower())
         try:
             ep_id = self.get_episode_id(sid, season, episode)
         except KeyError:
-            logger.debug(u'Could not find episode id for %s season %d episode %d' % (series, season, episode))
+            logger.debug('Could not find episode id for %s season %d episode %d' % (series, season, episode))
             return []
         subids = self.get_sub_ids(ep_id)
         # filter the subtitles with our queried languages

--- a/subliminal/videos.py
+++ b/subliminal/videos.py
@@ -126,9 +126,9 @@ class Video(object):
         video_infos = None
         try:
             video_infos = enzyme.parse(self.path)
-            logger.debug(u'Succeeded parsing %s with enzyme: %r' % (self.path, video_infos))
+            logger.debug('Succeeded parsing %s with enzyme: %r' % (self.path, video_infos))
         except:
-            logger.debug(u'Failed parsing %s with enzyme' % self.path)
+            logger.debug('Failed parsing %s with enzyme' % self.path)
         if isinstance(video_infos, enzyme.core.AVContainer):
             results.extend([subtitles.EmbeddedSubtitle.from_enzyme(self.path, s) for s in video_infos.subtitles])
         # cannot use glob here because it chokes if there are any square
@@ -217,13 +217,13 @@ def scan(entry, max_depth=3, scan_filter=None, depth=0):
     if depth > max_depth and max_depth != 0:  # we do not want to search the whole file system except if max_depth = 0
         return []
     if os.path.isdir(entry):  # a dir? recurse
-        logger.debug(u'Scanning directory %s with depth %d/%d' % (entry, depth, max_depth))
+        logger.debug('Scanning directory %s with depth %d/%d' % (entry, depth, max_depth))
         result = []
         for e in os.listdir(entry):
             result.extend(scan(os.path.join(entry, e), max_depth, scan_filter, depth + 1))
         return result
     if os.path.isfile(entry) or depth == 0:
-        logger.debug(u'Scanning file %s with depth %d/%d' % (entry, depth, max_depth))
+        logger.debug('Scanning file %s with depth %d/%d' % (entry, depth, max_depth))
         if depth != 0:  # trust the user: only check for valid format if recursing
             if mimetypes.guess_type(entry)[0] not in MIMETYPES and os.path.splitext(entry)[1] not in EXTENSIONS:
                 return []
@@ -262,7 +262,7 @@ def hash_opensubtitles(path):
             filehash += l_value
             filehash = filehash & 0xFFFFFFFFFFFFFFFF
     returnedhash = '%016x' % filehash
-    logger.debug(u'Computed OpenSubtitle hash %s for %s' % (returnedhash, path))
+    logger.debug('Computed OpenSubtitle hash %s for %s' % (returnedhash, path))
     return returnedhash
 
 
@@ -282,5 +282,5 @@ def hash_thesubdb(path):
         f.seek(-readsize, os.SEEK_END)
         data += f.read(readsize)
     returnedhash = hashlib.md5(data).hexdigest()
-    logger.debug(u'Computed TheSubDB hash %s for %s' % (returnedhash, path))
+    logger.debug('Computed TheSubDB hash %s for %s' % (returnedhash, path))
     return returnedhash


### PR DESCRIPTION
The logger tries to convert utf-8 strings to Unicode, with an ASCII-character set. As UTF-\* is fine for me, I simply changed all logger.debug(u'mystring %s' % (my_utf8_string)) to logger.debug('mystring %s' % (my_utf8_string)), as the encoding of the file is already utf8.
