### PR TITLE
Fix for #507

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -88,6 +88,7 @@ setup(name='subliminal',
           ],
           'babelfish.language_converters': [
               'addic7ed = subliminal.converters.addic7ed:Addic7edConverter',
+              'thesubdb = subliminal.converters.thesubdb:TheSubDBConverter',
               'tvsubtitles = subliminal.converters.tvsubtitles:TVsubtitlesConverter'
           ],
           'console_scripts': [

--- a/subliminal/converters/thesubdb.py
+++ b/subliminal/converters/thesubdb.py
@@ -1,0 +1,25 @@
+# -*- coding: utf-8 -*-
+from babelfish import LanguageReverseConverter
+from subliminal.exceptions import ConfigurationError
+
+
+class TheSubDBConverter(LanguageReverseConverter):
+    def __init__(self):
+        self.from_thesubdb = {'en': ('eng',), 'es': ('spa',), 'fr': ('fra',), 'it': ('ita',), 'nl': ('nld',),
+                              'pl': ('pol',), 'pt': ('por', 'BR'), 'ro': ('ron',), 'sv': ('swe',), 'tr': ('tur',)}
+        self.to_thesubdb = {v: k for k, v in self.from_thesubdb.items()}
+        self.codes = set(self.from_thesubdb.keys())
+
+    def convert(self, alpha3, country=None, script=None):
+        if (alpha3, country) in self.to_thesubdb:
+            return self.to_thesubdb[(alpha3, country)]
+        if (alpha3,) in self.to_thesubdb:
+            return self.to_thesubdb[(alpha3,)]
+
+        raise ConfigurationError('Unsupported language for thesubdb: %s, %s, %s' % (alpha3, country, script))
+
+    def reverse(self, thesubdb):
+        if thesubdb in self.from_thesubdb:
+            return self.from_thesubdb[thesubdb]
+
+        raise ConfigurationError('Unsupported language code for thesubdb: %s' % thesubdb)

--- a/subliminal/providers/thesubdb.py
+++ b/subliminal/providers/thesubdb.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import logging
 
-from babelfish import Language
+from babelfish import Language, language_converters
 from requests import Session
 
 from . import Provider, get_version
@@ -34,7 +34,7 @@ class TheSubDBSubtitle(Subtitle):
 
 
 class TheSubDBProvider(Provider):
-    languages = {Language.fromalpha2(l) for l in ['en', 'es', 'fr', 'it', 'nl', 'pl', 'pt', 'ro', 'sv', 'tr']}
+    languages = {Language.fromthesubdb(l) for l in language_converters['thesubdb'].codes}
     required_hash = 'thesubdb'
     server_url = 'http://api.thesubdb.com/'
 
@@ -61,7 +61,7 @@ class TheSubDBProvider(Provider):
         # loop over languages
         subtitles = []
         for language_code in r.text.split(','):
-            language = Language.fromalpha2(language_code)
+            language = Language.fromthesubdb(language_code)
 
             subtitle = TheSubDBSubtitle(language, hash)
             logger.debug('Found subtitle %r', subtitle)

--- a/tests/test_thesubdb.py
+++ b/tests/test_thesubdb.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 import os
 
-from babelfish import Language
+from babelfish import Language, language_converters
 import pytest
 from vcr import VCR
 
@@ -11,6 +11,31 @@ from subliminal.providers.thesubdb import TheSubDBProvider, TheSubDBSubtitle
 vcr = VCR(path_transformer=lambda path: path + '.yaml',
           record_mode=os.environ.get('VCR_RECORD_MODE', 'once'),
           cassette_library_dir=os.path.join('tests', 'cassettes', 'thesubdb'))
+
+
+@pytest.mark.converter
+def test_converter_convert_alpha3_country():
+    assert language_converters['thesubdb'].convert('por', 'BR') == 'pt'
+
+
+@pytest.mark.converter
+def test_converter_convert_alpha3():
+    assert language_converters['thesubdb'].convert('eng') == 'en'
+
+
+@pytest.mark.converter
+def test_converter_convert_alpha3_alpha2_converter():
+    assert language_converters['thesubdb'].convert('fra') == 'fr'
+
+
+@pytest.mark.converter
+def test_converter_reverse():
+    assert language_converters['thesubdb'].reverse('en') == ('eng', )
+
+
+@pytest.mark.converter
+def test_converter_reverse_alpha3_country():
+    assert language_converters['thesubdb'].reverse('pt') == ('por', 'BR')
 
 
 def test_get_matches(movies):
@@ -29,7 +54,7 @@ def test_get_matches_no_match(episodes):
 @vcr.use_cassette
 def test_query(movies):
     video = movies['man_of_steel']
-    expected_languages = {Language('eng'), Language('por')}
+    expected_languages = {Language('eng'), Language('por', 'BR')}
     with TheSubDBProvider() as provider:
         subtitles = provider.query(video.hashes['thesubdb'])
     assert len(subtitles) == 2


### PR DESCRIPTION
Added pt-BR as a supported language and changed query to match the languages and subtitles accordingly.

This should work now:
```
subliminal  download -l pt -p thesubdb <any.mkv>
subliminal  download -l pt-BR -p thesubdb <any.mkv>
subliminal  download -l pt-BR -p thesubdb -p opensubtitles <any.mkv>
```

Pending unit tests (still trying to fully setup my dev environment to be able to run them)

Waiting feedback and comments.