### PR TITLE
Fix empty archive's name in legendastv provider

### DIFF
--- a/subliminal/providers/legendastv.py
+++ b/subliminal/providers/legendastv.py
@@ -275,9 +275,9 @@ class LegendasTVProvider(Provider):
             soup = ParserBeautifulSoup(r.content, ['lxml', 'html.parser'])
             for archive_soup in soup.select('div.list_element > article > div'):
                 # create archive
-                archive = LegendasTVArchive(archive_soup.a['href'].split('/')[2], archive_soup.a.text,
+                archive = LegendasTVArchive(archive_soup.p.a['href'].split('/')[2], archive_soup.p.a.text,
                                             'pack' in archive_soup['class'], 'destaque' in archive_soup['class'],
-                                            self.server_url + archive_soup.a['href'][1:])
+                                            self.server_url + archive_soup.p.a['href'][1:])
 
                 # extract text containing downloads, rating and timestamp
                 data_text = archive_soup.find('p', class_='data').text


### PR DESCRIPTION
When logged in as a donor, there's an extra `<a href=... class="seta"></a>` in the div, causing `get_archives` to return an archive with no name. This will result in lots of unnecessary (and useless) downloads when `download_best_subtitles` is called.

To fix we just specify the correct anchor (the one inside the `<p>`) in `get_archives`. Easy fix, ugly test (without sharing my password, that is).