### PR TITLE
Small adjustments, split out from #605

### DIFF
--- a/subliminal/providers/addic7ed.py
+++ b/subliminal/providers/addic7ed.py
@@ -86,19 +86,20 @@ class Addic7edProvider(Provider):
     server_url = 'http://www.addic7ed.com/'
 
     def __init__(self, username=None, password=None):
-        if username is not None and password is None or username is None and password is not None:
+        if any((username, password)) and not all((username, password)):
             raise ConfigurationError('Username and password must be specified')
 
         self.username = username
         self.password = password
         self.logged_in = False
+        self.session = None
 
     def initialize(self):
         self.session = Session()
         self.session.headers['User-Agent'] = 'Subliminal/%s' % __short_version__
 
         # login
-        if self.username is not None and self.password is not None:
+        if self.username and self.password:
             logger.info('Logging in')
             data = {'username': self.username, 'password': self.password, 'Submit': 'Log in'}
             r = self.session.post(self.server_url + 'dologin.php', data, allow_redirects=False, timeout=10)

--- a/subliminal/providers/legendastv.py
+++ b/subliminal/providers/legendastv.py
@@ -163,19 +163,20 @@ class LegendasTVProvider(Provider):
     server_url = 'http://legendas.tv/'
 
     def __init__(self, username=None, password=None):
-        if username and not password or not username and password:
+        if any((username, password)) and not all((username, password)):
             raise ConfigurationError('Username and password must be specified')
 
         self.username = username
         self.password = password
         self.logged_in = False
+        self.session = None
 
     def initialize(self):
         self.session = Session()
         self.session.headers['User-Agent'] = 'Subliminal/%s' % __short_version__
 
         # login
-        if self.username is not None and self.password is not None:
+        if self.username and self.password:
             logger.info('Logging in')
             data = {'_method': 'POST', 'data[User][username]': self.username, 'data[User][password]': self.password}
             r = self.session.post(self.server_url + 'login', data, allow_redirects=False, timeout=10)

--- a/subliminal/providers/napiprojekt.py
+++ b/subliminal/providers/napiprojekt.py
@@ -42,6 +42,7 @@ class NapiProjektSubtitle(Subtitle):
     def __init__(self, language, hash):
         super(NapiProjektSubtitle, self).__init__(language)
         self.hash = hash
+        self.content = None
 
     @property
     def id(self):
@@ -62,6 +63,9 @@ class NapiProjektProvider(Provider):
     languages = {Language.fromalpha2(l) for l in ['pl']}
     required_hash = 'napiprojekt'
     server_url = 'http://napiprojekt.pl/unit_napisy/dl.php'
+
+    def __init__(self):
+        self.session = None
 
     def initialize(self):
         self.session = Session()

--- a/subliminal/providers/opensubtitles.py
+++ b/subliminal/providers/opensubtitles.py
@@ -125,11 +125,11 @@ class OpenSubtitlesProvider(Provider):
 
     def __init__(self, username=None, password=None):
         self.server = ServerProxy('https://api.opensubtitles.org/xml-rpc', TimeoutSafeTransport(10))
-        if username and not password or not username and password:
+        if any((username, password)) and not all((username, password)):
             raise ConfigurationError('Username and password must be specified')
-        # None values not allowed for logging in, so replace it by ''
-        self.username = username or ''
-        self.password = password or ''
+
+        self.username = username
+        self.password = password
         self.token = None
 
     def initialize(self):

--- a/subliminal/providers/podnapisi.py
+++ b/subliminal/providers/podnapisi.py
@@ -84,6 +84,9 @@ class PodnapisiProvider(Provider):
                  {Language.fromalpha2(l) for l in language_converters['alpha2'].codes})
     server_url = 'http://podnapisi.net/subtitles/'
 
+    def __init__(self):
+        self.session = None
+
     def initialize(self):
         self.session = Session()
         self.session.headers['User-Agent'] = 'Subliminal/%s' % __short_version__

--- a/subliminal/providers/shooter.py
+++ b/subliminal/providers/shooter.py
@@ -42,6 +42,9 @@ class ShooterProvider(Provider):
     languages = {Language(l) for l in ['eng', 'zho']}
     server_url = 'https://www.shooter.cn/api/subapi.php'
 
+    def __init__(self):
+        self.session = None
+
     def initialize(self):
         self.session = Session()
         self.session.headers['User-Agent'] = 'Subliminal/%s' % __short_version__

--- a/subliminal/providers/subscenter.py
+++ b/subliminal/providers/subscenter.py
@@ -76,19 +76,20 @@ class SubsCenterProvider(Provider):
     server_url = 'http://subscenter.cinemast.com/he/'
 
     def __init__(self, username=None, password=None):
-        if username is not None and password is None or username is None and password is not None:
+        if any((username, password)) and not all((username, password)):
             raise ConfigurationError('Username and password must be specified')
 
         self.username = username
         self.password = password
         self.logged_in = False
+        self.session = None
 
     def initialize(self):
         self.session = Session()
         self.session.headers['User-Agent'] = 'Subliminal/%s' % __short_version__
 
         # login
-        if self.username is not None and self.password is not None:
+        if self.username and self.password:
             logger.debug('Logging in')
             url = self.server_url + 'subscenter/accounts/login/'
 

--- a/subliminal/providers/thesubdb.py
+++ b/subliminal/providers/thesubdb.py
@@ -41,6 +41,9 @@ class TheSubDBProvider(Provider):
     required_hash = 'thesubdb'
     server_url = 'http://api.thesubdb.com/'
 
+    def __init__(self):
+        self.session = None
+
     def initialize(self):
         self.session = Session()
         self.session.headers['User-Agent'] = ('SubDB/1.0 (subliminal/%s; https://github.com/Diaoul/subliminal)' %

--- a/subliminal/providers/tvsubtitles.py
+++ b/subliminal/providers/tvsubtitles.py
@@ -79,6 +79,9 @@ class TVsubtitlesProvider(Provider):
     video_types = (Episode,)
     server_url = 'http://www.tvsubtitles.net/'
 
+    def __init__(self):
+        self.session = None
+
     def initialize(self):
         self.session = Session()
         self.session.headers['User-Agent'] = 'Subliminal/%s' % __short_version__


### PR DESCRIPTION
Use raw strings for regex literals
Tweak username and password conditionals in providers to also catch empty strings as invalid
Add some missing `__init__` methods, and add class properties that were defined outside of `__init__`
