### PR TITLE
Avoiding exceptions when legendastv provider returns invalid year/season

### DIFF
--- a/subliminal/providers/legendastv.py
+++ b/subliminal/providers/legendastv.py
@@ -212,8 +212,9 @@ class LegendasTVProvider(Provider):
             title_id = int(source['id_filme'])
 
             # extract type, title and year
-            title = {'type': type_map[source['tipo']], 'title': source['dsc_nome'],
-                     'year': int(source['dsc_data_lancamento'])}
+            title = {'type': type_map[source['tipo']], 'title': source['dsc_nome']}
+            if source['dsc_data_lancamento'] and source['dsc_data_lancamento'].isdigit():
+                title['year'] = int(source['dsc_data_lancamento'])
 
             # extract imdb_id
             if source['id_imdb'] != '0':
@@ -224,7 +225,7 @@ class LegendasTVProvider(Provider):
 
             # extract season
             if title['type'] == 'episode':
-                if source['temporada'] is not None:
+                if source['temporada'] is not None and source['temporada'].isdigit():
                     title['season'] = int(source['temporada'])
                 else:
                     match = season_re.search(source['dsc_nome_br'])

--- a/tests/cassettes/legendastv/test_search_titles_with_invalid_year.yaml
+++ b/tests/cassettes/legendastv/test_search_titles_with_invalid_year.yaml
@@ -1,0 +1,47 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [Subliminal/2.0-rc1]
+    method: GET
+    uri: http://legendas.tv/legenda/sugestao/Grave%20Danger
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA21U227jNhD9lYmfWsBxfE1qv7VbuNi6CdzYDQqsF8ZYGtlsKVEhKSftYv+9Zyh5
+        u0H7YFo8nOuZy4dPvb2pcnntLXqFsaWEXr+3j3/VcgH0bnLcxuPhZKq3kDmP56qxVm+u8Rmun3om
+        37ca/8oCMmV+ADKbTG/nt4CiqR3u9/paxf1RKvEKjIbjGbA8ZFBhwMBibNUGf9TH7q1yycFPns9C
+        P3J1FL+gJ2ebUmjcyQRTuTqo2G8l5S5QyQYhB8qNl9h+CWWmkpIpZ+LYsDU55zKg7ynsmuFQ5t6I
+        Sm2fVDvQgXO2+MEelYihim5AS2dIQmTKXHkwFSfNu3ROHMlrbV0wZ6bnRih617wKueSXVenXBlZM
+        RVv2rB+OvoHDlbGWftBDaN3YmpYmi8ZVdE1bKWunQT0ZZ5MXrjLD31INC7QWb46OmDYSocq2dKEP
+        f/EST5bCZiQgJNYdTfqsTUq4mOTGUYEkrFLy3KA4TFE9+pS20LvN+ytattZgrCokBKd8BHiGrf5X
+        meA5uoYaEFwASkqjEE3GdDIhth6hRRX4Qy24TiJ5bGzKMG840AmukYKX7CQaK/CgeMk+w18Gb1kU
+        32om42FAay+gQ66DtLRoCNGznlIFTrlL9OZvhCV9gmmTsvNSdKYSqfBbWA6nA2d/BiixbbI3FS5m
+        aKNrJTW1lYmgvs1zTuo1NZ72cYRckCrx9Jw0M+Ts2zpkvhGrZUFYOHyCz+bsCLyrlRJsgV4XFLZd
+        Ka8IjW1QHMLsmlAjsZbhs9h+220OdoquVtrGXyojXSnJHdAvjHEw3AZQg2gDhjgEODX+qhunnCPv
+        LVhJcmlW53TfPTbeXkb8FGO92N3sbl5eXgaKDUDO7iaaaAV/cdgO8+7mq1HeHzw0Ec6C3nmDGd5k
+        WAj0vjqDIw2v7fz/621Ywe5pd1e7i7506wXA+mnQMaBPN9Dtd7PZBFqFPe6tOYhyDXz4Js2EZ+wu
+        Ji4vutSGo+H1cH49Hm9Hk8X0bjG97VRLiVyfXCVwB8HVZvV4v3l4WG62q98fVo/L7cPPj/8RTZm/
+        FV0/rjbb9S/3GwjrYDrMZLhEomF3k3aB0KARLkXX82hyNxlPRrPpSD1pjytcsA3yWZnysbf4oGof
+        P3/8B6BKj4b2BQAA
+    headers:
+      accept-ranges: [bytes]
+      access-control-allow-origin: ['*']
+      age: ['0']
+      connection: [keep-alive]
+      content-encoding: [gzip]
+      content-length: ['867']
+      content-type: [text/html; charset=utf-8]
+      date: ['Sat, 02 Apr 2016 19:31:04 GMT']
+      set-cookie: [PHPSESSID=ttmu4fva7shj0m6vdfq75lahe2; path=/; HttpOnly]
+      vary: ['User-Agent,Accept-Encoding']
+      via: [1.1 varnish]
+      x-backend: [default_director]
+      x-cache: [MISS]
+      x-cacheable: ['NO:Not Cacheable']
+      x-varnish: ['2053514956']
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/test_legendastv.py
+++ b/tests/test_legendastv.py
@@ -128,6 +128,15 @@ def test_search_titles_quote():
 
 @pytest.mark.integration
 @vcr.use_cassette
+def test_search_titles_with_invalid_year():
+    with LegendasTVProvider() as provider:
+        titles = provider.search_titles('Grave Danger')
+    assert len(titles) == 1
+    assert set(titles.keys()) == {22034}
+
+
+@pytest.mark.integration
+@vcr.use_cassette
 def test_get_archives():
     with LegendasTVProvider() as provider:
         archives = provider.get_archives(34084, 2)


### PR DESCRIPTION
When searching for common series (e.g: CSI), some results might contain invalid data (year = '19 M') that cannot be correctly parsed and causes exceptions which aborts the whole process. These invalid entries should be skipped and shouldn't abort the whole search process.

Added a regression test.