### PR TITLE
do not crash when Subtitle.guess_encoding fails

### DIFF
--- a/subliminal/subtitle.py
+++ b/subliminal/subtitle.py
@@ -73,7 +73,11 @@ class Subtitle(object):
         if self.encoding:
             return self.content.decode(self.encoding, errors='replace')
 
-        return self.content.decode(self.guess_encoding(), errors='replace')
+        guessed_encoding = self.guess_encoding()
+        if not guessed_encoding:
+            return
+
+        return self.content.decode(guessed_encoding, errors='replace')
 
     def is_valid(self):
         """Check if a :attr:`text` is a valid SubRip format.


### PR DESCRIPTION
Sometimes `Subtitle.guess_encoding` will fail and return `None` therefore result in the CLI to crash.

Specifically, `chardet.detect` might return `None`.

This tiny patch will avoid it.

A better approach might be improving `guess_encoding`, but I am not confident enough to do that (at least for now)

thanks.