### PR TITLE
Declare custom test markers

### DIFF
--- a/pytest.ini
+++ b/pytest.ini
@@ -9,3 +9,6 @@ flakes-ignore =
     docs/conf.py ALL
     subliminal/__init__.py UnusedImport
 doctest_optionflags = NORMALIZE_WHITESPACE IGNORE_EXCEPTION_DETAIL
+markers =
+        integration
+        converter


### PR DESCRIPTION
Pytest needs us to declare custom test markers,
otherwise warnings are thrown when running tests like:

* PytestUnknownMarkWarning: Unknown pytest.mark.converter (...)
* PytestUnknownMarkWarning: Unknown pytest.mark.integration (...)

We could add custom descriptions but I opted not to
here for simplicity.

Signed-off-by: Sam James (sam_c) <sam@cmpct.info>