### PR TITLE
Fix wrong Turkish subtitle encoding detection #315

### DIFF
--- a/subliminal/subtitle.py
+++ b/subliminal/subtitle.py
@@ -49,6 +49,8 @@ class Subtitle(object):
             encodings.append('windows-1256')
         elif self.language.alpha3 == 'heb':
             encodings.append('windows-1255')
+        elif self.language.alpha3 == 'tur':
+            encodings.extend(['iso-8859-9', 'windows-1254'])
         else:
             encodings.append('latin-1')
 


### PR DESCRIPTION
Because of chardet Turkish encoding detect issue subliminal can't recognize Turkish encoding and convert correctly to utf-8 #315
