### PR TITLE
New score equations

### DIFF
--- a/docs/user/usage.rst
+++ b/docs/user/usage.rst
@@ -102,8 +102,8 @@ And then compute a score with those matches with :func:`~subliminal.score.comput
 
     >>> for s in subtitles[video]:
     ...     {s: compute_score(s, video)}
-    {<PodnapisiSubtitle 'ZtAW' [hu]>: 212}
-    {<PodnapisiSubtitle 'ONAW' [hu]>: 202}
+    {<PodnapisiSubtitle 'ZtAW' [hu]>: 354}
+    {<PodnapisiSubtitle 'ONAW' [hu]>: 337}
 
 Now you should have a better idea about which one you should choose.
 

--- a/subliminal/score.py
+++ b/subliminal/score.py
@@ -36,12 +36,12 @@ logger = logging.getLogger(__name__)
 
 
 #: Scores for episodes
-episode_scores = {'hash': 215, 'series': 108, 'year': 54, 'season': 18, 'episode': 18, 'release_group': 9,
-                  'format': 4, 'audio_codec': 2, 'resolution': 1, 'hearing_impaired': 1, 'video_codec': 1}
+episode_scores = {'hash': 359, 'series': 180, 'year': 90, 'season': 30, 'episode': 30, 'release_group': 15,
+                  'format': 7, 'audio_codec': 3, 'resolution': 2, 'video_codec': 2, 'hearing_impaired': 1}
 
 #: Scores for movies
-movie_scores = {'hash': 71, 'title': 36, 'year': 18, 'release_group': 9,
-                'format': 4, 'audio_codec': 2, 'resolution': 1, 'hearing_impaired': 1, 'video_codec': 1}
+movie_scores = {'hash': 119, 'title': 60, 'year': 30, 'release_group': 15,
+                'format': 7, 'audio_codec': 3, 'resolution': 2, 'video_codec': 2, 'hearing_impaired': 1}
 
 
 def get_scores(video):
@@ -160,13 +160,13 @@ def solve_episode_equations():
         Eq(audio_codec, video_codec + 1),
 
         # resolution counts as much as video_codec
-        Eq(resolution,  video_codec),
+        Eq(resolution, video_codec),
 
-        # hearing impaired is as much as resolution
-        Eq(hearing_impaired, resolution),
+        # video_codec is the least valuable match but counts more than the sum of all scoring increasing matches
+        Eq(video_codec, hearing_impaired + 1),
 
-        # video_codec is the least valuable match
-        Eq(video_codec,  1),
+        # hearing impaired is only used for score increasing, so put it to 1
+        Eq(hearing_impaired, 1),
     ]
 
     return solve(equations, [hash, series, year, season, episode, release_group, format, audio_codec, resolution,
@@ -200,13 +200,13 @@ def solve_movie_equations():
         Eq(audio_codec, video_codec + 1),
 
         # resolution counts as much as video_codec
-        Eq(resolution,  video_codec),
+        Eq(resolution, video_codec),
 
-        # hearing impaired is as much as resolution
-        Eq(hearing_impaired, resolution),
+        # video_codec is the least valuable match but counts more than the sum of all scoring increasing matches
+        Eq(video_codec, hearing_impaired + 1),
 
-        # video_codec is the least valuable match
-        Eq(video_codec,  1),
+        # hearing impaired is only used for score increasing, so put it to 1
+        Eq(hearing_impaired, 1),
     ]
 
     return solve(equations, [hash, title, year, release_group, format, audio_codec, resolution, hearing_impaired,


### PR DESCRIPTION
With the new score calculation, a score increasing match (like
hearing_impaired) should not influence the score matching of the video
properties. Score increasing matches should only count as 1 and the
lowest video property match should be at least 1 more than the sum of
all score increasing matches (currently only hearing_impaired).
This fixes https://github.com/Diaoul/subliminal/issues/664