### PR TITLE
fixed hearing impaired flag for podnapisi

### DIFF
--- a/subliminal/providers/podnapisi.py
+++ b/subliminal/providers/podnapisi.py
@@ -118,14 +118,14 @@ class PodnapisiProvider(Provider):
             if series and season and episode:
                 subtitles.extend([PodnapisiSubtitle(language, int(s.find('id').text),
                                                     s.find('release').text.split() if s.find('release').text else [],
-                                                    'h' in (s.find('flags').text or ''), s.find('url').text,
+                                                    'n' in (s.find('flags').text or ''), s.find('url').text,
                                                     series=series, season=season, episode=episode,
                                                     year=s.find('year').text)
                                   for s in root.findall('subtitle')])
             elif title:
                 subtitles.extend([PodnapisiSubtitle(language, int(s.find('id').text),
                                                     s.find('release').text.split() if s.find('release').text else [],
-                                                    'h' in (s.find('flags').text or ''), s.find('url').text,
+                                                    'n' in (s.find('flags').text or ''), s.find('url').text,
                                                     title=title, year=s.find('year').text)
                                   for s in root.findall('subtitle')])
             if int(root.find('pagination/current').text) >= int(root.find('pagination/count').text):


### PR DESCRIPTION
According to https://www.podnapisi.net/wiki/wiki/Docs/SSP the hearing impaired flag is 'n' while 'h' is for HD version.
