### PR TITLE
Fixes #739

### DIFF
--- a/subliminal/cli.py
+++ b/subliminal/cli.py
@@ -490,7 +490,7 @@ def download(obj, provider, refiner, language, age, directory, encoding, single,
                     language=s.language.name if s.language.country is None else '%s (%s)' % (s.language.name,
                                                                                              s.language.country.name),
                     provider_name=s.provider_name,
-                    matches=', '.join(sorted(matches, key=scores.get, reverse=True))
+                    matches=', '.join(sorted(matches, key=lambda m: scores.get(m, 0), reverse=True))
                 ))
 
     if verbose == 0:


### PR DESCRIPTION
There is no imdb_id nor tvdb_id (or their series_ version) in the scores dictionary, so calling scores.get returns None.