### PR TITLE
Update for python-guessit 0.7.1

### DIFF
--- a/subliminal/video.py
+++ b/subliminal/video.py
@@ -69,7 +69,7 @@ class Video(object):
 
     @classmethod
     def fromname(cls, name):
-        return cls.fromguess(os.path.split(name)[1], guessit.guess_file_info(name, 'autodetect'))
+        return cls.fromguess(os.path.split(name)[1], guessit.guess_file_info(name))
 
     def __repr__(self):
         return '<%s [%r]>' % (self.__class__.__name__, self.name)
@@ -200,7 +200,7 @@ def scan_video(path, subtitles=True, embedded_subtitles=True):
     """
     dirpath, filename = os.path.split(path)
     logger.info('Scanning video %r in %r', filename, dirpath)
-    video = Video.fromguess(path, guessit.guess_file_info(path, 'autodetect'))
+    video = Video.fromguess(path, guessit.guess_file_info(path))
     video.size = os.path.getsize(path)
     if video.size > 10485760:
         logger.debug('Size is %d', video.size)


### PR DESCRIPTION
The new python-guessit automatically tries to autodetect the type if "movie" or "episode" are not specified, so the 'autodetect' is not needed anymore.

Without this change, subliminal fails with the following error:

```
Traceback (most recent call last):
File "/usr/bin/subliminal", line 9, in <module>
load_entry_point('subliminal==0.8.0-dev', 'console_scripts', 'subliminal')()
File "/usr/lib/python2.7/site-packages/subliminal/cli.py", line 174, in subliminal
embedded_subtitles=not args.force, age=args.age)
File "/usr/lib/python2.7/site-packages/subliminal/video.py", line 309, in scan_videos
videos.append(scan_video(filepath, subtitles, embedded_subtitles))
File "/usr/lib/python2.7/site-packages/subliminal/video.py", line 203, in scan_video
video = Video.fromguess(path, guessit.guess_file_info(path, 'autodetect'))
File "/usr/lib/python2.7/site-packages/subliminal/video.py", line 64, in fromguess
if guess['type'] == 'episode':
KeyError: u'type'
```
