### PR TITLE
Adding missing hash and id property in shooter provider

### DIFF
--- a/subliminal/core.py
+++ b/subliminal/core.py
@@ -17,7 +17,7 @@ import requests
 from .extensions import provider_manager, refiner_manager
 from .score import compute_score as default_compute_score
 from .subtitle import SUBTITLE_EXTENSIONS, get_subtitle_path
-from .utils import hash_napiprojekt, hash_opensubtitles, hash_thesubdb
+from .utils import hash_napiprojekt, hash_opensubtitles, hash_shooter, hash_thesubdb
 from .video import VIDEO_EXTENSIONS, Episode, Movie, Video
 
 #: Supported archive extensions
@@ -384,6 +384,7 @@ def scan_video(path):
     if video.size > 10485760:
         logger.debug('Size is %d', video.size)
         video.hashes['opensubtitles'] = hash_opensubtitles(path)
+        video.hashes['shooter'] = hash_shooter(path)
         video.hashes['thesubdb'] = hash_thesubdb(path)
         video.hashes['napiprojekt'] = hash_napiprojekt(path)
         logger.debug('Computed hashes %r', video.hashes)

--- a/subliminal/providers/shooter.py
+++ b/subliminal/providers/shooter.py
@@ -24,6 +24,7 @@ class ShooterSubtitle(Subtitle):
         self.hash = hash
         self.download_link = download_link
 
+    @property
     def id(self):
         return self.download_link
 

--- a/subliminal/utils.py
+++ b/subliminal/utils.py
@@ -69,6 +69,27 @@ def hash_napiprojekt(video_path):
     return hashlib.md5(data).hexdigest()
 
 
+def hash_shooter(video_path):
+    """Compute a hash using Shooter's algorithm
+
+    :param string video_path: path of the video
+    :return: the hash
+    :rtype: string
+
+    """
+    filesize = os.path.getsize(video_path)
+    readsize = 4096
+    if os.path.getsize(video_path) < readsize * 2:
+        return None
+    offsets = (readsize, filesize // 3 * 2, filesize // 3, filesize - readsize * 2)
+    filehash = []
+    with open(video_path, 'rb') as f:
+        for offset in offsets:
+            f.seek(offset)
+            filehash.append(hashlib.md5(f.read(readsize)).hexdigest())
+    return ';'.join(filehash)
+
+
 def sanitize(string, ignore_characters=None):
     """Sanitize a string to strip special characters.
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -246,6 +246,8 @@ def test_refine_video_metadata(mkv):
     assert scanned_video.hashes == {
         'napiprojekt': 'de2e9caa58dd53a6ab9d241e6b252e35',
         'opensubtitles': '49e2530ea3bd0d18',
+        'shooter': '36f3e2c50566ca01f939bf15d8031432;b6132ab62b8f7d4aaabe9d6344b90d90;'
+                   'bea6074cef7f1de85794f3941530ba8b;18db05758d5d0d96f246249e4e4b5d79',
         'thesubdb': '64a8b87f12daa4f31895616e6c3fd39e'}
     assert scanned_video.size == 31762747
     assert scanned_video.subtitle_languages == {Language('spa'), Language('deu'), Language('jpn'), Language('und'),


### PR DESCRIPTION
It seems that shooter_hash and id property was missing. I'm not sure if that was on purpose or just forgotten.

Credits to @medariox