### PR TITLE
Fix RegistrableExtensionManager not working with stevedore after 1.19.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ def find_version(*file_paths):
 setup_requirements = ['pytest-runner'] if {'pytest', 'test', 'ptr'}.intersection(sys.argv) else []
 
 install_requirements = ['guessit>=2.0.1', 'babelfish>=0.5.2', 'enzyme>=0.4.1', 'beautifulsoup4>=4.4.0',
-                        'requests>=2.0', 'click>=4.0', 'dogpile.cache>=0.6.0', 'stevedore>=1.0.0, <=1.19.1',
+                        'requests>=2.0', 'click>=4.0', 'dogpile.cache>=0.6.0', 'stevedore>=1.0.0',
                         'chardet>=2.3.0', 'pysrt>=1.0.1', 'six>=1.9.0', 'appdirs>=1.3', 'rarfile>=2.7',
                         'pytz>=2012c']
 if sys.version_info < (3, 2):

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ def find_version(*file_paths):
 setup_requirements = ['pytest-runner'] if {'pytest', 'test', 'ptr'}.intersection(sys.argv) else []
 
 install_requirements = ['guessit>=2.0.1', 'babelfish>=0.5.2', 'enzyme>=0.4.1', 'beautifulsoup4>=4.4.0',
-                        'requests>=2.0', 'click>=4.0', 'dogpile.cache>=0.6.0', 'stevedore>=1.0.0',
+                        'requests>=2.0', 'click>=4.0', 'dogpile.cache>=0.6.0', 'stevedore>=1.0.0, <=1.19.1',
                         'chardet>=2.3.0', 'pysrt>=1.0.1', 'six>=1.9.0', 'appdirs>=1.3', 'rarfile>=2.7',
                         'pytz>=2012c']
 if sys.version_info < (3, 2):

--- a/subliminal/extensions.py
+++ b/subliminal/extensions.py
@@ -29,10 +29,7 @@ class RegistrableExtensionManager(ExtensionManager):
 
         super(RegistrableExtensionManager, self).__init__(namespace, **kwargs)
 
-    def _find_entry_points(self, namespace):
-        # copy of default extensions
-        eps = list(super(RegistrableExtensionManager, self)._find_entry_points(namespace))
-
+    def list_all_extensions(self, eps):
         # internal extensions
         for iep in self.internal_extensions:
             ep = EntryPoint.parse(iep)
@@ -46,6 +43,18 @@ class RegistrableExtensionManager(ExtensionManager):
                 eps.append(ep)
 
         return eps
+
+    def _find_entry_points(self, namespace):
+        # copy of default extensions
+        # Used in stevedore <= 1.19.1
+        eps = list(super(RegistrableExtensionManager, self)._find_entry_points(namespace))
+        return self.list_all_extensions(eps)
+
+    def list_entry_points(self):
+        # copy of default extensions
+        # Used in stevedore > 1.20.1
+        eps = list(super(RegistrableExtensionManager, self).list_entry_points())
+        return self.list_all_extensions(eps)
 
     def register(self, entry_point):
         """Register an extension

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -1,17 +1,15 @@
 # -*- coding: utf-8 -*-
-from pkg_resources import EntryPoint, iter_entry_points
+from pkg_resources import EntryPoint
 
 from subliminal.extensions import RegistrableExtensionManager, provider_manager
 
 
-def test_registrable_extension_manager_all_extensions():
+def test_registrable_extension_manager_single_extension():
     manager = RegistrableExtensionManager('subliminal.providers', [
         'de7cidda = subliminal.providers.addic7ed:Addic7edProvider'
     ])
     extensions = sorted(e.name for e in manager)
-    assert len(extensions) == 9
-    assert extensions == ['addic7ed', 'de7cidda', 'legendastv', 'opensubtitles', 'podnapisi', 'shooter', 'subscenter',
-                          'thesubdb', 'tvsubtitles']
+    assert 'de7cidda' in extensions
 
 
 def test_registrable_extension_manager_internal_extension():
@@ -52,6 +50,6 @@ def test_registrable_extension_manager_unregister():
 
 
 def test_provider_manager():
-    setup_names = {ep.name for ep in iter_entry_points(provider_manager.namespace)}
+    setup_names = {ep.name for ep in provider_manager.extensions}
     internal_names = {EntryPoint.parse(iep).name for iep in provider_manager.internal_extensions}
     assert setup_names == internal_names


### PR DESCRIPTION
@Diaoul stevedore 1.20.0 broke the test_extensions.py 

http://git.openstack.org/cgit/openstack/stevedore/commit/?id=eb04fc4a3e3db913475d2f7105420351a0a781a9

With 1.19.1 it passes

UPDATE: new version has a new method so my fix is to override both methods

I changed the first test because in newest version, `RegistrableExtensionManager` will only have the extensions that was passed