### PR TITLE
Fixed `.lower()` error thrown on certain videos

### DIFF
--- a/subliminal/subtitle.py
+++ b/subliminal/subtitle.py
@@ -2,7 +2,6 @@
 import codecs
 import logging
 import os
-import sys
 
 import chardet
 import pysrt
@@ -233,8 +232,9 @@ def guess_matches(video, guess, partial=False):
     if video.resolution and 'screen_size' in guess and guess['screen_size'] == video.resolution:
         matches.add('resolution')
     # format
-    if video.format and guess.get('format') \
-            and isinstance(guess['format'], str if sys.version_info[0] >= 3 else basestring) \
+    # Guessit may return a list for `format`, which indicates a conflict in the guessing.
+    # We should match `format` only when it returns single value to avoid false `format` matches
+    if video.format and guess.get('format') and not isinstance(guess['format'], list) \
             and guess['format'].lower() == video.format.lower():
         matches.add('format')
     # video_codec

--- a/subliminal/subtitle.py
+++ b/subliminal/subtitle.py
@@ -2,6 +2,7 @@
 import codecs
 import logging
 import os
+import sys
 
 import chardet
 import pysrt
@@ -232,7 +233,7 @@ def guess_matches(video, guess, partial=False):
     if video.resolution and 'screen_size' in guess and guess['screen_size'] == video.resolution:
         matches.add('resolution')
     # format
-    if video.format and 'format' in guess and guess['format'].lower() == video.format.lower():
+    if video.format and 'format' in guess and isinstance(guess['format'], str if sys.version_info[0] >= 3 else basestring) and guess['format'].lower() == video.format.lower(): 
         matches.add('format')
     # video_codec
     if video.video_codec and 'video_codec' in guess and guess['video_codec'] == video.video_codec:

--- a/subliminal/subtitle.py
+++ b/subliminal/subtitle.py
@@ -233,7 +233,9 @@ def guess_matches(video, guess, partial=False):
     if video.resolution and 'screen_size' in guess and guess['screen_size'] == video.resolution:
         matches.add('resolution')
     # format
-    if video.format and 'format' in guess and isinstance(guess['format'], str if sys.version_info[0] >= 3 else basestring) and guess['format'].lower() == video.format.lower(): 
+    if video.format and guess.get('format') \
+            and isinstance(guess['format'], str if sys.version_info[0] >= 3 else basestring) \
+            and guess['format'].lower() == video.format.lower():
         matches.add('format')
     # video_codec
     if video.video_codec and 'video_codec' in guess and guess['video_codec'] == video.video_codec:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -38,7 +38,10 @@ def movies():
             Movie(u'Café Society.1080p.avc1.RARBG.mp4', u'Café Society', year=2016),
             'interstellar':
             Movie('Interstellar.2014.2014.1080p.BluRay.x264.YIFY.rar', 'Interstellar',
-                  format='BluRay', release_group='YIFY', resolution='1080p', video_codec='h264', year=2014)}
+                  format='BluRay', release_group='YIFY', resolution='1080p', video_codec='h264', year=2014),
+            'inferno':
+            Movie('Inferno.2016.1080p.WEB.BluRay.x264-[GROUP1.AG].mp4', 'Inferno', format=['BluRay', 'WEB-DL'],
+                  release_group='GROUP1', resolution='1080p', video_codec='h264', year=2016)}
 
 
 @pytest.fixture

--- a/tests/test_subtitle.py
+++ b/tests/test_subtitle.py
@@ -125,3 +125,12 @@ def test_subtitle_empty_encoding():
 def test_subtitle_invalid_encoding():
     subtitle = Subtitle(Language('deu'), False, None, 'rubbish')
     assert subtitle.encoding is None
+
+
+def test_guess_multiple_formats(movies):
+    video = movies['inferno']
+    guess = {'title': video.title.upper(), 'year': video.year, 'release_group': video.release_group.upper(),
+             'screen_size': video.resolution, 'format': video.format, 'video_codec': video.video_codec}
+    expected = {'title', 'year', 'release_group', 'resolution', 'video_codec'}
+    # Assert `format` is not a match
+    assert guess_matches(video, guess) == expected


### PR DESCRIPTION
From @Deathspike:

Create a feature branch and cherry-picked his commit:
https://github.com/Diaoul/subliminal/pull/814

Fixed `.lower()` error thrown on certain videos due to `format` being a list. Or something. I don't actually understand anything that's going on here, but this change works on Py2+Py3 and seems to achieve my desired result - get subtitles even on those files.
