### PR TITLE
Handling titles with year/country in legendastv provider.

### DIFF
--- a/tests/cassettes/legendastv/test_search_titles_containing_year_information.yaml
+++ b/tests/cassettes/legendastv/test_search_titles_containing_year_information.yaml
@@ -1,0 +1,241 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: ['*/*']
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [Subliminal/2.1]
+    method: GET
+    uri: http://legendas.tv/legenda/sugestao/Bull
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA9VdCW/bSJb+KzXGYpMAslukbg8WAx85JrGdjKXunsVmEZTEklQxxdLwkOMs9r/v
+        +94rUrQlObbj2d4F+rDIIlnX+9796j/+a++LTSLzbe9wb2rjhcn2Gntf8pulKS/gt43oV9gJ+n38
+        yiYupdtJEcf45Yp0Qj//a89GX+SJdVu6ZBfRmK4E7WanHwzoWm6Xji4McTvJv8xMYlJcCJqtLl2L
+        sgk9o+ly+QlcSRy/95gu3Khjo/PIXSe+dWYTt8w2b6vPRbNpBqpYqMykVkdOvUyNjm1+o7K5u36l
+        Iq1yE5uVzbhpyym9oJYTnWg1kSeWLlXnOr1Sx0WamDxX/yhM+WLzzY4t2phYq/PRbwfq9UJNNL3V
+        LOWV01ZkXUPRe5epyUyS0ytT9V5nDr0Lm8HkXN/MzYL/jtS5jWOTqshkemq1GtNwrMmUVnGR61RN
+        XJKn8oNeQzeWqZvaLLMu0Tajx9T5+RG1WtATk7lOJgbXZjqZ08P/EjQPms3mgfqoIpvMjU0dj4XG
+        n+HNmZkVZkEPLA3tB0XDom6YBf2au/LLmSmoN9HKpDJhQWpd1lBG5Y7auy0vTsqJXX/B92elrVpq
+        eqnOVFbQf1bcNMpp8bMDv7SRzvWXmEZC65Lk2CU0T01/s0jjcnfN83x5+PmXz79cX18f4NoBzcLn
+        X3Kbx4b+l/vd9/mXvfV2+jJON7fMvmqhG1qrEY3dpbSY9AjtcaER2ZB5detwryW7vKAh0GRgG/fD
+        ZrfTocvTePYltmNDLXGjeWtMfH2iXX2T444MMdhv9umfUdA9DDuHTDZosDC5Xs5dYuh76PvZ8Wh0
+        cTkaDi82GsjguMHo/NPliBpgUzraj1n5TXTQU0Z5KdZZTi83IPig1Qs7vbAXtPF2Ws4cl6c6zsx/
+        Y07SfO/wP2gC/vO/Gw9HkW672X4giPimawxptbutbg1CzjchJOzfgZC9PJfHDr4uZ3u3wOSTSRL1
+        r7TQILpDhZ2QzW3+pw1Y+ZS6WaoXRFRC+LmduP2JpR0pW3ZKv0FpkwK0Mi8WLpUbGVrWaZ/hJHJE
+        rAshoBk1yA7U6etsRWSniXKJzoQSBt+pZaamOneZEGDB13sMLB2jMjexoHsQW53OIvudyExggPEu
+        0pG5j6KarcdTVFNmdQtF7ZjWx5HReoPWKCh4IAWtf98hmE8Xo7PL47O/j7aTS/32E4ilFQzaQa/5
+        jMTS6rZ7wQOppWxbI5fOoBv0+vew3OZdYonNDNsw+5KvvhAMdZqEZWEzHLS6m+RzTAtM6J1EKp8b
+        XubIzbIN4jlSwisGqa0YZ+bGqSG+TLxMCCVirkdsJJ3QbgXzWoCNyidO9TX45cvj1EzUsSZ+l8xM
+        +or3/cquaPM72m3fiIUYZROTLbFfeHsTjfBLiZ3/jTZWbtKxnlyBtxGXYeY4LXIzdjH+pK2nDE10
+        rA8+p58T/Cvfp3d8LYh8lSZCLMfZ8Px7RGMfpe7Gc/CXJ+5GDXNzTV+THmrqBvWMGJ271Qm6o9SF
+        uc5pYEUU3ah3NJXEMl3yCjyadlAC7KCdopn6NVP0mY1psVL1ztCgaBN9x1Wnhm45t6ZBr1yYeE4Y
+        oxd2tmN2GyR/TK5oMS418evs6kZeUQAyrsfUfZqerIgbaqivb0z6Z+rpOx2bGzX6WkjTT2ZJc3wv
+        j+48HlH8dt3Go3fttHsAJbjLl8N2s9lv936OL3f2m+F+szsKm4et4LDZ28qXt8EPxiHXHwss9+JJ
+        8Dg8CTrdsPtAPCnb7ma/D5Hgn4P9nlpaQk/PtGWWxIqJECMLMdSxEBwV4JFE/ZEAjCUscFNDeGHB
+        Qlk+B7c04IRq4SJQz4E6imdFArmZyK4BFAGTpi3cUJU+QN/AMzalN9LemqAnxK8/gi9TL9xtRq54
+        TMaPidAkL98T2WzpMvSSqNKsiIKJ3pauEMFh7KCiJJkTgGyiy1nm8KVfM9r3Ti0Km3vRglFu6tKF
+        5+wNkbSpNyQ6LAhlFi63K36vpgGSNK0I/1bAVdpmJBnQl0mcgZD/SS+delOAEP4EGJIVePXPERW2
+        CwqgapmuR9JzQNTc/Clqbg72m+39YDAK2oet/mGlV2wIDRejH4gN3OCpEnZ3EAjZPBORh4OgP3io
+        nu7b/vFEXt1Za+26Ljl4Pd2uwKRJlC4SGxHFGObV22SMtdStBQCiYon/GqEiSy/JPv9i4wLqM/9S
+        tzrbINl5SitiE+aHQJSlTawXvrOaLqAJPHRuSpGf5RDZeSSci6hDQgtJEKUc7zxy1WR91t6JMIXC
+        CdIILWyuY0E9PaOx0Ngdj/ajcuOvRmjcsSWjHDNp7ETuBFKEL8SyZ/qWwsDfgMqd1MGDpr+ICBu5
+        KRG7xXBy4wB0rNSQ4r4k/Fu/ivCsAREtjXVevZobTszyzhdNyqrQtJ0YjdEvCHAbdwYOA0qSCcio
+        SVqaAQga6aU0zonNSOi4o2/90/QZoWGT/SUzMNP8W7Adt7bv6ccAWKfXDlv9n5NHWvvNYL/ZGoWt
+        w3Bw2NphJ/jnqj3Pj2DtsMmC2kMQrGy7RrBOP+yF4c+oPd3mIKRdRPpUe4vaQ51RL9Hq1QaIfVSn
+        6YE370m7c0uEYmL1u9Eku6bxzauaVVJHKzeDVWAyN5YZNlE8djHx/RMWCYpM5UIQgKf5wWnG3F4V
+        CVFyRmQQu5kliZ6GV9hbFAr9Is5h35wk0kqsbYSBifkKYyIDIwGTYzMDoZhjeuePTmJQm6F+DKEV
+        LYClGurFiHZCrI4SHd9khG4nLsUGzwlCG9KMtI5KMoMqRngSM7o2RHc4p92fZVqdu3SmSal7S4tC
+        mH6i0/RVg0GfdkZOkEm9i0nRK9aWFM361FeRt2he9FiTrlPIuKCVeHwIZi5xfya1MUluaDHoferl
+        ew2F78wY9cGmkzltBP6aMt/2I9qzOdRIzIfzKhN1G5Nx4ahv/+7Sqz9TD8c08eeTk9SlN+rlUZLo
+        MRBAHeUkNGriIr7/XwneCchJx4LydDIvkisStGi3pqQdzmn0rH9Bz0MHvvIOSOu6KAllpbkIA2Z7
+        qfISHM8hTZDlSSX0Tg0jOrUFm0tZLmTDr1uvIuQ/Ugo1X/xaxDPBSlpd3qS5XoxlUy6qNaRdwOYs
+        dOLYYCJPZGqmLVq0N6mBxnrpotTOCvOdRo6e0i40KT2fYzmqzQ1jspnS/iEOnEIbVtgaBPiEMvfq
+        kN3Ho7in/R12Xk+2al8FjzPybmB3qxX02632z4F3d58k0DAcNZuH7f4h2zr/PymTg1Y/fCBI+6Y1
+        KbPf6XRrEL3FktvaQGmSMvmx7ZhscnXsbjYg+dJOrkCu2RwmjN8JEwmbboOwI/VpwnIWxB2arozA
+        lcU2Iri/JjMSc0iM0bLHF6AjWGJgLhLdr2UUw6ay6aLS94wKQlJuQGQjF4F6v1siJ7HT9jSpj98B
+        XHnpoiEyyiqLFtFhsnIxKJ5IZXHbnQRZa2U9ULHARheilIiNvnVEiqNmNEk0upqq4dxo9TIjcc3o
+        /XPa4yTLqaFeFCameYBgnfJYSJ8V6Isti9hpkUMxBHMBj6gMzBib/Ubg7JIZd56EVUJGqJnoPnUP
+        +q1XZOnm2rcG2zdrpIppizrroJGSiByzzr3ZCVjy+K2yigT4BHSJKcEQy5XaBa115tgJRehLb08L
+        iIsmrRT5aUsscZWynkGDjouayLsxPkAhLdD3A/9tNjTSyyOLsTYAqf8oiBXiP/RyktkdSehjK2I1
+        usa2xDk15felnm1ZAr7cZlND+vy9Mmz78ejXFPrYgn5DGswnk0Z+kPeinVy4bTvrEN79nK7d2w/C
+        /bA7ClqH7c5hJ9gKdnvHZ6Pj7ULq8OlOrBZhbV9k4x3Qh8ceZ0jrtQcPNqT5tjUJleYjvB/8Bpvg
+        x09tYt+FUxe0bxSJnKV11OQbMPgrEx07q0lwIMSDl7bmPo5h5aa9SQIo5D1WRR3p3KKWQrSgTQ6v
+        uN/eTv0GQ7P6SEhhCOLoBRq6Lcl7oscJSECiWhaxviOaEmXx32FCIiwJMXCIwYWcoZOKd+lUe/RD
+        xwgHZrDAL0DHC3ZqiWIMWRjmgNSy9AMPM/T13YQVDDqDJxBWkyd/m1hB85WpvxG6XJSje028YvFY
+        CgvgZPlpaxb+GQX9wzZJFN3tFHZxcX7RJDLbTmXHZ8MPF5fnT6WzsDno3idiPJ7Our32g+nMt63F
+        nATdoNlt30tpQXuT0vxzm7Q2LGiTkSaArXao4Pr5SAIwkY1yU/U6qlwU55adVEyMRF1bfGLXmvUH
+        Ynr0LlIMHSkCeA8UNhhxp2pcLMZQgBTummzfJvuk8tgEl4jWtbiwYEgx3GwhlEx0RF2A+4l6o8zK
+        xqTyuZxomy4Tmc3tbL4/jW/wCG1yQ2L8lHTTIsWFE3pTrt45ejxqqCP4o38n8mqQCLNQQ7iVaRUa
+        PMxTV8zUe9o4JHTQyN+mBW3OBTS69wWpJ4n6fU6KH+k4C32jEuoA+KPJaISkS+hJDt7Jg99fumua
+        zgZ1j145V+gk1FKMhbQZNaUO59zbFANO7Yr2FDXWOWbJrIzg3oxAgVSdHIOyEzV2Dn6+/ZmDsZ/6
+        +PucGlJHxwajzthTtqAu4yVYyPrSYoTKRRHpl3G1HhpWMPSjWjI4DWxO+GQWGYQLO+XOR6l/4k7P
+        MRggF8lTJMm4IsdSoTO0iAVh6K9LGnFkaaeT+ozHaPEiA10OX7+9liwcUpOZiyMJE4ICTo2ox7KU
+        U7PANzUsCrJiwGKa6WkRe6mJukJSG8l/9DctN02O7KZMsYMSO4a3GBgF5pl2FPrHj/Ccx/bK8Na/
+        ntvJnC9du5R6NIdARY+kmJzkXjHnCWjsyXObmFNbxD8GgUnM6bB3kP7Z7h3cG366/PDpcrhDzKlu
+        PgmAg0HQf2YADoKHOhPKtmsAbvcG/d4P8Lezib/y2C41j6juOCayVv9K+/ENSTPY0bQJT/S/zDeQ
+        9o3+bmAcSc3UpDWNiSSZ2OsCGXvuxCkoJjBi5wkgbATLCv1BIorwebo3ZFVtrS4QnFDv7HctTra6
+        WsbhgGzRok4WqegrTlSQQcRqG08drE4WdjJSV0iFoe7uZyJ1jR3bbFiduGuApzGRgAYxbqon1stD
+        S8cWvFTUWDu1EzYvin+fLYClGinRDLL63kkBLZRIW4z5gKwDdcqwRU+aZFa6AFgnhNAlntfbop1E
+        KmgAofgGWqlY0k50Nm+IWEnAKwGC3j0aEIJlE7ZhAdQqHZnmL4Z+uipjM4iFsGpaLFMOsoQyjm44
+        9qauVUG8fFrMbIEBfGctHHGNkDJhJ6vLqQ3uGIudWjl6Uw7HktfgIlKfiZumjl0RItFCvySqS1nF
+        x/d5uiJWmO9YYNEvl7DPJcvWQSWvObLjEH++N2l6o85idxOpg4MD9c5McnrorUu+E2xnaALOe+ry
+        G76PvuLiJQeZwFWd8PVTBwvd6wh8m59672hQJwhm9S1G82LGT8IenUbqhL1AfOuYUJK0ZXkvDHqO
+        Zu3cwOlN84YWn/Q4JoFfx5H5jmYfiBUl6q+JK26MfN+wWZfvudSqDwcKUgDfO2Proagm+WQuHxo5
+        4lVn8vCvyYSW+dgSr72Y0Rt5kk7NN3WuE9hsuPtusbhRo2tHf8m8wASpzicfbJL4Nh8Ih2n38Ovn
+        1r+L77x3c/RhRGPG3bdzkxNT+5TS3pDe03ZgC/AZsVHSeT7vfXLLz3ulnRbPfJoT873EHpWPHZHs
+        Npzr5EqmW8MYek28LZIZOy7oSVKgcHO4MnmMiOIh8XyIEJqb/GavcjjZ6HLsEnvFnr3YrnBl6a5I
+        GpQvDScQFfZ5Bs9sTjxQvbVpzJ0y4MTYbuP2aapnTv5UI2sIRhK/uuNxaQU/NTIB7/WcwI3eRYgH
+        kUzmKDP38eknGGObguM7taYKTR/NqrvhgBXon+PVnf1WcxT0SFU67IQ77RFD+vfNcPTm7M2HnTrT
+        aHjx4cksu9dr3xdg+2iW3Wo1w4eG2JZt1yw77HSoW/eZZn/kPWuTshwEYasd7mThOZHSV73BrIea
+        ROijmPCDKKs00aIlFKo5LLCAecDzmt0sikU9JJ8k2CRjlhWxncFbhvklLy+NhUkXu0+8P6SXlEzK
+        MfuDaEuItOD4OeKsltCAzX56wZ6L2IBLw8ApHhc2QxrvqVt65rpEVDzsqgsEx0+9BMIhBLUm9Cs1
+        xFSpSeZFlGxpLLt9avIFUQLfTSpf2GBxcGtY8nlxCjmS2okLer5Ksjy8brGbwCGTEUsmXODZmojB
+        hGOMvE8JaoIReQUJBsy9IE4g3kgvxrd5271+myd43/2u2+G3qW2YR4r03bD7czFCQRs4EQajIDxs
+        dQ7D7R72/z0nzePRIOxwmNSD0MC3rflpmkHdk37yeCxoN1tBt9MLWptY8MakkU3qYZ2b4nvZhHVQ
+        RPQpdo2mpX+BBOaxSNbYuD4pZUUjhQyLXBREwpCcG3O+jPeojuHQURM9NqU3Bg4dYrMk1eU0MXDa
+        /K3gr0JaTTK8akZKvf+okDTLv5PCO1+J7DRbLpDRwm9hORm9gp94TlpAEWn2LsA8wuLjenT3GSxb
+        /cfTU7PJK/f5l7/QrH35t2T1JUu/tDaIa90B6BMjDP3RNNbud8LeT4bVthGI12wh3aUzOGy3/r8R
+        GQL/H2ym9G3XRNYN2uEPslrCu3SW5/zUJlEdlbwB5ibQFQIsUr1JWqfeGa/VpVm5+I4ed26+cRpc
+        Q2IU4JIsU+Mc67MGTA7+O45F0RJUWix5X2eaqMynqHFQOhydNiXeK869hjgboPPeDfODopvjcVJK
+        TbzCaD1Rpa4Yg5hTeBr5Cj4pgyPeSTQWsSNiHcsQV5ok+KdTx8RsSYpnWlc+lCwviGe+ePEWNjP3
+        4kWlpL2BnqRG8qoJdVWzwjaqPeXY9KvjQ7Vrzj//IsL59G+FJVVkSEDwF7r2OuaokMncsaZjU0OK
+        wKE6JZkDsyv/t6ypeGMC7YND9UbD5Jgbfqi4E5B3qIKgTwvDnT9K8HvQ7eLHCd59QkJAaiP+4Ce/
+        Ctmh+qsXFGKrt2inb6kbHK+j1W/QUXIvY7EmKgNQ5wWUaxrUi/WoXrAeGGsSiT4gwcDyE3R/CI0V
+        N8+xH2jbHJvs2k6uRKMiaiTpB7fPXAFVF+4nVmGgGr64kNDLwL2gRZZZkKAeAjFZ54DzIfAEzf+B
+        DEaGSjvmKIFdlrpoJpO5LbVmephNLwl3a4h9qknZP3EJQpik2QnpbHHsRK2mrSmvTEgrTlNR5T7R
+        9ki5wVFMW21IezA1sXT+LEec+Yruo6MpOJJX0P1skpZb0EAxJeWb8dwljY1gWPoFKxSpdzKBoq+9
+        LfTS3cM1ulsUtopZuHS2wQt+hb0J3j8fTjWrcONR/KDX64WcN/AT7KCJqMawOwqDw2b/sLWdHewd
+        QTG7bL6/uDzbrpj9en589unS33+iObU/6D0noyA5d/BQaaxsW/Nn9cOgw0bqx4XN+Oc2mcUlLWx2
+        5ZYbzOHCedMke1SRbgFbyI36TScLnZIIhkRl5g0+DK+MYQOcezfyHWOYmRRePLO6rrHpsUOKhSvN
+        eCsYNWxStnWyHyFy8e3EzESFmlhW/ziPwsBqlcFUp2Hy9KE8cyfxONN2YmsiHSdeiMG17APseNC6
+        siKdIdwmNhIgx7HJMN5JGNvG6Il1FRPSompRP+wo8UEwZcyHluznf9wKOLFIrc5KRc3eHwoXbBLz
+        D70ksug7VKo58ec/Qp0K4KQO+qPmACkX4Q6zy+XFaPjh0y5zy7snx4G0BkH4rIJf2A8f7J8u29bo
+        uddvDvr30/M2/4h/bovwR1sVnucX2a44kKOlUA9s/tNUSEoELhgsUsmLaKjfiCtbdYrYXCMtebf7
+        tKElkqJgpIAVntUeT0dsSdASOCy2e6JnPdMgB+hppTxWaWLeFg/zBXoydRIQl5mvTEy33AFQUdiy
+        r79zyhb9hNPA0uaCdmiJrJZE0gwXcIGkZpIWknRtSFybwa2aVM4QpGTwXEncdTX27OD24Jn8lbxx
+        QWIZolnWYCXpHDHDDXtgJIwN/kcE1YgnoQQ6hB6yUijjcD4z9VZfCBViPanMNyTQFnCLaMuSMW0y
+        cefQwwjkdkil8K/HKyVSp/7tKa0GSb1aoE0yL5bA64QLNlT9p12nY28z48hGCa+BirtyE4+bgGFo
+        srcSzssIO4Kr0kGk2OVVomIDXmbMYCH2snuBLnwC0FVUdMcZ7Kb28Saj7qD5kxAXchxOgKyyDkkv
+        O7LKjobDi+HOOJzhm6dCXLstNpxng7h2v9d5IML5pjX/b7/T6/1AXult4ps8tglvb1NDatSpvjks
+        FS6LQJhjO47NBtJttKjF/J6c0tY+/e1UabgckUcF2RcmneoTjdvqo4GxeAUQY7wIm82OSjj5VHAH
+        FR1MCm8r3IHUmiPMx1qi37/Lg5UOSrqHhfbogUSicdWxvkHaWSQKoWRs4330DyJB3CS2SzFiea1t
+        TEM58lq5+ivtlLyxOTHrRDjFAg16qi3r5kgdyzB2Ul9YM6nmoUGfFqpnOO12UDqmMhjTOM5tDOfj
+        B3OT0IsuOAOEwPfYXce4fWkAZr8mVqaOVFNDCimG9JVrZPgprMcr55ybis/SM2ET2H4nl4ywshrL
+        beHSLyNMDbKMbpkjMYRmkZYnLmxKT5qEuh6061kSiFIhNbM2n5UBgCRgbJC5F+G6HSjXnGYsDLBK
+        tDDfJsghXFVufsnSAK9c3c2/S3Uqfq8xka1lA0nD9xBzTQNLkeSYi1FeUnQWftOVQ0OEUFFlJa6X
+        zogzIpHgbeYzqFogfFQ0S9pD/PWpzBv+XpBgmosJk1M+kF5NxJb7KE5EiEIL9Tynog71UtKNI577
+        KccSIbqBB19fOMZ/5nPCcDhbseQd+5PSqBAlhXsFjVx5yT+CeF++mmjCTYqF7OFaJ7wfBuYkEtrh
+        9pEPw+1ShedPieAmkvriAw6mmqPovZ5bRSHQxTKOn3gfkrG1ZFtHJqI33FFn8DA2a1puvmrnnNVx
+        o0x5ES1FhuZEm/DClJ7A6XPn7dLNMWkpeitJx9Uk0zYn+sTfGj6b7G4WGBQqGOQ3qJKELXvHRKZV
+        f+eLAHavkXhL/+c33KuwNO+r/7DMD67tFWFZZDVMEcTZ6efnX2ScxJe+6C91TF+z9PXS72/lABWr
+        3/tAKgRx14tjhJPfy/L/OZVm1t/fYZy43eBJ1Wb67f7zsvqw034oq/dN16x+0O4H98e0b4u05ad2
+        5FieFumcA6nvxs5Wy8lISqozZ80hkrLmzlmCdiJO0gDyfN47SRE8s0e7hxBWvZQYlhNCMckFxA5f
+        wQk7MUvmvs53QPJ7kcWRjbHJlfP2cCLDFFk3bEQnEKaZzdgM8nnvorgy9KkzHTsE4rwc2YW6dOOx
+        TTKfKgf9hbaUCAgcsMUV1kRdYWwhVE90ShwSvABRl2pJXJtD4HlER0liEUCxcoTGwyLTMDAzkiev
+        ygIRRBp6MXaSmaMFntezh6R4SVIx9UxE/jxmEEbaGKXahM/Q6/Zp0Bgb/Y+nc10ngzNIvTImUVYJ
+        EnwqbVOaR4ZkmASYyeU5oGnK66pIMJ1k7FeotDjnu2gFNHnUsH/e0nv47Q3inxNbwPMPr3ey4thZ
+        fj/aZOabsDGZOFap0JPvmj3cpV6Evi285WYgOug6kC1jNsIb4qDcO7Tc1eqTfjQr6CUZLT4W3SDB
+        6vbaUHNA6Tj1hX3E4y7lhzJRpiO2STss+Tqj8rYkcYAPXLqYI7+HJInRl7wos1eVLEHwAIiXhYc7
+        AXnIp0/MQst7ZjSM1wRy+av7HJH9JzkimcS3xeqyrk/86Ii47C3sJli8fHf+x+B29e1tStnl6OL8
+        iWU+gNaBaLfPhtbN7sPrcfq2ddtT0OaKJ49LQpLHNhEbIfQwEW934x9tJCxWBJ9LxKsPHI2cbHnL
+        JaxKfyNH1grgu9JZOCliAAwsErkWxYJE6pIBrN/viNJm/IV6biHsEUSWqVg7srpXcSZBv8CBMcJi
+        SbZbd/xAvfMBAZzLfpPGJFRFEVEhsZSvbk4chV47uWpwMU5j9f6Fs7LN3+s0IjZAHRkz84iQCx+/
+        qjlYpeJoKoL0iniH4DbkNBkFhxxJNuE6d5TBmZ68G4e7AIj6TG9fXIQkLpmVGYqSepznspw2FUNX
+        KqmtXObTRzRAa+L817JECc0m5gIoLYEQgBrEpibeTo78WT3OijQSgRoiaErwlMw5GuJrIQvpDXIN
+        mUawBp7+At8qC47e/sQnNODWeoY03NL0ZL7BIY2+LXwdBXEX1LfEoRL31p/uAbjBU1LDhCK2ANz7
+        +oaUqSPtf/XoCIt2p91u/VxmAjxqnf2wOWr2Dzvtw3B7qvle8/2HXeLq++FodH58+WSzVNjviE7w
+        fOgXNB9aI6RsW0O/sBP0ws6j5VX/3DaJFRHG98YybTZRE9b4szJ3s0hob8EGjlITSPgipr3vrpP9
+        7Ipk1WFulkhieilx3oREs9krBDfRkyS2ahJKqgSd1HHlELskITN1GaluJAYsjWSBSRU15GE5yViK
+        XT7HZiNkynIFI7r09eXQLuAj16S+j29ewbzy1aEM8o3KYHzP+UvLuZ0ousyJakj9SV7kpJpPc373
+        LC0QgPyBIfKE+zKNtdfbbgwk3OFc8tMy+01dG3OVSX7buIhmhpO8QMdso9GtXqfZaDabDR4G1hf8
+        AmkIMOZgzI7l3BU05Mj43KQFLABxmdFVmlyA2tT4XZHMEOOQwFMB6EfmvIlQ1sOSgHw9R/4F7ZJl
+        zK+bzJ0lsZJTCWYvSGKz8VWZX0UkuzI0qFyhlvB+7vZpfPmcE7Q4GQzBpX/NX7Ayns0dsUvOY6Ox
+        4BvX1PfUwLB/Q99H1HYRo1/HCDTIc/7IhTOxemNNjN436M25pPVZFKRL1TQl+D7Hp27UMXQPyVI8
+        dytUh7y26AwttoLNP4PuRFMQS1A5UvvQnQSivvmBev8goFzmdSu9UM42d+SvFxf/ro4uTtXo3Wt1
+        /OvZ2aMRshuGzZ+spEQI2eJ48A6s9sGO3K3ji4tRcxdGrm8+DSJ7TQn1ezaIbLe6rYdCpG9bT57t
+        9PrB432T/NiuwO8toJhP5qS0yG3SRgjlbL1y+wqOepIWSGowBeShRpXKQ/SIooic3pPoeqmJhlo5
+        iIU+XpOXXpJ6EHVdiP9xrG3KRvmV3id58x8F+wJhonfuKr5JDtSZm7nK/FZ/o69YDjlxVkV1m4Br
+        walEip2jCEVUFuaAkZDdayjluK7QSm8/MxJz7r8i9V65oIRGCQsJX2XhOCsj19ZBDiOdXDW8M9HA
+        VeoKfN6HLDQQfMdSHip4NCoTg3qLTNn7NL3BU7I9ZOV3hnA/mqj77Z9N8kC0QYeLTnCSR3t3kseu
+        UIOnRxp02/1nJeag2ek8VN4p29ascwS/g/u1vW2V0+WxTWI+Z08E8ihIRjDM+2SRN0uifd57Ddlc
+        ookqp3GVp1i5ESrfmBRSbsgxAygWVRn/ayFBpLhZ/9QbxFOvxP8wpP0Fp8xBdbhC2U9fnrnCFdF8
+        qpLqRJ6kYSTsKDCiPGWQqmI9gWMLyYG0Tt6dkHsLSmb+wVcmcLg4zp4oK54pdtzkZbaHjxAYlsP/
+        pEl7FcKFwXHMZXMsAUIq1aJF7UMoUsRupTI+Vgw3msgGhy7Ah1HWK8s5iZW2Rlos2QIn6SXrcpU0
+        gWgAgVNbH9jk40A588StY5FidpwZVInkmpHZynq/EVxBWd07QWICh8WmrIChAj7CgrUPhSiDyPSS
+        lXsxQv5oHpWOrbh66nXJStz1zgxWkVPkJ6JGQuTdrpsvR8GStEi5+l2Z75uzUwVbYGW++07VEVyS
+        ihoc+iZOKx5Fozr1I1lZnZaR/rcqFpGCrUsXFD5OlIp4CZR/KpeJraj4qOdiSxQpzqqIldqmjCLJ
+        GT01GXVAo/SQRLaV5xCEC64qnpUhHxwrHXk9mBgEl80kRZhzig7hfDMJGxjKbcL9QF2GwvroDslr
+        kLpKdywKdDH1fsOGHKlSWzW8VurpoX4cFPbygp//ivBrq+Dq9fIkAkmCT/y00T5H/I4+QOZmrvcl
+        DxqjsxPk5HJVUFShytj7DNIovmImwWHXlbbANW9TXrWSXGAhN4cQHyTpSSpF3zX7NMqhS70G/0NK
+        z2al6eKOr7cyjRPfNzqS+tFbwt0FbrMyePIOahQxijpLweoyPWtm4KEtwygrH24V2YTirUj0WhCb
+        X1T7GopRLnS6QmXZqpCPVKeQfcUb49a636sG9J4gJghP2SImrMH6saJCJ+gHP1kKug/xH4VUw8Og
+        f1jxwrulG9hnt11YOMe9p4oLSJV9Vldep995qOjvm96R/J8QlciP7ZL8lyRVTzekgxDUgbSGGqIT
+        mUv1O3+ICRiWB1XOtS/rPFXX/imC7LbA2fGtkdxyWHxi09gf47CQb2+XXz892WQXDEghfd492Xpw
+        XXLftBZJFrbazfuTpLbZ6+SxLe4KACGcqcjhj26QwnMCcwxMLGyZG+Yu3SwmuSij4qWoN8moenk3
+        dkNYVOWBJvy3q5RdFbddcJ4HWamuLWnE6yNFzuzUcG8+oui4kwpTd3rdQJ5LjnKESSk0O58MeaaL
+        lN2fQ87xV8ti7P3hPpAN6iwJ1T5OV4tBkMvMGlKEl2Vhx7vlPaIdY/ajbKwl/DKbWfKkXRqxg8Ml
+        ZRXZGSStW3nOKEOka6XARQyuufUb4htKHSLnJZA/J5FpDp8RNrO/Bj8+xONVpS9kktsJQZcE1EzK
+        sGfE+1MWHC1MAJKt5g0GsjZL5E2/ZBOtCnqdAWLYet3eq+rgCAnNYmHaH9cSGVmkao1qHtyFP6fB
+        ZJwXruNStoUhQ/pXE+QOuBOTAUc5Z/zmtzZme+BREnE79fIIVouV2/87+5m5UsqJc1xX+Qg5W3xm
+        DXK0JAyv31SnVmc0gPcItrtRF0TJCHF4WQaOI5SaGr51CKaK4HC5enW7rG8Vnei4AigtSlXimtuN
+        XZ67xZNjg3aWkmBC3oLJD6bkNVyPLoejy/O/X4w+/DGQvf7+B8gM9GM7fG9t9zQoDzph6zmhvN0L
+        H+p69k1rFSbaYfCEJCZ5bLt4sYnUb+ISaREIySbCQbOshrK2LtaL/6KeujwkuonXzkkkJs035fqX
+        XIyhjBdtblbh9dfnxQKBM1siBtmC5wvlKoJXY/UCZaLGcGfqqU0XYhaZkyg/lc6MuTPiAEZZbS5M
+        gWzBG9SfMGlZw4l2ceJmXo+denMAl1tC4b1vBbR+LjAPrbcqom4Y9McFu265ma8kha1yQN/J/Lcq
+        oPaTJwxsqtlmUtduCah4lhu3qrXjE65olFqORCe5osQ+rpK7Dne+Mz8fMxk2q1o28triam1M8qfp
+        wNMtsajESDKbF7eXgMtZrb8epTWDwL2A9YTsq6Zs150HTu4jmDIFy83UEcqHReZWxbo91iX+EHly
+        lyxJ+HPxbng+HD21Ol3QH/Sk8O/zFbcIWg9Vc8q29VI37XavdV95uh+XtwiDXhjAIfZgj4ccSzBK
+        keLkaemFNH1xKzUxKtJyg7NtxHE4X2ysKoNWbheTKUuPZ2WAICKZE+LV5VdSyG33lZoI1yL0o0q3
+        8Cw+m93/mYq2hPtBDwnEyCHenoLzf7ieRDjohw+OxPVta/p7tx8GP3DdbbP2++ceymIFyNa8dNNM
+        L9bmSILHb8m2F7DcpZtahKhXtXPTkJkYe4s4hyPJHbbIIw3RpN4r5k9YarANMLuta0HwLxNHFt7S
+        OYE4G1mUlGF2R982zOOmbZjK2UGIAcJDviX2Xb2hntYD/NkP6c+PTH1+C8mr8Cw32Kn978QDfRrl
+        V52YMtFec3IPeyS5RAOXvMZpb7hhvqNS7TqxjtvBEYh4BX9N5oZzNBdVl3F41crEVb6zL9EvSIIS
+        WRM+5HmaIv2SD7ebmbrwgKpURF84Xra0e+cJezcNV7z0E4UrfKD0xtLD98BGSe3dC5zUIkrlFGlE
+        UmZSR6T0WW9A5qq80EQRAeNVwOrkq8wbO/lk7AWONplIbo44c7HT1Yvb87I+1JvesBDF6wWcFABC
+        tiO7lS1PnSqlQFH3liItwTRd1h9B+R4EBYrwULqIYn8oi6pvF0wTbwScKlgee8X21oyzZmtnEVY2
+        W/cDZH5KBrjQ804ZBKehBK8ei89hs90d/GyFB9ha94MQ8WhBuAug75FFnmpnbfc7rWdVhIJes/vQ
+        gg5l28dU/tkWg/u/U/nnB4V/XkqBllc/rgAUV4YWCOpSJgZGm5f1ojIwqtwtE+RLBC2eu0bQua5k
+        JGSTofIPMAoWZ18tL+UjCuo+QQ6JpYEAF/gw4Oo4UpRKKYc95hQIWHfWw4wABUB+fwRJ/URR6Shy
+        wSTqde0fh+s7mXBVWgmcVeabn4EJTg5RF5gUjsul51c6W59zyEfXfNcbp8TAo1lWpIDTTyYZ7l45
+        VBXgto6UKTMTaloewmf/co+xfVvJmWaz3OO3EQjVZjh+gGN6P9b26uM8P71Bt/2TJ5MM9uH96Y+C
+        4BD1x3ZUm3l99veLv3+4GO44nuT/YK2ZoN16cOW/sm0tYmTQZpB/nA+In9p5PpOPPn0ntUfuSJPY
+        DAkOgltX5dvfMJrTxmx5W0DDyz3iq4VZW0tis1oiIkB293h96FgZWn7APmApTWHSmUvEQe/PQqnJ
+        oiQDqJcr5Pb4oPy00HJg0kLYdnUK57r4hElSS92aII/7DX33iluvT0gCVdUjBpCzBCjyvvhjDiEp
+        UxcgsuYsFGUQWsro/PckPdZTq0ClCbIMGlJt2onJCtYtPgTJH+JZBpCxDtmAlWV9smAVa1I//w42
+        dE5R46OQhpomPVnb1VuuKv2TViWjfAVVdYww3zPjktmBep2UwnyjVv2QcdYV6Ea5oPhKzHzCyVHJ
+        DXzB74WyAEVGn0g5OmSMow3mutKGWYrmdLkqMmGNfQyyW7ZY7aRn+CtyPSlIfBfRdMzBRFzLhGuJ
+        VYnirO3EUoeIjV6OK0yr3523GsYckU1rUTRQFQA2q3VIjFfauYQcioPsDTXOZppc2WSp52oy9xnQ
+        SCIj2Xqc6n3aXwuJIrkD6KIuUZ/zoixKslG7/t44v+YmYj8gowtEvqOq8yYJb6X9R4F8q9n5yXNS
+        CeCD0Fd7btE/O87GGX0Yvt8ZCnjx4Rj5us2nVx8KWv3W85adbPUe7OUv264Rvhf2mvdnQGwTPvmp
+        LQiPLKd7zp+62JHCxUDEch8AlIPfvIkYKFYe8uazoVD9gWZm0eBwWge5Ddpwt9lUbHD3Zwmn7ORj
+        YSgrS8KyYg2tzgfb+JOr1rItkhtKn6VURXK+ImzCmZ0adb1wiENqlrGRlLO79gup6SGlk8tC+xxN
+        nJWVynzOv3gLy0MzUf6BBSD1Tk+uFppQVuq1n7hxkSY4ooDEygnYQ0q9b6hTPUYOxolj328DB3Qy
+        AsEnaNRfOWUgSe47eCUY9J7ihWvy6m8h/Y803mziyrU7RUybn5bHUvug2/rpWJ4g2A/aiOVpd3cW
+        4Dke7T4G6+Pl8MPofDR8+jksYbv1rOlOOGf5oadtlm1rFsHmoNW+/7jNrdlO/NjOc1jUR7ifaIPr
+        6Fpv2gdfk+AT48y4yJO7z9gPm/WisgWcyblB/nVVjq8q5CEZj1IhI0Ww79rNjjhB+O2JzEteo/2Z
+        l1GZbiccOhShBAQ+tQsvDfmkR64jttQ44kO4eWKRZ+i/PyCk2TyzlnP3pSaayFNVCqo/vRmcOivY
+        5IW8cvud/W7rWFavNNKGj/T+pLSMxf6AUc22ICmiiA+zV50rXyfVkS936geR4BHdqCNalEQp6dX7
+        ei7qyVx//85nEEtyLYofWSCE+t3y8V6cKh/JCcHqIw6Ql/xVTlQ44iGc0Cp/LVbo0r0SxVOOrZR9
+        ts25z0eQ0BaqbbJHgUm3Hf5k6qRHk3DUDA9Jegh3JQadjYZvLo8vR79vR5TR5fDC330ioLS6Pz4l
+        4j//B9VXnrnPkQAA
+    headers:
+      accept-ranges: [bytes]
+      access-control-allow-origin: ['*']
+      age: ['0']
+      connection: [keep-alive]
+      content-encoding: [gzip]
+      content-length: ['11925']
+      content-type: [text/html; charset=utf-8]
+      date: ['Thu, 13 Oct 2016 05:32:17 GMT']
+      set-cookie: [PHPSESSID=scfvo2j16vfers1of52lp9imi7; path=/; HttpOnly]
+      vary: ['User-Agent,Accept-Encoding']
+      via: [1.1 varnish]
+      x-backend: [default_director]
+      x-cache: [MISS]
+      x-cacheable: ['NO:Not Cacheable']
+      x-varnish: ['648888615']
+    status: {code: 200, message: OK}
+version: 1

--- a/tests/test_legendastv.py
+++ b/tests/test_legendastv.py
@@ -187,6 +187,16 @@ def test_search_titles_without_season_information():
 
 @pytest.mark.integration
 @vcr.use_cassette
+def test_search_titles_containing_year_information():
+    with LegendasTVProvider() as provider:
+        titles = provider.search_titles('Bull')
+    assert 42047 in titles.keys()
+    t = titles[42047]
+    assert t['title'], t['year'] == ('Bull', 2016)
+
+
+@pytest.mark.integration
+@vcr.use_cassette
 def test_get_archives():
     with LegendasTVProvider() as provider:
         archives = provider.get_archives(34084, 2)


### PR DESCRIPTION
Series titles with year (and country) should be parsed correctly.
The example is: `"dsc_nome":"Bull (2016)",`
http://legendas.tv/legenda/sugestao/bull

```
   {  
      "_index":"filmes",
      "_type":"filme",
      "_id":"42047",
      "_score":null,
      "_source":{  
         "id_filme":"42047",
         "id_imdb":"5827228",
         "tipo":"S",
         "int_genero":"0",
         "dsc_imagen":"legendas_tv_20160922004714.jpg",
         "dsc_nome":"Bull (2016)",
         "dsc_sinopse":"....",
         "dsc_data_lancamento":"2016",
         "dsc_url_imdb":"http:\/\/www.imdb.com\/title\/tt5827228\/",
         "dsc_nome_br":"Bull (2016) - 1\u00aa Temporada",
         "soundex":null,
         "temporada":"1",
         "id_usuario":"3318434",
         "flg_liberado":"0",
         "dsc_data_liberacao":null,
         "dsc_data":"2016-09-22T00:48:04",
         "dsc_metaphone_us":null,
         "dsc_metaphone_br":null,
         "episodios":null,
         "flg_seriado":null,
         "last_used":"0",
         "deleted":false
      },
```

This fixes #701 
