### PR TITLE
Correctly enable the Napiprojekt provider

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -69,6 +69,7 @@ setup(name='subliminal',
           'subliminal.providers': [
               'addic7ed = subliminal.providers.addic7ed:Addic7edProvider',
               'legendastv = subliminal.providers.legendastv:LegendasTVProvider',
+              'napiprojekt = subliminal.providers.napiprojekt:NapiProjektProvider',
               'opensubtitles = subliminal.providers.opensubtitles:OpenSubtitlesProvider',
               'podnapisi = subliminal.providers.podnapisi:PodnapisiProvider',
               'shooter = subliminal.providers.shooter:ShooterProvider',

--- a/subliminal/extensions.py
+++ b/subliminal/extensions.py
@@ -90,6 +90,7 @@ class RegistrableExtensionManager(ExtensionManager):
 provider_manager = RegistrableExtensionManager('subliminal.providers', [
     'addic7ed = subliminal.providers.addic7ed:Addic7edProvider',
     'legendastv = subliminal.providers.legendastv:LegendasTVProvider',
+    'napiprojekt = subliminal.providers.napiprojekt:NapiProjektProvider',
     'opensubtitles = subliminal.providers.opensubtitles:OpenSubtitlesProvider',
     'podnapisi = subliminal.providers.podnapisi:PodnapisiProvider',
     'shooter = subliminal.providers.shooter:ShooterProvider',

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -9,8 +9,9 @@ def test_registrable_extension_manager_all_extensions():
         'de7cidda = subliminal.providers.addic7ed:Addic7edProvider'
     ])
     extensions = sorted(e.name for e in manager)
-    assert len(extensions) == 8
-    assert extensions == ['addic7ed', 'de7cidda', 'legendastv', 'opensubtitles', 'podnapisi', 'shooter', 'thesubdb',
+    assert len(extensions) == 9
+    assert extensions == ['addic7ed', 'de7cidda', 'legendastv', 'napiprojekt',
+                          'opensubtitles', 'podnapisi', 'shooter', 'thesubdb',
                           'tvsubtitles']
 
 


### PR DESCRIPTION
Previously the Napiprojekt provider wasn't available in the CLI. This commit adds it to `extensions.py`, so that it's possible to use it.