### PR TITLE
TVDB refiner: failing tests for series name with year

### DIFF
--- a/subliminal/refiners/tvdb.py
+++ b/subliminal/refiners/tvdb.py
@@ -289,7 +289,7 @@ def refine(video, **kwargs):
         for series_name in series_names:
             # match on sanitized series name
             if sanitize(series_name) == sanitize(video.series):
-                logger.debug('Found exact match on series %r (%d)', series_name, series_year or 'no year')
+                logger.debug('Found exact match on series %r (%s)', series_name, series_year or 'no year')
                 match = True
                 break
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -87,7 +87,16 @@ def episodes():
             'the_100_s03e09':
             Episode('The.100.S03E09.720p.HDTV.x264-AVS.mkv', 'The 100', 3, 9, title='Stealing Fire', year=2014,
                     tvdb_id=5544536, series_tvdb_id=268592, series_imdb_id='tt2661044', format='HDTV',
-                    release_group='AVS', resolution='720p', video_codec='h264', imdb_id='tt4799896')}
+                    release_group='AVS', resolution='720p', video_codec='h264', imdb_id='tt4799896'),
+            'once_upon_a_time_2011_s01e01':
+            Episode('Once.Upon.a.Time.S01E01.720p.HDTV.X264-DIMENSION.mkv', 'Once Upon a Time', 1, 1, title='Pilot',
+                    year=2011, tvdb_id=4105178, series_tvdb_id=248835, series_imdb_id='tt1843230', format='HDTV',
+                    release_group='DIMENSION', resolution='720p', video_codec='h264', imdb_id='tt1983723'),
+            'house_of_cards_2013_s04e13':
+            Episode('House.of.Cards.2013.S04E13.720p.WEBRip.X264-DEFLATE.mkv', 'House of Cards', 4, 13,
+                    title='Chapter 52', year=2013, tvdb_id=5440817, series_tvdb_id=262980, series_imdb_id='tt1856010',
+                    format='WEBRip', release_group='DEFLATE', resolution='720p', video_codec='h264',
+                    imdb_id='tt5095748')}
 
 
 @pytest.fixture(scope='session')

--- a/tests/test_tvdb.py
+++ b/tests/test_tvdb.py
@@ -244,3 +244,34 @@ def test_refine_ambiguous_2(episodes):
     assert episode.series_imdb_id == video.series_imdb_id
     assert episode.tvdb_id == video.tvdb_id
     assert episode.series_tvdb_id == video.series_tvdb_id
+
+
+@pytest.mark.integration
+@vcr.use_cassette
+def test_refine_series_name_with_year(episodes):
+    video = episodes['once_upon_a_time_2011_s01e01']
+    episode = Episode(video.name.lower(), video.series.lower(), video.season, video.episode)
+    refine(episode)
+    assert episode.series == video.series
+    assert episode.year == video.year
+    assert episode.title == video.title
+    assert episode.imdb_id == video.imdb_id
+    assert episode.series_imdb_id == video.series_imdb_id
+    assert episode.tvdb_id == video.tvdb_id
+    assert episode.series_tvdb_id == video.series_tvdb_id
+
+
+@pytest.mark.integration
+@vcr.use_cassette
+def test_refine_series_name_with_year_2(episodes):
+    video = episodes['house_of_cards_2013_s04e13']
+    episode = Episode(video.name.lower(), video.series.lower(), video.season, video.episode)
+    refine(episode)
+    assert episode.series == video.series
+    assert episode.year == video.year
+    assert episode.title == video.title
+    assert episode.imdb_id == video.imdb_id
+    assert episode.series_imdb_id == video.series_imdb_id
+    assert episode.tvdb_id == video.tvdb_id
+    assert episode.series_tvdb_id == video.series_tvdb_id
+


### PR DESCRIPTION
This is only the failing test cases for series with year in their name, e.g:
- Once Upon a Time (2011)
- House of Cards (2013)

No cassettes since I don't have a tvdb API key.

I hope this could be useful.