### PR TITLE
Fix (rename) file using release name

### DIFF
--- a/subliminal/cli.py
+++ b/subliminal/cli.py
@@ -320,10 +320,12 @@ def cache(ctx, clear_subliminal):
 @click.option('-z/-Z', '--archives/--no-archives', default=True, show_default=True, help='Scan archives for videos '
               '(supported extensions: %s).' % ', '.join(ARCHIVE_EXTENSIONS))
 @click.option('-v', '--verbose', count=True, help='Increase verbosity.')
+@click.option('-ff', '--fix-filename', is_flag=True, default=False, help='Fix video file name according to the release '
+              'name of the subtitle. Works only if the provider allows searching by file hash and has release names.')
 @click.argument('path', type=click.Path(), required=True, nargs=-1)
 @click.pass_obj
 def download(obj, provider, refiner, language, age, directory, encoding, single, force, hearing_impaired, min_score,
-             max_workers, archives, verbose, path):
+             max_workers, archives, verbose, fix_filename, path):
     """Download best subtitles.
 
     PATH can be an directory containing videos, a video file path or a video file name. It can be used multiple times.
@@ -364,7 +366,7 @@ def download(obj, provider, refiner, language, age, directory, encoding, single,
             # directories
             if os.path.isdir(p):
                 try:
-                    scanned_videos = scan_videos(p, age=age, archives=archives)
+                    scanned_videos = scan_videos(p, age=age, archives=archives, fix_filename=fix_filename)
                 except:
                     logger.exception('Unexpected error while collecting directory path %s', p)
                     errored_paths.append(p)
@@ -384,7 +386,7 @@ def download(obj, provider, refiner, language, age, directory, encoding, single,
 
             # other inputs
             try:
-                video = scan_video(p)
+                video = scan_video(p, fix_filename)
             except:
                 logger.exception('Unexpected error while collecting path %s', p)
                 errored_paths.append(p)
@@ -447,7 +449,8 @@ def download(obj, provider, refiner, language, age, directory, encoding, single,
     # save subtitles
     total_subtitles = 0
     for v, subtitles in downloaded_subtitles.items():
-        saved_subtitles = save_subtitles(v, subtitles, single=single, directory=directory, encoding=encoding)
+        saved_subtitles = save_subtitles(v, subtitles, single=single, directory=directory, encoding=encoding,
+                                         fix_filename=fix_filename)
         total_subtitles += len(saved_subtitles)
 
         if verbose > 0:

--- a/subliminal/providers/opensubtitles.py
+++ b/subliminal/providers/opensubtitles.py
@@ -208,10 +208,14 @@ class OpenSubtitlesProvider(Provider):
             season = video.season
             episode = video.episode
         else:
+            # if the video doesn't have a title, then the query will be empty
             query = video.title
 
+        # if the query is empty, empty the tag and don't use the base name of the file to search
+        tag = os.path.basename(video.name) if query else None
+
         return self.query(languages, hash=video.hashes.get('opensubtitles'), size=video.size, imdb_id=video.imdb_id,
-                          query=query, season=season, episode=episode, tag=os.path.basename(video.name))
+                          query=query, season=season, episode=episode, tag=tag)
 
     def download_subtitle(self, subtitle):
         logger.info('Downloading subtitle %r', subtitle)


### PR DESCRIPTION
First of all, thanks for subliminal, it's the best subtitle downloaded I tried so far.

This is a hacky solution to solve a problem I had.
I recovered some movies from a failed hard drive, but the file names were gone.

So I modified subliminal to download subtitles by the file hash, then rename the movie file according to the release name.
I added an option `--fix-filename` to the `download` command.

This solution has several problems and hardcoded behaviours.

1. It only works with OpenSubtitles so far;
2. It breaks with some providers;
3. It loops on other providers;
4. The first release name is taken by default;
5. A subdirectory is created if different from the release name;
6. It only works with movies, not episodes;
7. Tests are broken.

If someone else is interested in this feature, then we can all brainstorm and suggest a better user interface for it.
Examples of some possibilities:

1. A separate command `rename` instead of `download`, with some common options and arguments;
2. Providers could have a boolean `allow_hash_search` attribute to indicate if the provider can search movies/episodes by hash;
3. Only accept the `--provider` option for providers that allow searching by hash;
4. Option `--use-release=ask/first/random`, if a movie has more than one release name matching the hash;
5. Use some other attribute to rename the file if the release name is not available.

I hope the feature is useful for someone else, even in the current raw state it's in.
Any suggestion, comment or correction is welcome.
