### PR TITLE
Add movie release name to subtitle ID

### DIFF
--- a/subliminal/providers/opensubtitles.py
+++ b/subliminal/providers/opensubtitles.py
@@ -155,7 +155,7 @@ class OpenSubtitlesProvider(Provider):
             language = Language.fromopensubtitles(subtitle_item['SubLanguageID'])
             hearing_impaired = bool(int(subtitle_item['SubHearingImpaired']))
             page_link = subtitle_item['SubtitlesLink']
-            subtitle_id = int(subtitle_item['IDSubtitleFile'])
+            subtitle_id = subtitle_id = subtitle_item['MovieReleaseName'] + " (" + subtitle_item['IDSubtitleFile'] + ")"
             matched_by = subtitle_item['MatchedBy']
             movie_kind = subtitle_item['MovieKind']
             hash = subtitle_item['MovieHash']


### PR DESCRIPTION
@Diaoul 
So we can debug release name and its score:
Otherwise we will only get an ID

At SickRage out log will be like this:
```
19:22:10 DEBUG::FINDSUBTITLES :: [opensubtitles] Subtitle score for  H* - 05x09 - The Litvinov Ruse.KILLERS.Portuguese (Brazilian).C.updated.Addic7ed.com(1954989638) is: 111 (min=132)
19:22:10 DEBUG::FINDSUBTITLES :: [opensubtitles] Subtitle score for H*.S05E09.HDTV.x264-KILLERS(1954989953) is: 115 (min=132)
19:22:11 DEBUG::FINDSUBTITLES :: No subtitles found for /media/M*.C*.S04E15.1080p.HDTV.X264-DIMENSION.mkv
19:22:13 DEBUG::FINDSUBTITLES :: [opensubtitles] Subtitle score for  M*.F*.S07E07.INTERNAL.XviD-AFG(1954974883) is: 111 (min=132)
19:22:13 DEBUG::FINDSUBTITLES :: [opensubtitles] Subtitle score for HDTV.x264-FLEET-720p.FLEET(1954974885) is: 115 (min=132)
19:22:14 DEBUG::FINDSUBTITLES :: [opensubtitles] Subtitle score for T*.G*.W*.S07E09.HDTV.x264-LOL(1954990049) is: 121 (min=132)
```

and SickRage code for the log:
```
for sub in subtitles_list:
            matches = sub.get_matches(video, hearing_impaired=False)
            score = subliminal.subtitle.compute_score(matches, video)
            logger.log(u"[%s] Subtitle score for %s is: %s (min=132)" % (sub.provider_name, sub.id, score), logger.DEBUG)
```

Subliminal don't return movierelease name in here:
http://subliminal.readthedocs.org/en/latest/api/subtitle.html?highlight=subtitles#module-subliminal.subtitle