### PR TITLE
Fix logging error

### DIFF
--- a/subliminal/api.py
+++ b/subliminal/api.py
@@ -189,7 +189,7 @@ class ProviderPool(object):
         for subtitle, score in scored_subtitles:
             # check score
             if score < min_score:
-                logger.info('Score %d is below min_score (%d)', (score, min_score))
+                logger.info('Score %d is below min_score (%d)', score, min_score)
                 break
 
             # check downloaded languages


### PR DESCRIPTION
Fix console error when logging score below min_score
```
Traceback (most recent call last):
  File "C:\Tools\Python-2.7.9\Lib\logging\handlers.py", line 76, in emit
    if self.shouldRollover(record):
  File "C:\Tools\Python-2.7.9\Lib\logging\handlers.py", line 156, in shouldRollover
    msg = "%s\n" % self.format(record)
  File "C:\Tools\Python-2.7.9\Lib\logging\__init__.py", line 732, in format
    return fmt.format(record)
  File "C:\Tools\Python-2.7.9\Lib\logging\__init__.py", line 471, in format
    record.message = record.getMessage()
  File "C:\Tools\Python-2.7.9\Lib\logging\__init__.py", line 335, in getMessage
    msg = msg % self.args
TypeError: %d format: a number is required, not tuple
Logged from file api.py, line 192
```