### PR TITLE
Get enconding from OpenSubtitles provider

### DIFF
--- a/subliminal/providers/opensubtitles.py
+++ b/subliminal/providers/opensubtitles.py
@@ -23,8 +23,8 @@ class OpenSubtitlesSubtitle(Subtitle):
     series_re = re.compile('^"(?P<series_name>.*)" (?P<series_title>.*)$')
 
     def __init__(self, language, hearing_impaired, page_link, subtitle_id, matched_by, movie_kind, hash, movie_name,
-                 movie_release_name, movie_year, movie_imdb_id, series_season, series_episode):
-        super(OpenSubtitlesSubtitle, self).__init__(language, hearing_impaired, page_link)
+                 movie_release_name, movie_year, movie_imdb_id, series_season, series_episode, encoding):
+        super(OpenSubtitlesSubtitle, self).__init__(language, hearing_impaired, page_link, encoding)
         self.subtitle_id = subtitle_id
         self.matched_by = matched_by
         self.movie_kind = movie_kind
@@ -165,10 +165,11 @@ class OpenSubtitlesProvider(Provider):
             movie_imdb_id = int(subtitle_item['IDMovieImdb'])
             series_season = int(subtitle_item['SeriesSeason']) if subtitle_item['SeriesSeason'] else None
             series_episode = int(subtitle_item['SeriesEpisode']) if subtitle_item['SeriesEpisode'] else None
+            encoding = subtitle_item.get('SubEncoding') or None
 
             subtitle = OpenSubtitlesSubtitle(language, hearing_impaired, page_link, subtitle_id, matched_by, movie_kind,
                                              hash, movie_name, movie_release_name, movie_year, movie_imdb_id,
-                                             series_season, series_episode)
+                                             series_season, series_episode, encoding)
             logger.debug('Found subtitle %r', subtitle)
             subtitles.append(subtitle)
 

--- a/subliminal/subtitle.py
+++ b/subliminal/subtitle.py
@@ -5,6 +5,7 @@ import os
 import chardet
 from guessit.matchtree import MatchTree
 from guessit.plugins.transformers import get_transformer
+from codecs import lookup
 import pysrt
 
 from .video import Episode, Movie
@@ -20,12 +21,14 @@ class Subtitle(object):
     :param bool hearing_impaired: whether or not the subtitle is hearing impaired.
     :param page_link: URL of the web page from which the subtitle can be downloaded.
     :type page_link: str
+    :param encoding: Text encoding of the subtitle
+    :type encoding: str
 
     """
     #: Name of the provider that returns that class of subtitle
     provider_name = ''
 
-    def __init__(self, language, hearing_impaired=False, page_link=None):
+    def __init__(self, language, hearing_impaired=False, page_link=None, encoding=None):
         #: Language of the subtitle
         self.language = language
 
@@ -39,7 +42,15 @@ class Subtitle(object):
         self.content = None
 
         #: Encoding to decode with when accessing :attr:`text`
-        self.encoding = None
+        if encoding:
+            try:
+                # set encoding to canonical codec name
+                self.encoding = lookup(encoding).name
+            except (TypeError, LookupError):
+                logger.debug('Unsupported encoding "%s", setting to None', encoding)
+                self.encoding = None
+        else:
+            self.encoding = None
 
     @property
     def id(self):
@@ -56,7 +67,11 @@ class Subtitle(object):
         if not self.content:
             return
 
-        return self.content.decode(self.encoding or self.guess_encoding(), errors='replace')
+        try:
+            return self.content.decode(self.encoding, errors='replace')
+        except (TypeError, LookupError):
+            # Failback to guess_encoding if empty or unknown encoding provided
+            return self.content.decode(self.guess_encoding(), errors='replace')
 
     def is_valid(self):
         """Check if a :attr:`text` is a valid SubRip format.

--- a/tests/test_opensubtitles.py
+++ b/tests/test_opensubtitles.py
@@ -18,7 +18,7 @@ vcr = VCR(path_transformer=lambda path: path + '.yaml',
 def test_get_matches_movie_hash(movies):
     subtitle = OpenSubtitlesSubtitle(Language('deu'), False, None, '1953771409', 'moviehash', 'movie',
                                      '5b8f8f4e41ccb21e', 'Man of Steel',
-                                     'Man.of.Steel.German.720p.BluRay.x264-EXQUiSiTE', 2013, 770828, 0, 0)
+                                     'Man.of.Steel.German.720p.BluRay.x264-EXQUiSiTE', 2013, 770828, 0, 0, None)
     matches = subtitle.get_matches(movies['man_of_steel'])
     assert matches == {'title', 'year', 'video_codec', 'imdb_id', 'hash', 'resolution', 'format', 'hearing_impaired'}
 
@@ -26,14 +26,14 @@ def test_get_matches_movie_hash(movies):
 def test_get_matches_episode(episodes):
     subtitle = OpenSubtitlesSubtitle(Language('ell'), False, None, '1953579014', 'fulltext', 'episode',
                                      '0', '"Game of Thrones" Mhysa',
-                                     ' Game.of.Thrones.S03E10.HDTV.XviD-AFG', 2013, 2178796, 3, 10)
+                                     ' Game.of.Thrones.S03E10.HDTV.XviD-AFG', 2013, 2178796, 3, 10, None)
     matches = subtitle.get_matches(episodes['got_s03e10'])
     assert matches == {'imdb_id', 'series', 'year', 'episode', 'season', 'title', 'hearing_impaired'}
 
 
 def test_get_matches_imdb_id(movies):
     subtitle = OpenSubtitlesSubtitle(Language('fra'), True, None, '1953767650', 'imdbid', 'movie', 0, 'Man of Steel',
-                                     'man.of.steel.2013.720p.bluray.x264-felony', 2013, 770828, 0, 0)
+                                     'man.of.steel.2013.720p.bluray.x264-felony', 2013, 770828, 0, 0, None)
     matches = subtitle.get_matches(movies['man_of_steel'], hearing_impaired=True)
     assert matches == {'title', 'year', 'video_codec', 'imdb_id', 'resolution', 'format', 'release_group',
                        'hearing_impaired'}
@@ -41,7 +41,7 @@ def test_get_matches_imdb_id(movies):
 
 def test_get_matches_no_match(episodes):
     subtitle = OpenSubtitlesSubtitle(Language('fra'), False, None, '1953767650', 'imdbid', 'movie', 0, 'Man of Steel',
-                                     'man.of.steel.2013.720p.bluray.x264-felony', 2013, 770828, 0, 0)
+                                     'man.of.steel.2013.720p.bluray.x264-felony', 2013, 770828, 0, 0, None)
     matches = subtitle.get_matches(episodes['got_s03e10'], hearing_impaired=True)
     assert matches == set()
 
@@ -216,3 +216,4 @@ def test_download_subtitle(movies):
         provider.download_subtitle(subtitles[0])
     assert subtitles[0].content is not None
     assert subtitles[0].is_valid() is True
+    assert subtitles[0].encoding == 'cp1252'

--- a/tests/test_subtitle.py
+++ b/tests/test_subtitle.py
@@ -141,3 +141,18 @@ def test_guess_properties():
 def test_fix_line_ending():
     content = b'Text\r\nwith\rweird\nline ending\r\ncharacters'
     assert fix_line_ending(content) == b'Text\nwith\nweird\nline ending\ncharacters'
+
+
+def test_subtitle_valid_encoding():
+    subtitle = Subtitle(Language('deu'), False, None, 'windows-1252')
+    assert subtitle.encoding == 'cp1252'
+
+
+def test_subtitle_empty_encoding():
+    subtitle = Subtitle(Language('deu'), False, None, None)
+    assert subtitle.encoding is None
+
+
+def test_subtitle_invalid_encoding():
+    subtitle = Subtitle(Language('deu'), False, None, 'rubbish')
+    assert subtitle.encoding is None


### PR DESCRIPTION
OpenSubtitles returns 'SubEncoding' that we can use to avoid guess_encoding()
