### PR TITLE
Adding support to proper decode Polish and Bulgarian

### DIFF
--- a/subliminal/subtitle.py
+++ b/subliminal/subtitle.py
@@ -51,7 +51,14 @@ class Subtitle(object):
             encodings.append('windows-1255')
         elif self.language.alpha3 == 'tur':
             encodings.extend(['iso-8859-9', 'windows-1254'])
+        elif self.language.alpha3 == 'pol':
+            # Eastern European Group 1
+            encodings.extend(['windows-1250'])
+        elif self.language.alpha3 == 'bul':
+            # Eastern European Group 2
+            encodings.extend(['windows-1251'])
         else:
+            # Western European (windows-1252)
             encodings.append('latin-1')
 
         # try to decode


### PR DESCRIPTION
When subliminal download subtitles in Polish and Bulgarian, it wrongly assumes that the original contexts of the subtitles is encoded in Latin-1 or Unicode. This fix adds the standard encoding associated with each of the languages.
