### PR TITLE
Use custom dogpile cache key generator

### DIFF
--- a/subliminal/cache.py
+++ b/subliminal/cache.py
@@ -15,19 +15,19 @@ EPISODE_EXPIRATION_TIME = datetime.timedelta(days=3).total_seconds()
 REFINER_EXPIRATION_TIME = datetime.timedelta(weeks=1).total_seconds()
 
 
-def _to_native_str(s):
+def _to_native_str(value):
     if six.PY2:
         # In Python 2, the native string type is bytes
-        if isinstance(s, six.text_type):  # unicode for Python 2
-            return s.encode('utf-8')
+        if isinstance(value, six.text_type):  # unicode for Python 2
+            return value.encode('utf-8')
         else:
-            return s
+            return six.binary_type(value)
     else:
         # In Python 3, the native string type is unicode
-        if isinstance(s, six.binary_type):  # bytes for Python 3
-            return s.decode('utf-8')
+        if isinstance(value, six.binary_type):  # bytes for Python 3
+            return value.decode('utf-8')
         else:
-            return s
+            return six.text_type(value)
 
 
 def _to_byte_str_key_generator(namespace, fn, to_str=_to_native_str):

--- a/subliminal/cache.py
+++ b/subliminal/cache.py
@@ -1,7 +1,9 @@
 # -*- coding: utf-8 -*-
 import datetime
 
+import six
 from dogpile.cache import make_region
+from dogpile.cache.util import function_key_generator
 
 #: Expiration time for show caching
 SHOW_EXPIRATION_TIME = datetime.timedelta(weeks=3).total_seconds()
@@ -13,4 +15,15 @@ EPISODE_EXPIRATION_TIME = datetime.timedelta(days=3).total_seconds()
 REFINER_EXPIRATION_TIME = datetime.timedelta(weeks=1).total_seconds()
 
 
-region = make_region()
+def _to_byte_str(value):
+    if isinstance(value, six.text_type):
+        return value.encode('utf-8')
+    else:
+        return six.binary_type(value)
+
+
+def _to_byte_str_key_generator(namespace, fn, to_str=_to_byte_str):
+    return function_key_generator(namespace, fn, to_str)
+
+
+region = make_region(function_key_generator=_to_byte_str_key_generator)

--- a/subliminal/cache.py
+++ b/subliminal/cache.py
@@ -30,7 +30,7 @@ def _to_native_str(s):
             return s
 
 
-def _to_byte_str_key_generator(namespace, fn, to_str=_to_native_str()):
+def _to_byte_str_key_generator(namespace, fn, to_str=_to_native_str):
     return function_key_generator(namespace, fn, to_str)
 
 

--- a/subliminal/cache.py
+++ b/subliminal/cache.py
@@ -30,8 +30,8 @@ def _to_native_str(value):
             return six.text_type(value)
 
 
-def _to_native_str_key_generator(namespace, fn, to_str=_to_native_str):
+def to_native_str_key_generator(namespace, fn, to_str=_to_native_str):
     return function_key_generator(namespace, fn, to_str)
 
 
-region = make_region(function_key_generator=_to_native_str_key_generator)
+region = make_region(function_key_generator=to_native_str_key_generator)

--- a/subliminal/cache.py
+++ b/subliminal/cache.py
@@ -15,14 +15,22 @@ EPISODE_EXPIRATION_TIME = datetime.timedelta(days=3).total_seconds()
 REFINER_EXPIRATION_TIME = datetime.timedelta(weeks=1).total_seconds()
 
 
-def _to_byte_str(value):
-    if isinstance(value, six.text_type):
-        return value.encode('utf-8')
+def _to_native_str(s):
+    if six.PY2:
+        # In Python 2, the native string type is bytes
+        if isinstance(s, six.text_type):  # unicode for Python 2
+            return s.encode('utf-8')
+        else:
+            return s
     else:
-        return six.binary_type(value)
+        # In Python 3, the native string type is unicode
+        if isinstance(s, six.binary_type):  # bytes for Python 3
+            return s.decode('utf-8')
+        else:
+            return s
 
 
-def _to_byte_str_key_generator(namespace, fn, to_str=_to_byte_str):
+def _to_byte_str_key_generator(namespace, fn, to_str=_to_native_str()):
     return function_key_generator(namespace, fn, to_str)
 
 

--- a/subliminal/cache.py
+++ b/subliminal/cache.py
@@ -30,8 +30,8 @@ def _to_native_str(value):
             return six.text_type(value)
 
 
-def _to_byte_str_key_generator(namespace, fn, to_str=_to_native_str):
+def _to_native_str_key_generator(namespace, fn, to_str=_to_native_str):
     return function_key_generator(namespace, fn, to_str)
 
 
-region = make_region(function_key_generator=_to_byte_str_key_generator)
+region = make_region(function_key_generator=_to_native_str_key_generator)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -9,6 +9,7 @@ try:
 except ImportError:
     from mock import Mock
 
+# A Mock version is already provided in conftest.py so no need to configure it again
 from subliminal.cache import region as region_custom
 
 # Configure default dogpile cache
@@ -19,14 +20,14 @@ region_dogpile.configure = Mock()
 unicode_string = u'The Simpsons-S12E09-HOMЯ'
 byte_string = b'The Simpsons-S12E09-HOM\xd0\xaf'
 namespace = 'namespace'
-expected_key = 'test_cache:fn|namespace|The Simpsons-S12E09-HOMЯ'  # native string
+expected_key = 'test_cache:fn|namespace|The Simpsons-S12E09-HOMЯ'  # Key is expected as native string
 
 
 def fn():
     pass
 
 
-def test_dogpile_cache_on_arguments_unicode_string():
+def test_dogpile_cache_key_generator_unicode_string():
     if six.PY2:
         with pytest.raises(UnicodeEncodeError):
             region_dogpile.function_key_generator(namespace, fn)(unicode_string)
@@ -36,18 +37,18 @@ def test_dogpile_cache_on_arguments_unicode_string():
         assert isinstance(key, six.text_type)  # In Python 3, the native string type is unicode
 
 
-def test_dogpile_cache_on_arguments_byte_string():
+def test_dogpile_cache_key_generator_byte_string():
     key = region_dogpile.function_key_generator(namespace, fn)(byte_string)
     if six.PY2:
         assert key == expected_key
         assert isinstance(key, six.binary_type)  # In Python 2, the native string type is bytes
     else:
         assert key == 'test_cache:fn|namespace|' + str(b'The Simpsons-S12E09-HOM\xd0\xaf')
-        assert key != expected_key  # key is not as expected
+        assert key != expected_key  # Key is not as expected
         assert isinstance(key, six.text_type)  # In Python 3, the native string type is unicode
 
 
-def test_custom_cache_on_arguments_unicode_string():
+def test_custom_cache_key_generator_unicode_string():
     key = region_custom.function_key_generator(namespace, fn)(unicode_string)
     assert key == expected_key
     if six.PY2:
@@ -56,7 +57,7 @@ def test_custom_cache_on_arguments_unicode_string():
         assert isinstance(key, six.text_type)  # In Python 3, the native string type is unicode
 
 
-def test_custom_cache_on_arguments_byte_string():
+def test_custom_cache_key_generator_byte_string():
     key = region_custom.function_key_generator(namespace, fn)(byte_string)
     assert key == expected_key
     if six.PY2:

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -23,8 +23,11 @@ def test_dogpile_cache_on_arguments_unicode_failure():
         search_default(u'The Simpsons-S12E09-HOMЯ')
 
 
-def test_dogpile_cache_on_arguments__unicode_to_native_str():
+def test_dogpile_cache_on_arguments_unicode_to_native_str():
     value = u'The Simpsons-S12E09-HOMЯ'
     search(value)
-    value_bytes = b'The Simpsons-S12E09-HOMЯ'
+
+
+def test_dogpile_cache_on_arguments_bytestring_to_native_str():
+    value_bytes = b'The Simpsons-S12E09-HOM\xd0\xaf'
     search(value_bytes)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,30 @@
+# coding=utf-8
+
+import pytest
+
+from dogpile.cache import make_region
+from subliminal.cache import region
+
+region_default = make_region()
+
+
+@region_default.cache_on_arguments()
+def search_default(value):
+    return value
+
+
+@region.cache_on_arguments()
+def search(value):
+    return value
+
+
+def test_dogpile_cache_on_arguments_unicode_failure():
+    with pytest.raises(UnicodeEncodeError):
+        search_default(u'The Simpsons-S12E09-HOMЯ')
+
+
+def test_dogpile_cache_on_arguments__unicode_to_native_str():
+    value = u'The Simpsons-S12E09-HOMЯ'
+    search(value)
+    value_bytes = b'The Simpsons-S12E09-HOMЯ'
+    search(value_bytes)


### PR DESCRIPTION
Dogpile cache cache only accepts ascii strings as values for the default key generator. Passing non ascii characters results in `UnicodeEncodeError`.
By creating a custom key generator we ensure that the value is converted to a valid native string.
On Python 2: unicode strings are converted to byte strings with utf-8 encoding.
On Python 3: byte strings are decoded with utf-8 encoding.
Fixes https://github.com/Diaoul/subliminal/issues/887 and also other `cache_on_arguments` calls where strings are passed with non ascii characters.