### PR TITLE
__repr__ result should never contain characters outside ASCII.

### DIFF
--- a/subliminal/videos.py
+++ b/subliminal/videos.py
@@ -152,7 +152,7 @@ class Video(object):
         return unicode(self).encode('utf-8')
 
     def __repr__(self):
-        return '%s(%s)' % (self.__class__.__name__, self)
+        return '%s(%r)' % (self.__class__.__name__, str(self))
 
     def __hash__(self):
         return hash(self.path or self.release)


### PR DESCRIPTION
Fixes issue #202. logger.debug(u"%r" % movie_instance) will no longer cause a UnicodeDecodeError.
