### PR TITLE
Update guessit to v3

### DIFF
--- a/docs/user/usage.rst
+++ b/docs/user/usage.rst
@@ -53,7 +53,7 @@ use :func:`~subliminal.core.scan_videos` on an existing directory path to scan a
 Here video information was guessed based on the name of the video, you can access some video attributes:
 
     >>> video.video_codec
-    'h264'
+    'H.264'
     >>> video.release_group
     'LOL'
 
@@ -95,8 +95,8 @@ them to the video and tell you exactly what matches with :meth:`~subliminal.subt
 
     >>> for s in subtitles[video]:
     ...     sorted(s.get_matches(video))
-    ['episode', 'format', 'release_group', 'season', 'series', 'video_codec', 'year']
-    ['episode', 'format', 'season', 'series', 'year']
+    ['episode', 'release_group', 'season', 'series', 'source', 'video_codec', 'year']
+    ['episode', 'season', 'series', 'source', 'year']
 
 And then compute a score with those matches with :func:`~subliminal.score.compute_score`:
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ def find_version(*file_paths):
 # requirements
 setup_requirements = ['pytest-runner'] if {'pytest', 'test', 'ptr'}.intersection(sys.argv) else []
 
-install_requirements = ['guessit>=2.0.1', 'babelfish>=0.5.2', 'enzyme>=0.4.1', 'beautifulsoup4>=4.4.0',
+install_requirements = ['guessit>=3.0.0', 'babelfish>=0.5.2', 'enzyme>=0.4.1', 'beautifulsoup4>=4.4.0',
                         'requests>=2.0', 'click>=4.0', 'dogpile.cache>=0.6.0', 'stevedore>=1.20.0',
                         'chardet>=2.3.0', 'pysrt>=1.0.1', 'six>=1.9.0', 'appdirs>=1.3', 'rarfile>=2.7',
                         'pytz>=2012c']

--- a/subliminal/providers/addic7ed.py
+++ b/subliminal/providers/addic7ed.py
@@ -72,9 +72,9 @@ class Addic7edSubtitle(Subtitle):
         # resolution
         if video.resolution and self.version and video.resolution in self.version.lower():
             matches.add('resolution')
-        # format
-        if video.format and self.version and video.format.lower() in self.version.lower():
-            matches.add('format')
+        # source
+        if video.source and self.version and video.source.lower() in self.version.lower():
+            matches.add('source')
         # other properties
         matches |= guess_matches(video, guessit(self.version), partial=True)
 

--- a/subliminal/refiners/metadata.py
+++ b/subliminal/refiners/metadata.py
@@ -45,13 +45,13 @@ def refine(video, embedded_subtitles=True, **kwargs):
 
             # video codec
             if video_track.codec_id == 'V_MPEG4/ISO/AVC':
-                video.video_codec = 'h264'
+                video.video_codec = 'H.264'
                 logger.debug('Found video_codec %s', video.video_codec)
             elif video_track.codec_id == 'V_MPEG4/ISO/SP':
                 video.video_codec = 'DivX'
                 logger.debug('Found video_codec %s', video.video_codec)
             elif video_track.codec_id == 'V_MPEG4/ISO/ASP':
-                video.video_codec = 'XviD'
+                video.video_codec = 'Xvid'
                 logger.debug('Found video_codec %s', video.video_codec)
         else:
             logger.warning('MKV has no video track')
@@ -61,7 +61,7 @@ def refine(video, embedded_subtitles=True, **kwargs):
             audio_track = mkv.audio_tracks[0]
             # audio codec
             if audio_track.codec_id == 'A_AC3':
-                video.audio_codec = 'AC3'
+                video.audio_codec = 'Dolby Digital'
                 logger.debug('Found audio_codec %s', video.audio_codec)
             elif audio_track.codec_id == 'A_DTS':
                 video.audio_codec = 'DTS'

--- a/subliminal/score.py
+++ b/subliminal/score.py
@@ -17,7 +17,7 @@ Available matches:
   * season
   * episode
   * release_group
-  * format
+  * source
   * audio_codec
   * resolution
   * hearing_impaired
@@ -37,11 +37,11 @@ logger = logging.getLogger(__name__)
 
 #: Scores for episodes
 episode_scores = {'hash': 359, 'series': 180, 'year': 90, 'season': 30, 'episode': 30, 'release_group': 15,
-                  'format': 7, 'audio_codec': 3, 'resolution': 2, 'video_codec': 2, 'hearing_impaired': 1}
+                  'source': 7, 'audio_codec': 3, 'resolution': 2, 'video_codec': 2, 'hearing_impaired': 1}
 
 #: Scores for movies
 movie_scores = {'hash': 119, 'title': 60, 'year': 30, 'release_group': 15,
-                'format': 7, 'audio_codec': 3, 'resolution': 2, 'video_codec': 2, 'hearing_impaired': 1}
+                'source': 7, 'audio_codec': 3, 'resolution': 2, 'video_codec': 2, 'hearing_impaired': 1}
 
 #: Equivalent release groups
 equivalent_release_groups = ({'LOL', 'DIMENSION'}, {'ASAP', 'IMMERSE', 'FLEET'}, {'AVS', 'SVA'})
@@ -152,30 +152,30 @@ def solve_episode_equations():
     from sympy import Eq, solve, symbols
 
     hash, series, year, season, episode, release_group = symbols('hash series year season episode release_group')
-    format, audio_codec, resolution, video_codec = symbols('format audio_codec resolution video_codec')
+    source, audio_codec, resolution, video_codec = symbols('source audio_codec resolution video_codec')
     hearing_impaired = symbols('hearing_impaired')
 
     equations = [
         # hash is best
-        Eq(hash, series + year + season + episode + release_group + format + audio_codec + resolution + video_codec),
+        Eq(hash, series + year + season + episode + release_group + source + audio_codec + resolution + video_codec),
 
         # series counts for the most part in the total score
-        Eq(series, year + season + episode + release_group + format + audio_codec + resolution + video_codec + 1),
+        Eq(series, year + season + episode + release_group + source + audio_codec + resolution + video_codec + 1),
 
         # year is the second most important part
-        Eq(year, season + episode + release_group + format + audio_codec + resolution + video_codec + 1),
+        Eq(year, season + episode + release_group + source + audio_codec + resolution + video_codec + 1),
 
         # season is important too
-        Eq(season, release_group + format + audio_codec + resolution + video_codec + 1),
+        Eq(season, release_group + source + audio_codec + resolution + video_codec + 1),
 
         # episode is equally important to season
         Eq(episode, season),
 
         # release group is the next most wanted match
-        Eq(release_group, format + audio_codec + resolution + video_codec + 1),
+        Eq(release_group, source + audio_codec + resolution + video_codec + 1),
 
-        # format counts as much as audio_codec, resolution and video_codec
-        Eq(format, audio_codec + resolution + video_codec),
+        # source counts as much as audio_codec, resolution and video_codec
+        Eq(source, audio_codec + resolution + video_codec),
 
         # audio_codec is more valuable than video_codec
         Eq(audio_codec, video_codec + 1),
@@ -190,7 +190,7 @@ def solve_episode_equations():
         Eq(hearing_impaired, 1),
     ]
 
-    return solve(equations, [hash, series, year, season, episode, release_group, format, audio_codec, resolution,
+    return solve(equations, [hash, series, year, season, episode, release_group, source, audio_codec, resolution,
                              hearing_impaired, video_codec])
 
 
@@ -198,24 +198,24 @@ def solve_movie_equations():
     from sympy import Eq, solve, symbols
 
     hash, title, year, release_group = symbols('hash title year release_group')
-    format, audio_codec, resolution, video_codec = symbols('format audio_codec resolution video_codec')
+    source, audio_codec, resolution, video_codec = symbols('source audio_codec resolution video_codec')
     hearing_impaired = symbols('hearing_impaired')
 
     equations = [
         # hash is best
-        Eq(hash, title + year + release_group + format + audio_codec + resolution + video_codec),
+        Eq(hash, title + year + release_group + source + audio_codec + resolution + video_codec),
 
         # title counts for the most part in the total score
-        Eq(title, year + release_group + format + audio_codec + resolution + video_codec + 1),
+        Eq(title, year + release_group + source + audio_codec + resolution + video_codec + 1),
 
         # year is the second most important part
-        Eq(year, release_group + format + audio_codec + resolution + video_codec + 1),
+        Eq(year, release_group + source + audio_codec + resolution + video_codec + 1),
 
         # release group is the next most wanted match
-        Eq(release_group, format + audio_codec + resolution + video_codec + 1),
+        Eq(release_group, source + audio_codec + resolution + video_codec + 1),
 
-        # format counts as much as audio_codec, resolution and video_codec
-        Eq(format, audio_codec + resolution + video_codec),
+        # source counts as much as audio_codec, resolution and video_codec
+        Eq(source, audio_codec + resolution + video_codec),
 
         # audio_codec is more valuable than video_codec
         Eq(audio_codec, video_codec + 1),
@@ -230,5 +230,5 @@ def solve_movie_equations():
         Eq(hearing_impaired, 1),
     ]
 
-    return solve(equations, [hash, title, year, release_group, format, audio_codec, resolution, hearing_impaired,
+    return solve(equations, [hash, title, year, release_group, source, audio_codec, resolution, hearing_impaired,
                              video_codec])

--- a/subliminal/subtitle.py
+++ b/subliminal/subtitle.py
@@ -10,6 +10,7 @@ from .score import get_equivalent_release_groups
 from .video import Episode, Movie
 from .utils import sanitize, sanitize_release_group
 
+from six import text_type
 
 logger = logging.getLogger(__name__)
 
@@ -70,10 +71,12 @@ class Subtitle(object):
         if not self.content:
             return
 
-        if self.encoding:
-            return self.content.decode(self.encoding, errors='replace')
+        if not isinstance(self.content, text_type):
+            if self.encoding:
+                return self.content.decode(self.encoding, errors='replace')
+            return self.content.decode(self.guess_encoding(), errors='replace')
 
-        return self.content.decode(self.guess_encoding(), errors='replace')
+        return self.content
 
     def is_valid(self):
         """Check if a :attr:`text` is a valid SubRip format.

--- a/subliminal/subtitle.py
+++ b/subliminal/subtitle.py
@@ -237,9 +237,9 @@ def guess_matches(video, guess, partial=False):
     # resolution
     if video.resolution and 'screen_size' in guess and guess['screen_size'] == video.resolution:
         matches.add('resolution')
-    # format
-    if video.format and 'format' in guess and guess['format'].lower() == video.format.lower():
-        matches.add('format')
+    # source
+    if video.source and 'source' in guess and guess['source'].lower() == video.source.lower():
+        matches.add('source')
     # video_codec
     if video.video_codec and 'video_codec' in guess and guess['video_codec'] == video.video_codec:
         matches.add('video_codec')

--- a/subliminal/video.py
+++ b/subliminal/video.py
@@ -24,7 +24,7 @@ class Video(object):
     Represent a video, existing or not.
 
     :param str name: name or path of the video.
-    :param str format: format of the video (HDTV, WEB-DL, BluRay, ...).
+    :param str source: source of the video (HDTV, Web, Blu-ray, ...).
     :param str release_group: release group of the video.
     :param str resolution: resolution of the video stream (480p, 720p, 1080p or 1080i).
     :param str video_codec: codec of the video stream.
@@ -35,13 +35,13 @@ class Video(object):
     :param set subtitle_languages: existing subtitle languages.
 
     """
-    def __init__(self, name, format=None, release_group=None, resolution=None, video_codec=None, audio_codec=None,
+    def __init__(self, name, source=None, release_group=None, resolution=None, video_codec=None, audio_codec=None,
                  imdb_id=None, hashes=None, size=None, subtitle_languages=None):
         #: Name or path of the video
         self.name = name
 
-        #: Format of the video (HDTV, WEB-DL, BluRay, ...)
-        self.format = format
+        #: Source of the video (HDTV, Web, Blu-ray, ...)
+        self.source = source
 
         #: Release group of the video
         self.release_group = release_group
@@ -176,7 +176,7 @@ class Episode(Video):
         episode = min(episode_guess) if episode_guess and isinstance(episode_guess, list) else episode_guess
 
         return cls(name, guess['title'], guess.get('season', 1), episode, title=guess.get('episode_title'),
-                   year=guess.get('year'), format=guess.get('format'), original_series='year' not in guess,
+                   year=guess.get('year'), source=guess.get('source'), original_series='year' not in guess,
                    release_group=guess.get('release_group'), resolution=guess.get('screen_size'),
                    video_codec=guess.get('video_codec'), audio_codec=guess.get('audio_codec'))
 
@@ -220,7 +220,7 @@ class Movie(Video):
         if 'title' not in guess:
             raise ValueError('Insufficient data to process the guess')
 
-        return cls(name, guess['title'], format=guess.get('format'), release_group=guess.get('release_group'),
+        return cls(name, guess['title'], source=guess.get('source'), release_group=guess.get('release_group'),
                    resolution=guess.get('screen_size'), video_codec=guess.get('video_codec'),
                    audio_codec=guess.get('audio_codec'), year=guess.get('year'))
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,7 +24,7 @@ def configure_region():
 def movies():
     return {'man_of_steel':
             Movie(os.path.join('Man of Steel (2013)', 'man.of.steel.2013.720p.bluray.x264-felony.mkv'), 'Man of Steel',
-                  format='BluRay', release_group='felony', resolution='720p', video_codec='h264', audio_codec='DTS',
+                  source='Blu-ray', release_group='felony', resolution='720p', video_codec='H.264', audio_codec='DTS',
                   imdb_id='tt0770828', size=7033732714, year=2013,
                   hashes={'napiprojekt': '6303e7ee6a835e9fcede9fb2fb00cb36',
                           'opensubtitles': '5b8f8f4e41ccb21e',
@@ -33,12 +33,12 @@ def movies():
                           'thesubdb': 'ad32876133355929d814457537e12dc2'}),
             'enders_game':
             Movie('enders.game.2013.720p.bluray.x264-sparks.mkv', 'Ender\'s Game',
-                  format='BluRay', release_group='sparks', resolution='720p', video_codec='h264', year=2013),
+                  source='Blu-ray', release_group='sparks', resolution='720p', video_codec='H.264', year=2013),
             'café_society':
             Movie(u'Café Society.1080p.avc1.RARBG.mp4', u'Café Society', year=2016),
             'interstellar':
             Movie('Interstellar.2014.2014.1080p.BluRay.x264.YIFY.rar', 'Interstellar',
-                  format='BluRay', release_group='YIFY', resolution='1080p', video_codec='h264', year=2014)}
+                  source='Blu-ray', release_group='YIFY', resolution='1080p', video_codec='H.264', year=2014)}
 
 
 @pytest.fixture
@@ -47,8 +47,9 @@ def episodes():
             Episode(os.path.join('The Big Bang Theory', 'Season 07',
                                  'The.Big.Bang.Theory.S07E05.720p.HDTV.X264-DIMENSION.mkv'),
                     'The Big Bang Theory', 7, 5, title='The Workplace Proximity', year=2007, tvdb_id=4668379,
-                    series_tvdb_id=80379, series_imdb_id='tt0898266', format='HDTV', release_group='DIMENSION',
-                    resolution='720p', video_codec='h264', audio_codec='AC3', imdb_id='tt3229392', size=501910737,
+                    series_tvdb_id=80379, series_imdb_id='tt0898266', source='HDTV', release_group='DIMENSION',
+                    resolution='720p', video_codec='H.264', audio_codec='Dolby Digital',
+                    imdb_id='tt3229392', size=501910737,
                     hashes={'napiprojekt': '6303e7ee6a835e9fcede9fb2fb00cb36',
                             'opensubtitles': '6878b3ef7c1bd19e',
                             'shooter': 'c13e0e5243c56d280064d344676fff94;cd4184d1c0c623735f6db90841ce15fc;'
@@ -58,8 +59,8 @@ def episodes():
             Episode(os.path.join('Game of Thrones', 'Season 03',
                                  'Game.of.Thrones.S03E10.Mhysa.720p.WEB-DL.DD5.1.H.264-NTb.mkv'),
                     'Game of Thrones', 3, 10, title='Mhysa', tvdb_id=4517466, series_tvdb_id=121361,
-                    series_imdb_id='tt0944947', format='WEB-DL', release_group='NTb', resolution='720p',
-                    video_codec='h264', audio_codec='AC3', imdb_id='tt2178796', size=2142810931,
+                    series_imdb_id='tt0944947', source='Web', release_group='NTb', resolution='720p',
+                    video_codec='H.264', audio_codec='Dolby Digital', imdb_id='tt2178796', size=2142810931,
                     hashes={'napiprojekt': '6303e7ee6a835e9fcede9fb2fb00cb36',
                             'opensubtitles': 'b850baa096976c22',
                             'shooter': 'b02d992c04ad74b31c252bd5a097a036;ef1b32f873b2acf8f166fc266bdf011a;'
@@ -74,62 +75,62 @@ def episodes():
                     imdb_id='tt2205526'),
             'marvels_agents_of_shield_s02e06':
             Episode('Marvels.Agents.of.S.H.I.E.L.D.S02E06.720p.HDTV.x264-KILLERS.mkv',
-                    'Marvel\'s Agents of S.H.I.E.L.D.', 2, 6, year=2013, format='HDTV', release_group='KILLERS',
-                    resolution='720p', video_codec='h264'),
+                    'Marvel\'s Agents of S.H.I.E.L.D.', 2, 6, year=2013, source='HDTV', release_group='KILLERS',
+                    resolution='720p', video_codec='H.264'),
             'csi_cyber_s02e03':
-            Episode('CSI.Cyber.S02E03.hdtv-lol.mp4', 'CSI: Cyber', 2, 3, format='HDTV', release_group='lol'),
+            Episode('CSI.Cyber.S02E03.hdtv-lol.mp4', 'CSI: Cyber', 2, 3, source='HDTV', release_group='lol'),
             'the_x_files_s10e02':
-            Episode('The.X-Files.S10E02.HDTV.x264-KILLERS.mp4', 'The X-Files', 10, 2, format='HDTV',
-                    release_group='KILLERS', video_codec='h264'),
+            Episode('The.X-Files.S10E02.HDTV.x264-KILLERS.mp4', 'The X-Files', 10, 2, source='HDTV',
+                    release_group='KILLERS', video_codec='H.264'),
             'colony_s01e09':
             Episode('Colony.S01E09.720p.HDTV.x264-KILLERS.mkv', 'Colony', 1, 9, title='Zero Day', year=2016,
-                    tvdb_id=5463229, series_tvdb_id=284210, series_imdb_id='tt4209256', format='HDTV',
-                    release_group='KILLERS', resolution='720p', video_codec='h264', imdb_id='tt4926022'),
+                    tvdb_id=5463229, series_tvdb_id=284210, series_imdb_id='tt4209256', source='HDTV',
+                    release_group='KILLERS', resolution='720p', video_codec='H.264', imdb_id='tt4926022'),
             'the_jinx_e05':
             Episode('The.Jinx-The.Life.and.Deaths.of.Robert.Durst.E05.BDRip.x264-ROVERS.mkv',
                     'The Jinx: The Life and Deaths of Robert Durst', 1, 5, year=2015, original_series=True,
-                    format='BluRay', release_group='ROVERS', video_codec='h264'),
+                    source='Blu-ray', release_group='ROVERS', video_codec='H.264'),
             'the_100_s03e09':
             Episode('The.100.S03E09.720p.HDTV.x264-AVS.mkv', 'The 100', 3, 9, title='Stealing Fire', year=2014,
-                    tvdb_id=5544536, series_tvdb_id=268592, series_imdb_id='tt2661044', format='HDTV',
-                    release_group='AVS', resolution='720p', video_codec='h264', imdb_id='tt4799896'),
+                    tvdb_id=5544536, series_tvdb_id=268592, series_imdb_id='tt2661044', source='HDTV',
+                    release_group='AVS', resolution='720p', video_codec='H.264', imdb_id='tt4799896'),
             'the fall':
             Episode('the_fall.3x01.720p_hdtv_x264-fov.mkv', 'The Fall', 3, 1, title='The Fall', year=2013,
-                    tvdb_id=5749493, series_tvdb_id=258107, series_imdb_id='tt2294189', format='HDTV',
-                    release_group='fov', resolution='720p', video_codec='h264', imdb_id='tt4516230'),
+                    tvdb_id=5749493, series_tvdb_id=258107, series_imdb_id='tt2294189', source='HDTV',
+                    release_group='fov', resolution='720p', video_codec='H.264', imdb_id='tt4516230'),
             'csi_s15e18':
             Episode('CSI.S15E18.720p.HDTV.X264.DIMENSION.mkv', 'CSI: Crime Scene Investigation', 15, 18,
                     title='The End Game', year=2000, tvdb_id=5104359, series_tvdb_id=72546, series_imdb_id='tt0247082',
-                    format='HDTV', release_group='DIMENSION', resolution='720p', video_codec='h264',
+                    source='HDTV', release_group='DIMENSION', resolution='720p', video_codec='H.264',
                     imdb_id='tt4145952'),
             'turn_s04e03':
             Episode('Turn.S04E03.720p.HDTV.x264-AVS.mkv', "TURN: Washington's Spies", 4, 3,
                     title='Blood for Blood', year=2014, tvdb_id=6124360, series_tvdb_id=272135,
                     series_imdb_id='tt2543328',
-                    format='HDTV', release_group='AVS', resolution='720p', video_codec='h264',
+                    source='HDTV', release_group='AVS', resolution='720p', video_codec='H.264',
                     imdb_id='tt6137686', alternative_series=['Turn']),
             'turn_s03e01':
             Episode('Turn.S03E01.720p.HDTV.x264-AVS.mkv', "TURN: Washington's Spies", 3, 1,
                     title='Valediction', year=2014, tvdb_id=5471384, series_tvdb_id=272135,
                     series_imdb_id='tt2543328',
-                    format='HDTV', release_group='AVS', resolution='720p', video_codec='h264',
+                    source='HDTV', release_group='AVS', resolution='720p', video_codec='H.264',
                     imdb_id='tt4909774', alternative_series=['Turn']),
             'marvels_jessica_jones_s01e13':
             Episode('Marvels.Jessica.Jones.S01E13.720p.WEBRip.x264-2HD', "Marvels Jessica Jones", 1, 13,
                     title='AKA Smile', year=2015, tvdb_id=5311273, series_tvdb_id=284190,
                     series_imdb_id='tt2357547',
-                    format='WEBRip', release_group='2HD', resolution='720p', video_codec='h264',
+                    source='Web', release_group='2HD', resolution='720p', video_codec='H.264',
                     imdb_id='tt4162096', alternative_series=['Jessica Jones']),
             'fear_walking_dead_s03e10':
             Episode('Fear.the.Walking.Dead.S03E10.1080p.WEB-DL.DD5.1.H264-RARBG', 'Fear the Walking Dead', 3, 10,
-                    resolution='1080p', format='WEB-DL', video_codec='h264', release_group='RARBG'),
+                    resolution='1080p', source='Web', video_codec='H.264', release_group='RARBG'),
             'the_end_of_the_fucking_world':
             Episode('the.end.of.the.fucking.world.s01e04.720p.web.x264-skgtv.mkv', 'The End of the Fucking World', 1, 4,
-                    resolution='720p', format='WEB-DL', video_codec='h264', release_group='skgtv',
+                    resolution='720p', source='Web', video_codec='H.264', release_group='skgtv',
                     alternative_series=['The end of the f***ing world']),
             'Marvels.Agents.of.S.H.I.E.L.D.S05E01-E02':
             Episode('Marvels.Agents.of.S.H.I.E.L.D.S05E01-E02.720p.HDTV.x264-AVS', 'Marvels.Agents.of.S.H.I.E.L.D', 5,
-                    1, resolution='720p', format='HDTV', video_codec='h264', release_group='AVS')}
+                    1, resolution='720p', source='HDTV', video_codec='H.264', release_group='AVS')}
 
 
 @pytest.fixture(scope='session')

--- a/tests/test_addic7ed.py
+++ b/tests/test_addic7ed.py
@@ -73,11 +73,11 @@ def test_get_matches_resolution_release_group(episodes):
     assert matches == {'series', 'season', 'episode', 'title', 'year', 'release_group', 'resolution'}
 
 
-def test_get_matches_format_release_group(episodes):
+def test_get_matches_source_release_group(episodes):
     subtitle = Addic7edSubtitle(Language('eng'), True, None, 'Game of Thrones', 3, 10, 'Mhysa', None, 'WEB-DL-NTb',
                                 None)
     matches = subtitle.get_matches(episodes['got_s03e10'])
-    assert matches == {'series', 'season', 'episode', 'title', 'year', 'release_group', 'format'}
+    assert matches == {'series', 'season', 'episode', 'title', 'year', 'release_group', 'source'}
 
 
 def test_get_matches_no_match(episodes):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -197,7 +197,7 @@ def test_scan_video_movie(movies, tmpdir, monkeypatch):
     tmpdir.ensure(video.name)
     scanned_video = scan_video(video.name)
     assert scanned_video.name == video.name
-    assert scanned_video.format == video.format
+    assert scanned_video.source == video.source
     assert scanned_video.release_group == video.release_group
     assert scanned_video.resolution == video.resolution
     assert scanned_video.video_codec == video.video_codec
@@ -216,7 +216,7 @@ def test_scan_video_episode(episodes, tmpdir, monkeypatch):
     tmpdir.ensure(video.name)
     scanned_video = scan_video(video.name)
     assert scanned_video.name, video.name
-    assert scanned_video.format == video.format
+    assert scanned_video.source == video.source
     assert scanned_video.release_group == video.release_group
     assert scanned_video.resolution == video.resolution
     assert scanned_video.video_codec == video.video_codec
@@ -238,10 +238,10 @@ def test_refine_video_metadata(mkv):
     refine(scanned_video, episode_refiners=('metadata',), movie_refiners=('metadata',))
     assert type(scanned_video) is Movie
     assert scanned_video.name == mkv['test5']
-    assert scanned_video.format is None
+    assert scanned_video.source is None
     assert scanned_video.release_group is None
     assert scanned_video.resolution is None
-    assert scanned_video.video_codec == 'h264'
+    assert scanned_video.video_codec == 'H.264'
     assert scanned_video.audio_codec == 'AAC'
     assert scanned_video.imdb_id is None
     assert scanned_video.hashes == {
@@ -281,7 +281,7 @@ def test_scan_video_broken(mkv, tmpdir, monkeypatch):
     scanned_video = scan_video(broken_path)
     assert type(scanned_video) is Movie
     assert scanned_video.name == str(broken_path)
-    assert scanned_video.format is None
+    assert scanned_video.source is None
     assert scanned_video.release_group is None
     assert scanned_video.resolution is None
     assert scanned_video.video_codec is None
@@ -305,7 +305,7 @@ def test_scan_archive(movies, tmpdir, monkeypatch):
     scanned_video = scan_archive(str(enders_game))
     assert type(scanned_video) is Movie
     assert scanned_video.name == os.path.join(str(tmpdir), video.name)
-    assert scanned_video.format == video.format
+    assert scanned_video.source == video.source
     assert scanned_video.release_group == video.release_group
     assert scanned_video.resolution == video.resolution
     assert scanned_video.video_codec == video.video_codec

--- a/tests/test_legendastv.py
+++ b/tests/test_legendastv.py
@@ -79,7 +79,7 @@ def test_get_matches(episodes):
                                   archive, 'TBBT S07 x264/The.Big.Bang.Theory.S07E05.HDTV.x264-LOL.srt')
 
     matches = subtitle.get_matches(episodes['bbt_s07e05'])
-    assert matches == {'series', 'year', 'season', 'episode', 'release_group', 'format', 'video_codec',
+    assert matches == {'series', 'year', 'season', 'episode', 'release_group', 'source', 'video_codec',
                        'series_imdb_id'}
 
 

--- a/tests/test_opensubtitles.py
+++ b/tests/test_opensubtitles.py
@@ -21,7 +21,7 @@ def test_get_matches_movie_hash(movies):
                                      'Man.of.Steel.German.720p.BluRay.x264-EXQUiSiTE', 2013, 'tt0770828', 0, 0,
                                      'Man.of.Steel.German.720p.BluRay.x264-EXQUiSiTE.srt', None)
     matches = subtitle.get_matches(movies['man_of_steel'])
-    assert matches == {'title', 'year', 'video_codec', 'imdb_id', 'hash', 'resolution', 'format'}
+    assert matches == {'title', 'year', 'video_codec', 'imdb_id', 'hash', 'resolution', 'source'}
 
 
 def test_get_matches_episode(episodes):
@@ -48,7 +48,7 @@ def test_get_matches_episode_filename(episodes):
                                      'HDTV.x264-KILLERS-mSD-AFG-EVO-KILLERS', 2014, 'tt4078580', 2, 6,
                                      'Marvels.Agents.of.S.H.I.E.L.D.S02E06.720p.HDTV.x264-KILLERS.srt', 'cp1252')
     matches = subtitle.get_matches(episodes['marvels_agents_of_shield_s02e06'])
-    assert matches == {'series', 'year', 'season', 'episode', 'release_group', 'format', 'resolution', 'video_codec'}
+    assert matches == {'series', 'year', 'season', 'episode', 'release_group', 'source', 'resolution', 'video_codec'}
 
 
 def test_get_matches_episode_tag(episodes):
@@ -57,7 +57,7 @@ def test_get_matches_episode_tag(episodes):
                                      'HDTV.x264-KILLERS-mSD-AFG-EVO-KILLERS', 2014, 'tt4078580', 2, 6,
                                      '', 'cp1252')
     matches = subtitle.get_matches(episodes['marvels_agents_of_shield_s02e06'])
-    assert matches == {'series', 'year', 'season', 'episode', 'format', 'video_codec'}
+    assert matches == {'series', 'year', 'season', 'episode', 'source', 'video_codec'}
 
 
 def test_get_matches_imdb_id(movies):
@@ -65,7 +65,7 @@ def test_get_matches_imdb_id(movies):
                                      'man.of.steel.2013.720p.bluray.x264-felony', 2013, 'tt0770828', 0, 0,
                                      'man.of.steel.2013.720p.bluray.x264-felony.srt', None)
     matches = subtitle.get_matches(movies['man_of_steel'])
-    assert matches == {'title', 'year', 'video_codec', 'imdb_id', 'resolution', 'format', 'release_group'}
+    assert matches == {'title', 'year', 'video_codec', 'imdb_id', 'resolution', 'source', 'release_group'}
 
 
 def test_get_matches_no_match(episodes):

--- a/tests/test_podnapisi.py
+++ b/tests/test_podnapisi.py
@@ -30,7 +30,7 @@ def test_get_matches_movie(movies):
     subtitle = PodnapisiSubtitle(Language('eng'), True, None, 'EMgo', subtitle_releases, 'Man of Steel', None, None,
                                  2013)
     matches = subtitle.get_matches(movies['man_of_steel'])
-    assert matches == {'title', 'year', 'video_codec', 'resolution', 'format', 'release_group'}
+    assert matches == {'title', 'year', 'video_codec', 'resolution', 'source', 'release_group'}
 
 
 def test_get_matches_episode(episodes):
@@ -41,7 +41,7 @@ def test_get_matches_episode(episodes):
     subtitle = PodnapisiSubtitle(Language('eng'), False, None, 'EdQo', subtitle_releases, 'The Big Bang Theory', 7, 5,
                                  2007)
     matches = subtitle.get_matches(episodes['bbt_s07e05'])
-    assert matches == {'series', 'season', 'episode', 'video_codec', 'resolution', 'format', 'release_group', 'year'}
+    assert matches == {'series', 'season', 'episode', 'video_codec', 'resolution', 'source', 'release_group', 'year'}
 
 
 def test_get_matches_episode_year(episodes):

--- a/tests/test_score.py
+++ b/tests/test_score.py
@@ -45,7 +45,7 @@ def test_compute_score_episode_imdb_id(movies):
                                      'Man of Steel', 'man.of.steel.2013.720p.bluray.x264-felony.mkv', 2013, 770828,
                                      None, None, '', 'utf-8')
     assert compute_score(subtitle, video) == sum(movie_scores.get(m, 0) for m in
-                                                 ('imdb_id', 'title', 'year', 'release_group', 'format', 'resolution',
+                                                 ('imdb_id', 'title', 'year', 'release_group', 'source', 'resolution',
                                                   'video_codec'))
 
 
@@ -55,7 +55,7 @@ def test_compute_score_episode_title(episodes):
                                  ['The.Big.Bang.Theory.S07E05.The.Workplace.Proximity.720p.HDTV.x264-DIMENSION.mkv'],
                                  None, 7, 5, None)
     assert compute_score(subtitle, video) == sum(episode_scores.get(m, 0) for m in
-                                                 ('series', 'year', 'season', 'episode', 'release_group', 'format',
+                                                 ('series', 'year', 'season', 'episode', 'release_group', 'source',
                                                   'resolution', 'video_codec', 'title'))
 
 

--- a/tests/test_subtitle.py
+++ b/tests/test_subtitle.py
@@ -72,9 +72,9 @@ def test_get_subtitle_path_language_undefined(movies):
 def test_guess_matches_movie(movies):
     video = movies['man_of_steel']
     guess = {'title': video.title.upper(), 'year': video.year, 'release_group': video.release_group.upper(),
-             'screen_size': video.resolution, 'format': video.format.upper(), 'video_codec': video.video_codec,
+             'screen_size': video.resolution, 'source': video.source.upper(), 'video_codec': video.video_codec,
              'audio_codec': video.audio_codec}
-    expected = {'title', 'year', 'release_group', 'resolution', 'format', 'video_codec', 'audio_codec'}
+    expected = {'title', 'year', 'release_group', 'resolution', 'source', 'video_codec', 'audio_codec'}
     assert guess_matches(video, guess) == expected
 
 
@@ -82,9 +82,9 @@ def test_guess_matches_episode(episodes):
     video = episodes['bbt_s07e05']
     guess = {'title': video.series, 'season': video.season, 'episode': video.episode, 'year': video.year,
              'episode_title': video.title.upper(), 'release_group': video.release_group.upper(),
-             'screen_size': video.resolution, 'format': video.format.upper(), 'video_codec': video.video_codec,
+             'screen_size': video.resolution, 'source': video.source.upper(), 'video_codec': video.video_codec,
              'audio_codec': video.audio_codec}
-    expected = {'series', 'season', 'episode', 'title', 'year', 'release_group', 'resolution', 'format', 'video_codec',
+    expected = {'series', 'season', 'episode', 'title', 'year', 'release_group', 'resolution', 'source', 'video_codec',
                 'audio_codec'}
     assert guess_matches(video, guess) == expected
 
@@ -93,9 +93,9 @@ def test_guess_matches_episode_equivalent_release_group(episodes):
     video = episodes['bbt_s07e05']
     guess = {'title': video.series, 'season': video.season, 'episode': video.episode, 'year': video.year,
              'episode_title': video.title.upper(), 'release_group': 'LOL',
-             'screen_size': video.resolution, 'format': video.format.upper(), 'video_codec': video.video_codec,
+             'screen_size': video.resolution, 'source': video.source.upper(), 'video_codec': video.video_codec,
              'audio_codec': video.audio_codec}
-    expected = {'series', 'season', 'episode', 'title', 'year', 'release_group', 'resolution', 'format', 'video_codec',
+    expected = {'series', 'season', 'episode', 'title', 'year', 'release_group', 'resolution', 'source', 'video_codec',
                 'audio_codec'}
     assert guess_matches(video, guess) == expected
 

--- a/tests/test_tvsubtitles.py
+++ b/tests/test_tvsubtitles.py
@@ -43,14 +43,14 @@ def test_get_matches_format_release_group(episodes):
     subtitle = TVsubtitlesSubtitle(Language('fra'), None, 249518, 'The Big Bang Theory', 7, 5, 2007, 'HDTV',
                                    'lol-dimension')
     matches = subtitle.get_matches(episodes['bbt_s07e05'])
-    assert matches == {'series', 'season', 'episode', 'year', 'format', 'release_group'}
+    assert matches == {'series', 'season', 'episode', 'year', 'source', 'release_group'}
 
 
 def test_get_matches_format_equivalent_release_group(episodes):
     subtitle = TVsubtitlesSubtitle(Language('fra'), None, 249518, 'The Big Bang Theory', 7, 5, 2007, 'HDTV',
                                    'lol')
     matches = subtitle.get_matches(episodes['bbt_s07e05'])
-    assert matches == {'series', 'season', 'episode', 'year', 'format', 'release_group'}
+    assert matches == {'series', 'season', 'episode', 'year', 'source', 'release_group'}
 
 
 def test_get_matches_video_codec_resolution(episodes):

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -49,7 +49,7 @@ def test_video_fromname_movie(movies):
     video = Video.fromname(movies['man_of_steel'].name)
     assert type(video) is Movie
     assert video.name == movies['man_of_steel'].name
-    assert video.format == movies['man_of_steel'].format
+    assert video.source == movies['man_of_steel'].source
     assert video.release_group == movies['man_of_steel'].release_group
     assert video.resolution == movies['man_of_steel'].resolution
     assert video.video_codec == movies['man_of_steel'].video_codec
@@ -66,7 +66,7 @@ def test_video_fromname_episode(episodes):
     video = Video.fromname(episodes['bbt_s07e05'].name)
     assert type(video) is Episode
     assert video.name == episodes['bbt_s07e05'].name
-    assert video.format == episodes['bbt_s07e05'].format
+    assert video.source == episodes['bbt_s07e05'].source
     assert video.release_group == episodes['bbt_s07e05'].release_group
     assert video.resolution == episodes['bbt_s07e05'].resolution
     assert video.video_codec == episodes['bbt_s07e05'].video_codec
@@ -87,7 +87,7 @@ def test_video_fromname_episode_no_season(episodes):
     video = Video.fromname(episodes['the_jinx_e05'].name)
     assert type(video) is Episode
     assert video.name == episodes['the_jinx_e05'].name
-    assert video.format == episodes['the_jinx_e05'].format
+    assert video.source == episodes['the_jinx_e05'].source
     assert video.release_group == episodes['the_jinx_e05'].release_group
     assert video.resolution == episodes['the_jinx_e05'].resolution
     assert video.video_codec == episodes['the_jinx_e05'].video_codec
@@ -146,7 +146,7 @@ def test_movie_fromguess_insufficient_data(movies):
 def test_movie_fromname(movies):
     video = Movie.fromname(movies['man_of_steel'].name)
     assert video.name == movies['man_of_steel'].name
-    assert video.format == movies['man_of_steel'].format
+    assert video.source == movies['man_of_steel'].source
     assert video.release_group == movies['man_of_steel'].release_group
     assert video.resolution == movies['man_of_steel'].resolution
     assert video.video_codec == movies['man_of_steel'].video_codec
@@ -162,7 +162,7 @@ def test_movie_fromname(movies):
 def test_episode_fromname(episodes):
     video = Episode.fromname(episodes['bbt_s07e05'].name)
     assert video.name == episodes['bbt_s07e05'].name
-    assert video.format == episodes['bbt_s07e05'].format
+    assert video.source == episodes['bbt_s07e05'].source
     assert video.release_group == episodes['bbt_s07e05'].release_group
     assert video.resolution == episodes['bbt_s07e05'].resolution
     assert video.video_codec == episodes['bbt_s07e05'].video_codec


### PR DESCRIPTION
Changes:
- format -> source
- Update video_codec values
- Update audio_codec values
- BluRay -> Blu-ray
- Update guessit version requirement
- WEB-DL -> Web
- WEBRip -> Web
- Fix usage.rst test
- PEP8

We have been using this version with [Medusa](https://github.com/pymedusa/Medusa) for quite some time now.