### PR TITLE
Fix stevedore incompatibility since version 1.20.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ def find_version(*file_paths):
 setup_requirements = ['pytest-runner'] if {'pytest', 'test', 'ptr'}.intersection(sys.argv) else []
 
 install_requirements = ['guessit>=2.0.1', 'babelfish>=0.5.2', 'enzyme>=0.4.1', 'beautifulsoup4>=4.4.0',
-                        'requests>=2.0', 'click>=4.0', 'dogpile.cache>=0.6.0', 'stevedore>=1.0.0',
+                        'requests>=2.0', 'click>=4.0', 'dogpile.cache>=0.6.0', 'stevedore>=1.20.0',
                         'chardet>=2.3.0', 'pysrt>=1.0.1', 'six>=1.9.0', 'appdirs>=1.3', 'rarfile>=2.7',
                         'pytz>=2012c']
 if sys.version_info < (3, 2):

--- a/subliminal/extensions.py
+++ b/subliminal/extensions.py
@@ -29,9 +29,9 @@ class RegistrableExtensionManager(ExtensionManager):
 
         super(RegistrableExtensionManager, self).__init__(namespace, **kwargs)
 
-    def _find_entry_points(self, namespace):
+    def list_entry_points(self):
         # copy of default extensions
-        eps = list(super(RegistrableExtensionManager, self)._find_entry_points(namespace))
+        eps = list(super(RegistrableExtensionManager, self).list_entry_points())
 
         # internal extensions
         for iep in self.internal_extensions:


### PR DESCRIPTION
- Stevedore 1.20.0 changed `ExtensionManager` api.
- This fixes all tests apart from the `PARSER=lxml` environments. (That's a different issue not related to stevedore)