### PR TITLE
Fixed OpenSubtitles hash for ARM devices

### DIFF
--- a/subliminal/video.py
+++ b/subliminal/video.py
@@ -370,7 +370,7 @@ def hash_opensubtitles(video_path):
     :rtype: string
 
     """
-    bytesize = struct.calcsize(b'q')
+    bytesize = struct.calcsize(b'<q')
     with open(video_path, 'rb') as f:
         filesize = os.path.getsize(video_path)
         filehash = filesize


### PR DESCRIPTION
With this small change the OpenSubtitle hash will now work on BigEndian processors too.
