### PR TITLE
Fix for #602 and #603

### DIFF
--- a/subliminal/refiners/tvdb.py
+++ b/subliminal/refiners/tvdb.py
@@ -209,7 +209,7 @@ def search_series(name):
         key = 0
         if series['status'] != 'Continuing':
             key += 1
-        if series['seriesName'] != name:
+        if series['seriesName'].lower() != name and name not in [alias.lower() for alias in series['aliases']]:
             key += 2
 
         return key
@@ -288,7 +288,7 @@ def refine(video, **kwargs):
             logger.debug('Found result for original series without year')
             found = True
             break
-        if video.year == datetime.strptime(result['firstAired'], '%Y-%m-%d').year:
+        if result['firstAired'] and video.year == datetime.strptime(result['firstAired'], '%Y-%m-%d').year:
             logger.debug('Found result with matching year')
             found = True
             break
@@ -303,7 +303,8 @@ def refine(video, **kwargs):
     # add series information
     logger.debug('Found series %r', result)
     video.series = result['seriesName']
-    video.year = datetime.strptime(result['firstAired'], '%Y-%m-%d').year
+    if result['firstAired']:
+        video.year = datetime.strptime(result['firstAired'], '%Y-%m-%d').year
     video.series_imdb_id = result['imdbId']
     video.series_tvdb_id = result['id']
 


### PR DESCRIPTION
- Fixing date parse when there's no firstAired entry. (Fix for #602)
- Use case insensitive (e.g.: When searching for 'The 100' will not choose '100%', but the correct 'The 100' result). (Related to #602 and #603)
- 'aliases' for better series matching (e.g: CSI will be chosen since CSI is in the aliases list of CSI: Crime Scene Investigation) (Fix for #603)