### PR TITLE
Log error instead of traceback when can't refine mkv

### DIFF
--- a/subliminal/core.py
+++ b/subliminal/core.py
@@ -9,7 +9,6 @@ import operator
 import os.path
 import socket
 
-from enzyme import exceptions
 from babelfish import Language, LanguageReverseError
 from guessit import guessit
 from rarfile import NotRarFile, RarCannotExec, RarFile
@@ -541,11 +540,9 @@ def refine(video, episode_refiners=None, movie_refiners=None, **kwargs):
         logger.info('Refining video with %s', refiner)
         try:
             refiner_manager[refiner].plugin(video, **kwargs)
-        except exceptions.Error:
+        except:
             logger.error('Failed to refine video %s', video.name)
             logger.debug('Refiner exception:', exc_info=True)
-        except:
-            logger.exception('Failed to refine video')
 
 
 def list_subtitles(videos, languages, pool_class=ProviderPool, **kwargs):

--- a/subliminal/core.py
+++ b/subliminal/core.py
@@ -541,7 +541,7 @@ def refine(video, episode_refiners=None, movie_refiners=None, **kwargs):
         try:
             refiner_manager[refiner].plugin(video, **kwargs)
         except:
-            logger.error('Failed to refine video %s', video.name)
+            logger.error('Failed to refine video %r', video.name)
             logger.debug('Refiner exception:', exc_info=True)
 
 

--- a/subliminal/core.py
+++ b/subliminal/core.py
@@ -9,6 +9,7 @@ import operator
 import os.path
 import socket
 
+from enzyme import exceptions
 from babelfish import Language, LanguageReverseError
 from guessit import guessit
 from rarfile import NotRarFile, RarCannotExec, RarFile
@@ -540,6 +541,9 @@ def refine(video, episode_refiners=None, movie_refiners=None, **kwargs):
         logger.info('Refining video with %s', refiner)
         try:
             refiner_manager[refiner].plugin(video, **kwargs)
+        except exceptions.Error:
+            logger.error('Failed to refine video %s', video.name)
+            logger.debug('Refiner exception:', exc_info=True)
         except:
             logger.exception('Failed to refine video')
 

--- a/subliminal/refiners/metadata.py
+++ b/subliminal/refiners/metadata.py
@@ -3,7 +3,7 @@ import logging
 import os
 
 from babelfish import Error as BabelfishError, Language
-from enzyme import MKV
+from enzyme import MKV, exceptions
 
 logger = logging.getLogger(__name__)
 
@@ -29,7 +29,12 @@ def refine(video, embedded_subtitles=True, **kwargs):
     extension = os.path.splitext(video.name)[1]
     if extension == '.mkv':
         with open(video.name, 'rb') as f:
-            mkv = MKV(f)
+            try:
+                mkv = MKV(f)
+            except exceptions.Error:
+                logger.error('Unable to parse %s', video.name)
+                logger.debug('Invalid MKV: %r', video, exc_info=True)
+                return
 
         # main video track
         if mkv.video_tracks:

--- a/subliminal/refiners/metadata.py
+++ b/subliminal/refiners/metadata.py
@@ -3,7 +3,7 @@ import logging
 import os
 
 from babelfish import Error as BabelfishError, Language
-from enzyme import MKV, exceptions
+from enzyme import MKV
 
 logger = logging.getLogger(__name__)
 
@@ -29,12 +29,7 @@ def refine(video, embedded_subtitles=True, **kwargs):
     extension = os.path.splitext(video.name)[1]
     if extension == '.mkv':
         with open(video.name, 'rb') as f:
-            try:
-                mkv = MKV(f)
-            except exceptions.Error:
-                logger.error('Unable to parse %s', video.name)
-                logger.debug('Invalid MKV: %r', video, exc_info=True)
-                return
+            mkv = MKV(f)
 
         # main video track
         if mkv.video_tracks:


### PR DESCRIPTION
Failed to refine video:
Traceback (most recent call last):
  File "/lib/subliminal/core.py", line 542, in refine
    refiner_manager[refiner].plugin(video, **kwargs)
  File "/lib/subliminal/refiners/metadata.py", line 32, in refine
    mkv = MKV(f)
  File "/lib/enzyme/mkv.py", line 42, in __init__
    raise MalformedMKVError('No Segment found')
MalformedMKVError: No Segment found


As @ratoaq2 suggested:

Verbose logging:
```
Unable to parse /library/a.mkv
Invalid MKV <Video....> 
Traceback (most recent call last):
File "/lib/subliminal/core.py", line 542, in refine
refiner_manager[refiner].plugin(video, **kwargs)
File "/lib/subliminal/refiners/metadata.py", line 32, in refine
mkv = MKV(f)
File "/lib/enzyme/mkv.py", line 42, in init
raise MalformedMKVError('No Segment found')
MalformedMKVError: No Segment found
```

Non-verbose logging:
```
Unable to parse /library/a.mkv
```