### PR TITLE
Fix broken pytest after changing provider search URL

### DIFF
--- a/tests/cassettes/core/test_download_bad_subtitle.yaml
+++ b/tests/cassettes/core/test_download_bad_subtitle.yaml
@@ -125,7 +125,7 @@ interactions:
       Cookie: [au=3673290---198d5f2e1a202d0c2878ae871f911763d7cd76c0; PHPSESSID=t30lil6u18jhaaddcfb24spr97]
       User-Agent: [Subliminal/2.1]
     method: GET
-    uri: http://legendas.tv/util/carrega_legendas_busca_filme/29087/2/-/1
+    uri: http://legendas.tv/legenda/busca/-/2/-/0/29087
   response:
     body:
       string: !!binary |


### PR DESCRIPTION
Test was fine in the original commit but after I rebased with latest develop and this https://github.com/Diaoul/subliminal/pull/762/files got merged, I didn't updated cassette so test started to fail.
Thanks @sharkykh for finding this.

Sorry about that @Diaoul 