### PR TITLE
Revert changes related to multi episode video files

### DIFF
--- a/subliminal/providers/opensubtitles.py
+++ b/subliminal/providers/opensubtitles.py
@@ -220,7 +220,7 @@ class OpenSubtitlesProvider(Provider):
         if isinstance(video, Episode):
             query = video.series
             season = video.season
-            episode = min(video.episode) if isinstance(video.episode, list) else video.episode
+            episode = video.episode
         else:
             query = video.title
 

--- a/subliminal/providers/tvsubtitles.py
+++ b/subliminal/providers/tvsubtitles.py
@@ -172,9 +172,6 @@ class TVsubtitlesProvider(Provider):
 
         # get the episode ids
         episode_ids = self.get_episode_ids(show_id, season)
-        # Provider doesn't store multi episode information
-        episode = min(episode) if episode and isinstance(episode, list) else episode
-
         if episode not in episode_ids:
             logger.error('Episode %d not found', episode)
             return []

--- a/subliminal/video.py
+++ b/subliminal/video.py
@@ -169,7 +169,11 @@ class Episode(Video):
         if 'title' not in guess or 'episode' not in guess:
             raise ValueError('Insufficient data to process the guess')
 
-        return cls(name, guess['title'], guess.get('season', 1), guess['episode'], title=guess.get('episode_title'),
+        # guess can return a list of episodes, which we don't support for the moment -> return first (min) value instead
+        episode_guess = guess.get('episode')
+        episode = min(episode_guess) if episode_guess and isinstance(episode_guess, list) else episode_guess
+
+        return cls(name, guess['title'], guess.get('season', 1), episode, title=guess.get('episode_title'),
                    year=guess.get('year'), format=guess.get('format'), original_series='year' not in guess,
                    release_group=guess.get('release_group'), resolution=guess.get('screen_size'),
                    video_codec=guess.get('video_codec'), audio_codec=guess.get('audio_codec'))

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -125,13 +125,13 @@ def episodes():
                     resolution='1080p', format='WEB-DL', video_codec='h264', release_group='RARBG'),
             'Marvels.Agents.of.S.H.I.E.L.D.S05E01-E02':
             Episode('Marvels.Agents.of.S.H.I.E.L.D.S05E01-E02.720p.HDTV.x264-AVS', 'Marvels.Agents.of.S.H.I.E.L.D', 5,
-                    [1, 2], resolution='720p', format='HDTV', video_codec='h264', release_group='AVS'),
+                    1, resolution='720p', format='HDTV', video_codec='h264', release_group='AVS'),
             'the_end_of_the_fucking_world':
             Episode('the.end.of.the.fucking.world.s01e04.720p.web.x264-skgtv.mkv', 'The End of the Fucking World', 1, 4,
                     resolution='720p', format='WEB-DL', video_codec='h264', release_group='skgtv',
                     alternative_series=['The end of the f***ing world']),
             'the_gifted_S01E12E13':
-            Episode('The.Gifted.S01E12E13.eXtraction.and.X-roads.1080p.WEB-DL.h264-AJP69', 'The Gifted', 1, [12, 13],
+            Episode('The.Gifted.S01E12E13.eXtraction.and.X-roads.1080p.WEB-DL.h264-AJP69', 'The Gifted', 1, 12,
                     resolution='1080p', format='WEB-DL', video_codec='h265', release_group='AJP69'),
             }
 

--- a/tests/test_tvsubtitles.py
+++ b/tests/test_tvsubtitles.py
@@ -235,4 +235,4 @@ def test_multi_episode(episodes):
         matches = subtitles[0].get_matches(video)
     assert {subtitle.subtitle_id for subtitle in subtitles} == expected_subtitles
     # Assert episode not in matches
-    assert matches == {'series', 'format', 'year', 'season'}
+    assert matches == {'episode', 'series', 'format', 'year', 'season'}


### PR DESCRIPTION
Allowing the Video.episode to be a list causes more problems than it fixes.
In case guessit returns a list of episodes, we only take the first (lowest) episode.
Subtitle providers also do not support a list of episodes. A multi episode subitle will always be listed under the lowest episode number.

See discussion in https://github.com/Diaoul/subliminal/pull/859