### PR TITLE
TVDB refiner should discard result if year doesn't match

### DIFF
--- a/subliminal/refiners/tvdb.py
+++ b/subliminal/refiners/tvdb.py
@@ -283,7 +283,8 @@ def refine(video, **kwargs):
 
         # discard mismatches on year
         if video.year and series_year and video.year != series_year:
-            logger.debug('Discarding series %r mismatch on year %d', series_year)
+            logger.debug('Discarding series %r mismatch on year %d', result['seriesName'], series_year)
+            continue
 
         # iterate over series names
         for series_name in series_names:


### PR DESCRIPTION
- A small fix to discard the result if the year doesn't match
- Missing first argument in logging call.