### PR TITLE
Use regex to find external subtitles

### DIFF
--- a/subliminal/video.py
+++ b/subliminal/video.py
@@ -255,13 +255,12 @@ def search_external_subtitles(path):
 
         # extract the potential language code
         language_lookup = os.path.splitext(p)[0][len(fileroot):].replace(fileext, '')
-        match = re.search(r'(?:[^a-zA-Z]|^)([a-zA-Z]*)([_-][a-zA-Z]{2,4})?(?:[^a-zA-Z]|$)', language_lookup)
+        match = re.search(r'(?:[^a-zA-Z]|^)([a-zA-Z]+)([_-][a-zA-Z]{2,4})?(?:[^a-zA-Z]|$)', language_lookup)
+        language_code = None
         if match:
             language_code = match.group(1)
             if match.group(2):
                 language_code += match.group(2).replace('_', '-')
-        else:
-            language_code = None
 
         # default language is undefined
         language = Language('und')

--- a/subliminal/video.py
+++ b/subliminal/video.py
@@ -254,10 +254,12 @@ def search_external_subtitles(path):
             continue
 
         # extract the potential language code
-        language_lookup = os.path.splitext(p)[0][len(fileroot):]
-        match = re.search(r'[a-zA-Z]{2,3}([_-][a-zA-Z]{2})?', language_lookup)
+        language_lookup = os.path.splitext(p)[0][len(fileroot):].replace(fileext, '')
+        match = re.search(r'(?:[^a-zA-Z]|^)([a-zA-Z]*)([_-][a-zA-Z]{2,4})?(?:[^a-zA-Z]|$)', language_lookup)
         if match:
-            language_code = match.group(0).replace('_', '-')
+            language_code = match.group(1)
+            if match.group(2):
+                language_code += match.group(2).replace('_', '-')
         else:
             language_code = None
 

--- a/subliminal/video.py
+++ b/subliminal/video.py
@@ -4,6 +4,7 @@ from datetime import datetime, timedelta
 import hashlib
 import logging
 import os
+import re
 import struct
 
 from babelfish import Error as BabelfishError, Language
@@ -253,7 +254,12 @@ def search_external_subtitles(path):
             continue
 
         # extract the potential language code
-        language_code = p[len(fileroot):-len(os.path.splitext(p)[1])].replace(fileext, '').replace('_', '-')[1:]
+        language_lookup = os.path.splitext(p)[0][len(fileroot):]
+        match = re.search(r'[a-zA-Z]{2,3}[_-]?[a-zA-Z]{2,3}?', language_lookup)
+        if match:
+            language_code = match.group(0).replace('_', '-')
+        else:
+            language_code = None
 
         # default language is undefined
         language = Language('und')

--- a/subliminal/video.py
+++ b/subliminal/video.py
@@ -255,7 +255,7 @@ def search_external_subtitles(path):
 
         # extract the potential language code
         language_lookup = os.path.splitext(p)[0][len(fileroot):]
-        match = re.search(r'[a-zA-Z]{2,3}[_-]?[a-zA-Z]{2,3}?', language_lookup)
+        match = re.search(r'[a-zA-Z]{2,3}([_-][a-zA-Z]{2})?', language_lookup)
         if match:
             language_code = match.group(0).replace('_', '-')
         else:

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -177,6 +177,8 @@ def test_search_external_subtitles(episodes, tmpdir):
         video_name + '.fra.srt': Language('fra'),
         video_root + '.pt-BR.srt': Language('por', 'BR'),
         video_name + '.sr_cyrl.sub': Language('srp', script='Cyrl'),
+        video_root + '[fra].srt': Language('fra'),
+        video_root + '[pt-BR].srt': Language('por', 'BR'),
         video_name + '.something.srt': Language('und')
     }
     tmpdir.ensure(os.path.split(episodes['got_s03e10'].name)[1] + '.srt')


### PR DESCRIPTION
In the search_external_subtitles function, only subtitles of the form <video_name>.eng.srt. With also some errors, like  <video_name>[eng].srt is matched to `eng]`.
Using a regex allow for a better match, of the form en, eng, en_GB or eng_GB.