### PR TITLE
Fix lxml parsing for Addic7ed

### DIFF
--- a/subliminal/providers/addic7ed.py
+++ b/subliminal/providers/addic7ed.py
@@ -2,6 +2,7 @@
 import logging
 import re
 
+import six
 from babelfish import Language, language_converters
 from guessit import guessit
 from requests import Session
@@ -20,7 +21,10 @@ logger = logging.getLogger(__name__)
 language_converters.register('addic7ed = subliminal.converters.addic7ed:Addic7edConverter')
 
 # Series cell matching regex
-show_cells_re = re.compile(r'<td class="version">.*?</td>', re.DOTALL)
+if six.PY2:
+    show_cells_re = re.compile(r'<td class="version">.*?</td>', re.DOTALL)
+else:
+    show_cells_re = re.compile(br'<td class="version">.*?</td>', re.DOTALL)
 #: Series header parsing regex
 series_year_re = re.compile(r'^(?P<series>[ \w\'.:(),&!?-]+?)(?: \((?P<year>\d{4})\))?$')
 
@@ -138,31 +142,20 @@ class Addic7edProvider(Provider):
         logger.info('Getting show ids')
         r = self.session.get(self.server_url + 'shows.php', timeout=10)
         r.raise_for_status()
-        soup = ParserBeautifulSoup(r.content, ['lxml', 'html.parser'])
 
-        show_links = soup.select('td.version > h3 > a[href^="/show/"]')
-        if not show_links and soup.builder.NAME == 'lxml':
-            # LXML parser seems to fail when parsing Addic7ed.com HTML markup.
-            # Last known version to work properly is 3.6.4 (next version, 3.7.0, fails)
-            # This solution assumes that the site's markup is bad, and strips it down to only contain what's needed.
-            # It could fall back to html.parser whenever that fails,
-            # but that would mean not knowing it failed, and that's bad.
-            show_cells = re.findall(show_cells_re, r.content)
-            if show_cells:
-                # Re-parse stripped down HTML
-                soup = ParserBeautifulSoup(''.join(show_cells), ['lxml', 'html.parser'])
-            else:
-                # RegExp match failed
-                pass
-                # Re-parse using html.parser
-                # soup = ParserBeautifulSoup(r.content, ['html.parser'])
-
-            # Re-select elements and continue
-            show_links = soup.select('td.version > h3 > a[href^="/show/"]')
+        # LXML parser seems to fail when parsing Addic7ed.com HTML markup.
+        # Last known version to work properly is 3.6.4 (next version, 3.7.0, fails)
+        # Assuming the site's markup is bad, and stripping it down to only contain what's needed.
+        show_cells = re.findall(show_cells_re, r.content)
+        if show_cells:
+            soup = ParserBeautifulSoup(b''.join(show_cells), ['lxml', 'html.parser'])
+        else:
+            # Use original response content
+            soup = ParserBeautifulSoup(r.content, ['lxml', 'html.parser'])
 
         # populate the show ids
         show_ids = {}
-        for show in show_links:
+        for show in soup.select('td.version > h3 > a[href^="/show/"]'):
             show_ids[sanitize(show.text)] = int(show['href'][6:])
         logger.debug('Found %d show ids', len(show_ids))
 

--- a/subliminal/providers/addic7ed.py
+++ b/subliminal/providers/addic7ed.py
@@ -2,7 +2,6 @@
 import logging
 import re
 
-import six
 from babelfish import Language, language_converters
 from guessit import guessit
 from requests import Session
@@ -21,10 +20,8 @@ logger = logging.getLogger(__name__)
 language_converters.register('addic7ed = subliminal.converters.addic7ed:Addic7edConverter')
 
 # Series cell matching regex
-if six.PY2:
-    show_cells_re = re.compile(r'<td class="version">.*?</td>', re.DOTALL)
-else:
-    show_cells_re = re.compile(br'<td class="version">.*?</td>', re.DOTALL)
+show_cells_re = re.compile(b'<td class="version">.*?</td>', re.DOTALL)
+
 #: Series header parsing regex
 series_year_re = re.compile(r'^(?P<series>[ \w\'.:(),&!?-]+?)(?: \((?P<year>\d{4})\))?$')
 
@@ -150,8 +147,8 @@ class Addic7edProvider(Provider):
         if show_cells:
             soup = ParserBeautifulSoup(b''.join(show_cells), ['lxml', 'html.parser'])
         else:
-            # Use original response content
-            soup = ParserBeautifulSoup(r.content, ['lxml', 'html.parser'])
+            # If RegEx fails, fall back to original r.content and use 'html.parser'
+            soup = ParserBeautifulSoup(r.content, ['html.parser'])
 
         # populate the show ids
         show_ids = {}


### PR DESCRIPTION
Basically, after like, 2 or 3 hours of trying different things,
I've come to the conclusion that,
  1. Addic7ed HTML markup is probably broken.
  2. Parsing using lxml worked just fine up until version lxml 3.7.0 was released.
      See [the last Travis job log for `PARSER=lxml` that passed](https://travis-ci.org/Diaoul/subliminal/jobs/169318251#L620).
    Something changed in lxml that caused it to not be able to parse Addic7ed's (broken) html properly, only parsing the some of the site.

Since we can't control Addic7ed's HTML code, we need to find a way around it.
(Oh, the joys of website scraping...)

Using a regex pattern is probably the simplest and fastest way to go about this, and it seems to work.
What it does is strip down the HTML to only the `<td class="version">` tags and discarding everything else.

Note: There are two commits, this is intentional, in order to show my progress.
- The first commit has a slower method - checking if it failed, and if it did then re-parsing with the stripped content.
This makes parsing the page with lxml much slower, **to a point where html.parser is faster**.
- The second commit just simplifies everything, and strips down the HTML **either way**.
    If the stripping down fails, it falls back to using the current method of BeautifulSoup-ing the whole response content **using only html.parser**, because we already know lxml can't parse it.
    This method is faster than both the first commit, and the current method, because BS4 only has to parse about half the HTML (`1.07 MB => 621 KB`).

Ping @fernandog

Some code I used for testing:
https://gist.github.com/sharkykh/40b059cfcdcf5aab360a3bcd7db65ed5