### PR TITLE
Change from pysrt to srt

### DIFF
--- a/docs/user/how_it_works.rst
+++ b/docs/user/how_it_works.rst
@@ -48,4 +48,4 @@ Various libraries are used by subliminal and are key to its success:
 * `dogpile.cache <http://dogpilecache.readthedocs.org>`_ to cache intermediate search results
 * `stevedore <http://docs.openstack.org/developer/stevedore/>`_ to manage the provider entry point
 * `chardet <http://chardet.readthedocs.org>`_ to detect subtitles' encoding
-* `pysrt <https://github.com/byroot/pysrt>`_ to validate downloaded subtitles
+* `srt <https://github.com/cdown/srt>`_ to validate downloaded subtitles

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ setup_requirements = ['pytest-runner'] if {'pytest', 'test', 'ptr'}.intersection
 
 install_requirements = ['guessit>=3.0.0', 'babelfish>=0.5.2', 'enzyme>=0.4.1', 'beautifulsoup4>=4.4.0',
                         'requests>=2.0', 'click>=4.0', 'dogpile.cache>=0.6.0', 'stevedore>=1.20.0',
-                        'chardet>=2.3.0', 'pysrt>=1.0.1', 'six>=1.9.0', 'appdirs>=1.3', 'rarfile>=2.7',
+                        'chardet>=2.3.0', 'srt>=3.5.0', 'six>=1.9.0', 'appdirs>=1.3', 'rarfile>=2.7',
                         'pytz>=2012c']
 if sys.version_info < (3, 2):
     install_requirements.append('futures>=3.0')

--- a/subliminal/subtitle.py
+++ b/subliminal/subtitle.py
@@ -4,7 +4,7 @@ import logging
 import os
 
 import chardet
-import pysrt
+import srt
 
 from six import text_type
 
@@ -95,10 +95,9 @@ class Subtitle(object):
             return False
 
         try:
-            pysrt.from_string(self.text, error_handling=pysrt.ERROR_RAISE)
-        except pysrt.Error as e:
-            if e.args[0] < 80:
-                return False
+            srt.parse(self.text)
+        except srt.SRTParseError:
+            return False
 
         return True
 


### PR DESCRIPTION
Changes from pysrt library to srt. Srt is more recently maintained and claims to be faster. 

Full disclosure: I don't use this software, and the unit tests failed to run due to out-of-date configuration, so this is currently untested.