### PR TITLE
Read paths correctly in video.py

### DIFF
--- a/subliminal/cli.py
+++ b/subliminal/cli.py
@@ -183,7 +183,6 @@ def subliminal():
     # save subtitles
     save_subtitles(subtitles, single=args.single, directory=args.directory, encoding=args.encoding)
 
-
     # result output
     if not subtitles:
         if not args.quiet:


### PR DESCRIPTION
isinstance(p , bytes) checks if `p` is a string, therefore the logical tests are changed to their opposite logical tests.
