### PR TITLE
Limit versions of rarfile that can be used

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup_requirements = ['pytest-runner'] if {'pytest', 'test', 'ptr'}.intersection
 
 install_requirements = ['guessit>=3.0.0', 'babelfish>=0.5.2', 'enzyme>=0.4.1', 'beautifulsoup4>=4.4.0',
                         'requests>=2.0', 'click>=4.0', 'dogpile.cache>=0.6.0', 'stevedore>=1.20.0',
-                        'chardet>=2.3.0', 'pysrt>=1.0.1', 'six>=1.9.0', 'appdirs>=1.3', 'rarfile>=2.7',
+                        'chardet>=2.3.0', 'pysrt>=1.0.1', 'six>=1.9.0', 'appdirs>=1.3', 'rarfile>=2.7, <=3.1',
                         'pytz>=2012c']
 if sys.version_info < (3, 2):
     install_requirements.append('futures>=3.0')


### PR DESCRIPTION
In markokr/rarfile#70 it's reported that the `custom_check` function was removed from the rarfile pypi package. As a result the error reported in Diaoul/subliminal#1013 occurs when a version of rarfile newer than 3.1 is installed.

This fixes #1013 by limiting the range of rarfile versions.

Once the legendastv provider is changed to no longer use `custom_check` this version constraint could be removed.