### PR TITLE
Update requirements of enzyme 0.2 to workaround/fix issue #210

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 beautifulsoup4>=4.1.3
 guessit>=0.5.3
 requests>=1.1
-enzyme>=0.2
+enzyme==0.2
 html5lib
 dogpile.cache>=0.4.1


### PR DESCRIPTION
Enzyme 0.3 is not backwards compatible, changing the requirement on the version to strictly 0.2 avoid the failure.
