### PR TITLE
Changing cache configuration for legendastv provider

### DIFF
--- a/subliminal/providers/legendastv.py
+++ b/subliminal/providers/legendastv.py
@@ -42,7 +42,7 @@ downloads_re = re.compile(r'(?P<downloads>\d+) downloads')
 rating_re = re.compile(r'nota (?P<rating>\d+)')
 
 #: Timestamp parsing regex
-timestamp_re = re.compile(r'(?P<day>\d+)/(?P<month>\d+)/(?P<year>\d+) - (?P<minute>\d+):(?P<second>\d+)')
+timestamp_re = re.compile(r'(?P<day>\d+)/(?P<month>\d+)/(?P<year>\d+) - (?P<hour>\d+):(?P<minute>\d+)')
 
 #: Cache key for releases
 releases_key = __name__ + ':releases|{archive_id}'
@@ -251,7 +251,7 @@ class LegendasTVProvider(Provider):
 
         return titles
 
-    @region.cache_on_arguments(expiration_time=timedelta(minutes=15))
+    @region.cache_on_arguments(expiration_time=timedelta(minutes=15).total_seconds())
     def get_archives(self, title_id, language_code):
         """Get the archive list from a given `title_id` and `language_code`.
 


### PR DESCRIPTION
- Removing caching when listing archives
> when an episode or a movie is release, you'll have a growing list of archives for the next couple of days. If we cache this URL (carrega_legendas_busca_filme) we might wait for a long time to get a subtitle that was added afer your initial search.

- Changing release names cache to 15 min
> It's a common practice that the uploaders re-upload the archivers adding more releases to it. And that happens in a high frequency for the first couple of days after the release. 
