### PR TITLE
Drop old python versions (<3.8)

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# -*- coding: utf-8 -*-
 #
 # subliminal documentation build configuration file, created by
 # sphinx-quickstart on Sat Jul 11 00:40:28 2015.

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 import sys
 

--- a/docs/conftest.py
+++ b/docs/conftest.py
@@ -1,11 +1,8 @@
 import os
 import sys
+from unittest.mock import Mock
 
 import pytest
-try:
-    from unittest.mock import Mock
-except ImportError:
-    from mock import Mock
 from vcr import VCR
 
 from subliminal.cache import region
@@ -27,13 +24,7 @@ def chdir(tmpdir, monkeypatch):
     monkeypatch.chdir(str(tmpdir))
 
 
-@pytest.yield_fixture(autouse=True)
+@pytest.fixture(autouse=True)
 def use_cassette(request):
     with vcr.use_cassette('test_' + request.fspath.purebasename):
         yield
-
-
-@pytest.fixture(autouse=True)
-def skip_python_2():
-    if sys.version_info < (3, 0):
-        return pytest.skip('Requires python 3')

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,6 +1,6 @@
 [pytest]
 norecursedirs = build dist env .tox .eggs
-#addopts = --pep8 --flakes --doctest-glob='*.rst'
+addopts = --doctest-glob='*.rst'
 pep8maxlinelength = 120
 pep8ignore =
     docs/conf.py ALL

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python
-# -*- coding: utf-8 -*-
 import io
 import os
 import re

--- a/setup.py
+++ b/setup.py
@@ -27,9 +27,9 @@ def find_version(*file_paths):
 setup_requirements = ['pytest-runner'] if {'pytest', 'test', 'ptr'}.intersection(sys.argv) else []
 
 install_requirements = ['guessit>=3.0.0', 'babelfish>=0.5.2', 'enzyme>=0.4.1', 'beautifulsoup4>=4.4.0',
-                        'requests>=2.0', 'requests_cache', 'click>=4.0', 'dogpile.cache>=0.6.0',
-                        'chardet>=2.3.0', 'srt>=3.5.0', 'appdirs>=1.3', 'rarfile>=2.7',
-                        'pytz>=2012c', 'stevedore>=1.20.0', 'setuptools']
+                        'requests>=2.0', 'requests_cache', 'click>=4.0', 'dogpile.cache>=1.0',
+                        'chardet>=5.0', 'srt>=3.5.0', 'appdirs>=1.3', 'rarfile>=2.7',
+                        'stevedore>=3.0', 'setuptools']
 
 test_requirements = ['sympy', 'vcrpy>=1.6.1', 'pytest', 'pytest-pep8', 'pytest-flakes', 'pytest-cov']
 

--- a/setup.py
+++ b/setup.py
@@ -27,9 +27,8 @@ def find_version(*file_paths):
 setup_requirements = ['pytest-runner'] if {'pytest', 'test', 'ptr'}.intersection(sys.argv) else []
 
 install_requirements = ['guessit>=3.0.0', 'babelfish>=0.5.2', 'enzyme>=0.4.1', 'beautifulsoup4>=4.4.0',
-                        'requests>=2.0', 'requests_cache', 'click>=4.0', 'dogpile.cache>=1.0',
-                        'chardet>=5.0', 'srt>=3.5.0', 'appdirs>=1.3', 'rarfile>=2.7',
-                        'stevedore>=3.0', 'setuptools']
+                        'rebulk>=3.0', 'requests>=2.0', 'requests_cache', 'click>=4.0', 'dogpile.cache>=1.0',
+                        'stevedore>=3.0', 'chardet>=5.0', 'srt>=3.5.0', 'appdirs>=1.3', 'rarfile>=2.7']
 
 test_requirements = ['sympy', 'vcrpy>=1.6.1', 'pytest', 'pytest-pep8', 'pytest-flakes', 'pytest-cov']
 

--- a/setup.py
+++ b/setup.py
@@ -28,14 +28,10 @@ setup_requirements = ['pytest-runner'] if {'pytest', 'test', 'ptr'}.intersection
 
 install_requirements = ['guessit>=3.0.0', 'babelfish>=0.5.2', 'enzyme>=0.4.1', 'beautifulsoup4>=4.4.0',
                         'requests>=2.0', 'requests_cache', 'click>=4.0', 'dogpile.cache>=0.6.0',
-                        'chardet>=2.3.0', 'srt>=3.5.0', 'six>=1.9.0', 'appdirs>=1.3', 'rarfile>=2.7',
+                        'chardet>=2.3.0', 'srt>=3.5.0', 'appdirs>=1.3', 'rarfile>=2.7',
                         'pytz>=2012c', 'stevedore>=1.20.0', 'setuptools']
-if sys.version_info < (3, 2):
-    install_requirements.append('futures>=3.0')
 
 test_requirements = ['sympy', 'vcrpy>=1.6.1', 'pytest', 'pytest-pep8', 'pytest-flakes', 'pytest-cov']
-if sys.version_info < (3, 3):
-    test_requirements.append('mock')
 
 dev_requirements = ['tox', 'sphinx', 'sphinx_rtd_theme', 'sphinxcontrib-programoutput', 'wheel']
 
@@ -56,13 +52,12 @@ setup(name='subliminal',
           'License :: OSI Approved :: MIT License',
           'Operating System :: OS Independent',
           'Programming Language :: Python',
-          'Programming Language :: Python :: 2',
-          'Programming Language :: Python :: 2.7',
           'Programming Language :: Python :: 3',
-          'Programming Language :: Python :: 3.5',
-          'Programming Language :: Python :: 3.6',
-          'Programming Language :: Python :: 3.7',
           'Programming Language :: Python :: 3.8',
+          'Programming Language :: Python :: 3.9',
+          'Programming Language :: Python :: 3.10',
+          'Programming Language :: Python :: 3.11',
+          'Programming Language :: Python :: 3.12',
           'Topic :: Software Development :: Libraries :: Python Modules',
           'Topic :: Multimedia :: Video'
       ],

--- a/subliminal/__init__.py
+++ b/subliminal/__init__.py
@@ -1,4 +1,5 @@
-# -*- coding: utf-8 -*-
+from __future__ import annotations
+
 __title__ = 'subliminal'
 __version__ = '2.1.1-dev'
 __short_version__ = '.'.join(__version__.split('.')[:2])

--- a/subliminal/cache.py
+++ b/subliminal/cache.py
@@ -1,7 +1,7 @@
-# -*- coding: utf-8 -*-
+from __future__ import annotations
+
 import datetime
 
-import six
 from dogpile.cache import make_region
 from dogpile.cache.util import function_key_generator
 
@@ -16,18 +16,9 @@ REFINER_EXPIRATION_TIME = datetime.timedelta(weeks=1).total_seconds()
 
 
 def _to_native_str(value):
-    if six.PY2:
-        # In Python 2, the native string type is bytes
-        if isinstance(value, six.text_type):  # unicode for Python 2
-            return value.encode('utf-8')
-        else:
-            return six.binary_type(value)
-    else:
-        # In Python 3, the native string type is unicode
-        if isinstance(value, six.binary_type):  # bytes for Python 3
-            return value.decode('utf-8')
-        else:
-            return six.text_type(value)
+    if isinstance(value, bytes):
+        return value.decode('utf-8')
+    return str(value)
 
 
 def to_native_str_key_generator(namespace, fn, to_str=_to_native_str):

--- a/subliminal/cli.py
+++ b/subliminal/cli.py
@@ -1,9 +1,9 @@
-# -*- coding: utf-8 -*-
 """
 Subliminal uses `click <http://click.pocoo.org>`_ to provide a powerful :abbr:`CLI (command-line interface)`.
 
 """
-from __future__ import division
+from __future__ import annotations
+
 from collections import defaultdict
 from datetime import timedelta
 import glob
@@ -17,7 +17,7 @@ from babelfish import Error as BabelfishError, Language
 import click
 from dogpile.cache.backends.file import AbstractFileLock
 from dogpile.util.readwrite_lock import ReadWriteMutex
-from six.moves import configparser
+from configparser import ConfigParser
 
 from subliminal import (AsyncProviderPool, Episode, Movie, Video, __version__, check_video, compute_score, get_scores,
                         provider_manager, refine, refiner_manager, region, save_subtitles, scan_video, scan_videos)
@@ -59,7 +59,7 @@ class Config(object):
         self.path = path
 
         #: The underlying configuration object
-        self.config = configparser.SafeConfigParser()
+        self.config = ConfigParser()
         self.config.add_section('general')
         self.config.set('general', 'languages', json.dumps(['en']))
         self.config.set('general', 'providers', json.dumps(sorted([p.name for p in provider_manager])))

--- a/subliminal/cli.py
+++ b/subliminal/cli.py
@@ -46,7 +46,7 @@ class MutexLock(AbstractFileLock):
         return self.mutex.release_write_lock()
 
 
-class Config(object):
+class Config:
     """A :class:`~configparser.ConfigParser` wrapper to store configuration.
 
     Interaction with the configuration is done with the properties.

--- a/subliminal/converters/addic7ed.py
+++ b/subliminal/converters/addic7ed.py
@@ -1,4 +1,5 @@
-# -*- coding: utf-8 -*-
+from __future__ import annotations
+
 from babelfish import LanguageReverseConverter, language_converters
 
 

--- a/subliminal/converters/opensubtitlescom.py
+++ b/subliminal/converters/opensubtitlescom.py
@@ -1,4 +1,5 @@
-# -*- coding: utf-8 -*-
+from __future__ import annotations
+
 from babelfish import LanguageReverseConverter, language_converters
 
 

--- a/subliminal/converters/shooter.py
+++ b/subliminal/converters/shooter.py
@@ -1,4 +1,5 @@
-# -*- coding: utf-8 -*-
+from __future__ import annotations
+
 from babelfish import LanguageReverseConverter
 
 from ..exceptions import ConfigurationError

--- a/subliminal/converters/thesubdb.py
+++ b/subliminal/converters/thesubdb.py
@@ -1,4 +1,5 @@
-# -*- coding: utf-8 -*-
+from __future__ import annotations
+
 from babelfish import LanguageReverseConverter
 
 from ..exceptions import ConfigurationError

--- a/subliminal/converters/tvsubtitles.py
+++ b/subliminal/converters/tvsubtitles.py
@@ -1,4 +1,5 @@
-# -*- coding: utf-8 -*-
+from __future__ import annotations
+
 from babelfish import LanguageReverseConverter, language_converters
 
 

--- a/subliminal/core.py
+++ b/subliminal/core.py
@@ -26,7 +26,7 @@ ARCHIVE_EXTENSIONS = ('.rar',)
 logger = logging.getLogger(__name__)
 
 
-class ProviderPool(object):
+class ProviderPool:
     """A pool of providers with the same API as a single :class:`~subliminal.providers.Provider`.
 
     It has a few extra features:
@@ -247,13 +247,13 @@ class AsyncProviderPool(ProviderPool):
 
     """
     def __init__(self, max_workers=None, *args, **kwargs):
-        super(AsyncProviderPool, self).__init__(*args, **kwargs)
+        super().__init__(*args, **kwargs)
 
         #: Maximum number of threads to use
         self.max_workers = max_workers or len(self.providers)
 
     def list_subtitles_provider(self, provider, video, languages):
-        return provider, super(AsyncProviderPool, self).list_subtitles_provider(provider, video, languages)
+        return provider, super().list_subtitles_provider(provider, video, languages)
 
     def list_subtitles(self, video, languages):
         subtitles = []

--- a/subliminal/core.py
+++ b/subliminal/core.py
@@ -536,7 +536,7 @@ def refine(video, episode_refiners=None, movie_refiners=None, refiner_configs=No
     :param tuple movie_refiners: refiners to use for movies.
     :param dict refiner_configs: refiner configuration as keyword arguments per refiner name to pass when
         calling the refine method
-    :param \*\*kwargs: additional parameters for the :func:`~subliminal.refiners.refine` functions.
+    :param kwargs: additional parameters for the :func:`~subliminal.refiners.refine` functions.
 
     """
     refiners = ()
@@ -563,7 +563,7 @@ def list_subtitles(videos, languages, pool_class=ProviderPool, **kwargs):
     :type languages: set of :class:`~babelfish.language.Language`
     :param pool_class: class to use as provider pool.
     :type pool_class: :class:`ProviderPool`, :class:`AsyncProviderPool` or similar
-    :param \*\*kwargs: additional parameters for the provided `pool_class` constructor.
+    :param kwargs: additional parameters for the provided `pool_class` constructor.
     :return: found subtitles per video.
     :rtype: dict of :class:`~subliminal.video.Video` to list of :class:`~subliminal.subtitle.Subtitle`
 
@@ -600,7 +600,7 @@ def download_subtitles(subtitles, pool_class=ProviderPool, **kwargs):
     :type subtitles: list of :class:`~subliminal.subtitle.Subtitle`
     :param pool_class: class to use as provider pool.
     :type pool_class: :class:`ProviderPool`, :class:`AsyncProviderPool` or similar
-    :param \*\*kwargs: additional parameters for the provided `pool_class` constructor.
+    :param kwargs: additional parameters for the provided `pool_class` constructor.
 
     """
     with pool_class(**kwargs) as pool:
@@ -626,7 +626,7 @@ def download_best_subtitles(videos, languages, min_score=0, hearing_impaired=Fal
         `hearing_impaired` as keyword argument and returns the score.
     :param pool_class: class to use as provider pool.
     :type pool_class: :class:`ProviderPool`, :class:`AsyncProviderPool` or similar
-    :param \*\*kwargs: additional parameters for the provided `pool_class` constructor.
+    :param kwargs: additional parameters for the provided `pool_class` constructor.
     :return: downloaded subtitles per video.
     :rtype: dict of :class:`~subliminal.video.Video` to list of :class:`~subliminal.subtitle.Subtitle`
 

--- a/subliminal/core.py
+++ b/subliminal/core.py
@@ -1,7 +1,8 @@
-# -*- coding: utf-8 -*-
+from __future__ import annotations
+
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
-from datetime import datetime
+from datetime import datetime, timezone
 import io
 import itertools
 import logging
@@ -492,12 +493,12 @@ def scan_videos(path, age=None, archives=True):
 
             # skip old files
             try:
-                file_age = datetime.utcfromtimestamp(os.path.getmtime(filepath))
+                file_age = datetime.fromtimestamp(os.path.getmtime(filepath), timezone.utc)
             except ValueError:
                 logger.warning('Could not get age of file %r in %r', filename, dirpath)
                 continue
             else:
-                if age and datetime.utcnow() - file_age > age:
+                if age and datetime.now(timezone.utc) - file_age > age:
                     logger.debug('Skipping old file %r in %r', filename, dirpath)
                     continue
 

--- a/subliminal/exceptions.py
+++ b/subliminal/exceptions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 class Error(Exception):
     """Base class for exceptions in subliminal."""
     pass
@@ -6,6 +5,11 @@ class Error(Exception):
 
 class ProviderError(Error):
     """Exception raised by providers."""
+    pass
+
+
+class NotInitializedProviderError(ProviderError):
+    """Exception raised by providers when not initialized."""
     pass
 
 

--- a/subliminal/matches.py
+++ b/subliminal/matches.py
@@ -1,4 +1,5 @@
-# -*- coding: utf-8 -*-
+from __future__ import annotations
+
 from rebulk.loose import ensure_list
 
 from .score import get_equivalent_release_groups, score_keys

--- a/subliminal/providers/__init__.py
+++ b/subliminal/providers/__init__.py
@@ -1,9 +1,10 @@
-# -*- coding: utf-8 -*-
+from __future__ import annotations
+
 import logging
 import ssl
+from xmlrpc.client import SafeTransport
 
 from bs4 import BeautifulSoup, FeatureNotFound
-from six.moves.xmlrpc_client import SafeTransport
 from requests import adapters
 from urllib3 import poolmanager
 
@@ -30,7 +31,7 @@ class SecLevelOneTLSAdapter(adapters.HTTPAdapter):
 class TimeoutSafeTransport(SafeTransport):
     """Timeout support for ``xmlrpc.client.SafeTransport``."""
     def __init__(self, timeout, *args, **kwargs):
-        SafeTransport.__init__(self, *args, **kwargs)
+        super().__init__(*args, **kwargs)
         self.timeout = timeout
 
     def make_connection(self, host):
@@ -61,7 +62,7 @@ class ParserBeautifulSoup(BeautifulSoup):
         # pick the first parser available
         for parser in parsers:
             try:
-                super(ParserBeautifulSoup, self).__init__(markup, parser, **kwargs)
+                super().__init__(markup, parser, **kwargs)
                 return
             except FeatureNotFound:
                 pass
@@ -69,7 +70,7 @@ class ParserBeautifulSoup(BeautifulSoup):
         raise FeatureNotFound
 
 
-class Provider(object):
+class Provider:
     """Base class for providers.
 
     If any configuration is possible for the provider, like credentials, it must take place during instantiation.

--- a/subliminal/providers/addic7ed.py
+++ b/subliminal/providers/addic7ed.py
@@ -1,4 +1,5 @@
-# -*- coding: utf-8 -*-
+from __future__ import annotations
+
 import logging
 import re
 
@@ -31,7 +32,7 @@ class Addic7edSubtitle(Subtitle):
 
     def __init__(self, language, hearing_impaired, page_link, series, season, episode, title, year, version,
                  download_link):
-        super(Addic7edSubtitle, self).__init__(language, hearing_impaired=hearing_impaired, page_link=page_link)
+        super().__init__(language, hearing_impaired=hearing_impaired, page_link=page_link)
         self.series = series
         self.season = season
         self.episode = episode

--- a/subliminal/providers/argenteam.py
+++ b/subliminal/providers/argenteam.py
@@ -1,4 +1,5 @@
-# -*- coding: utf-8 -*-
+from __future__ import annotations
+
 import io
 import json
 import logging
@@ -7,7 +8,7 @@ from zipfile import ZipFile
 from babelfish import Language
 from guessit import guessit
 from requests import Session
-from six.moves import urllib
+from urllib.parse import unquote
 
 from . import Provider
 from ..cache import EPISODE_EXPIRATION_TIME, region
@@ -23,7 +24,7 @@ class ArgenteamSubtitle(Subtitle):
     provider_name = 'argenteam'
 
     def __init__(self, language, download_link, series, season, episode, release, version):
-        super(ArgenteamSubtitle, self).__init__(language, download_link)
+        super().__init__(language, download_link)
         self.download_link = download_link
         self.series = series
         self.season = season
@@ -37,7 +38,7 @@ class ArgenteamSubtitle(Subtitle):
 
     @property
     def info(self):
-        return urllib.parse.unquote(self.download_link.rsplit('/')[-1])
+        return unquote(self.download_link.rsplit('/')[-1])
 
     def get_matches(self, video):
         matches = guess_matches(video, {

--- a/subliminal/providers/gestdown.py
+++ b/subliminal/providers/gestdown.py
@@ -1,4 +1,5 @@
-# -*- coding: utf-8 -*-
+from __future__ import annotations
+
 import logging
 import re
 
@@ -25,7 +26,7 @@ class GestdownSubtitle(Subtitle):
         self, language, hearing_impaired, series, season, episode, title, version,
         download_link,
     ):
-        super(GestdownSubtitle, self).__init__(language, hearing_impaired=hearing_impaired)
+        super().__init__(language, hearing_impaired=hearing_impaired)
         self.series = series
         self.season = season
         self.episode = episode

--- a/subliminal/providers/napiprojekt.py
+++ b/subliminal/providers/napiprojekt.py
@@ -1,4 +1,5 @@
-# -*- coding: utf-8 -*-
+from __future__ import annotations
+
 import logging
 
 from babelfish import Language
@@ -39,7 +40,7 @@ class NapiProjektSubtitle(Subtitle):
     provider_name = 'napiprojekt'
 
     def __init__(self, language, hash):
-        super(NapiProjektSubtitle, self).__init__(language)
+        super().__init__(language)
         self.hash = hash
         self.content = None
 

--- a/subliminal/providers/opensubtitles.py
+++ b/subliminal/providers/opensubtitles.py
@@ -1,16 +1,16 @@
-# -*- coding: utf-8 -*-
+from __future__ import annotations
+
 import base64
 import logging
 import os
 import re
 import zlib
+from xmlrpc.client import ServerProxy
 
 from babelfish import Language, language_converters
 from guessit import guessit
-from six.moves.xmlrpc_client import ServerProxy
 
 from . import Provider, TimeoutSafeTransport
-from .. import __short_version__
 from ..exceptions import (AuthenticationError, ConfigurationError, DownloadLimitExceeded, ProviderError,
                           ServiceUnavailable)
 from ..matches import guess_matches
@@ -37,7 +37,7 @@ class OpenSubtitlesSubtitle(Subtitle):
 
     def __init__(self, language, hearing_impaired, page_link, subtitle_id, matched_by, movie_kind, hash, movie_name,
                  movie_release_name, movie_year, movie_imdb_id, series_season, series_episode, filename, encoding):
-        super(OpenSubtitlesSubtitle, self).__init__(language, hearing_impaired=hearing_impaired,
+        super().__init__(language, hearing_impaired=hearing_impaired,
                                                     page_link=page_link, encoding=encoding)
         self.subtitle_id = subtitle_id
         self.matched_by = matched_by

--- a/subliminal/providers/opensubtitlescom.py
+++ b/subliminal/providers/opensubtitlescom.py
@@ -1,4 +1,5 @@
-# -*- coding: utf-8 -*-
+from __future__ import annotations
+
 from datetime import datetime, timedelta, timezone
 import logging
 import time
@@ -76,12 +77,7 @@ class OpenSubtitlesComSubtitle(Subtitle):
         file_id = None,
         file_name = None,
     ):
-        super(OpenSubtitlesComSubtitle, self).__init__(
-            language,
-            hearing_impaired=hearing_impaired,
-            page_link="",
-            encoding="utf-8",
-        )
+        super().__init__(language, hearing_impaired=hearing_impaired, page_link="", encoding="utf-8")
         self.subtitle_id = subtitle_id
         self.movie_kind = movie_kind
         self.movie_hash = movie_hash

--- a/subliminal/providers/podnapisi.py
+++ b/subliminal/providers/podnapisi.py
@@ -1,4 +1,5 @@
-# -*- coding: utf-8 -*-
+from __future__ import annotations
+
 import io
 import json
 import logging
@@ -24,7 +25,7 @@ class PodnapisiSubtitle(Subtitle):
 
     def __init__(self, language, hearing_impaired, page_link, pid, releases, title, season=None, episode=None,
                  year=None):
-        super(PodnapisiSubtitle, self).__init__(language, hearing_impaired=hearing_impaired, page_link=page_link)
+        super().__init__(language, hearing_impaired=hearing_impaired, page_link=page_link)
         self.pid = pid
         self.releases = releases
         self.title = title

--- a/subliminal/providers/shooter.py
+++ b/subliminal/providers/shooter.py
@@ -1,4 +1,5 @@
-# -*- coding: utf-8 -*-
+from __future__ import annotations
+
 import json
 import logging
 import os
@@ -19,7 +20,7 @@ class ShooterSubtitle(Subtitle):
     provider_name = 'shooter'
 
     def __init__(self, language, hash, download_link):
-        super(ShooterSubtitle, self).__init__(language)
+        super().__init__(language)
         self.hash = hash
         self.download_link = download_link
 

--- a/subliminal/providers/thesubdb.py
+++ b/subliminal/providers/thesubdb.py
@@ -1,4 +1,5 @@
-# -*- coding: utf-8 -*-
+from __future__ import annotations
+
 import logging
 
 from babelfish import Language, language_converters
@@ -18,7 +19,7 @@ class TheSubDBSubtitle(Subtitle):
     provider_name = 'thesubdb'
 
     def __init__(self, language, hash):
-        super(TheSubDBSubtitle, self).__init__(language)
+        super().__init__(language)
         self.hash = hash
 
     @property

--- a/subliminal/providers/tvsubtitles.py
+++ b/subliminal/providers/tvsubtitles.py
@@ -1,4 +1,5 @@
-# -*- coding: utf-8 -*-
+from __future__ import annotations
+
 import io
 import logging
 import re
@@ -28,7 +29,7 @@ class TVsubtitlesSubtitle(Subtitle):
     provider_name = 'tvsubtitles'
 
     def __init__(self, language, page_link, subtitle_id, series, season, episode, year, rip, release):
-        super(TVsubtitlesSubtitle, self).__init__(language, page_link=page_link)
+        super().__init__(language, page_link=page_link)
         self.subtitle_id = subtitle_id
         self.series = series
         self.season = season

--- a/subliminal/refiners/__init__.py
+++ b/subliminal/refiners/__init__.py
@@ -7,6 +7,6 @@ A refiner is a simple function:
 
     :param video: the video to refine.
     :type video: :class:`~subliminal.video.Video`
-    :param \*\*kwargs: additional parameters for refiners.
+    :param kwargs: additional parameters for refiners.
 
 """

--- a/subliminal/refiners/hash.py
+++ b/subliminal/refiners/hash.py
@@ -1,4 +1,5 @@
-# -*- coding: utf-8 -*-
+from __future__ import annotations
+
 import logging
 
 from ..extensions import provider_manager, default_providers

--- a/subliminal/refiners/metadata.py
+++ b/subliminal/refiners/metadata.py
@@ -1,4 +1,5 @@
-# -*- coding: utf-8 -*-
+from __future__ import annotations
+
 import logging
 import os
 

--- a/subliminal/refiners/omdb.py
+++ b/subliminal/refiners/omdb.py
@@ -1,4 +1,5 @@
-# -*- coding: utf-8 -*-
+from __future__ import annotations
+
 import logging
 import operator
 
@@ -14,7 +15,7 @@ logger = logging.getLogger(__name__)
 OMDB_API_KEY = '44d5b275'
 
 
-class OMDBClient(object):
+class OMDBClient:
     base_url = 'http://www.omdbapi.com'
 
     def __init__(self, apikey=None, version=1, session=None, headers=None, timeout=10):

--- a/subliminal/refiners/tvdb.py
+++ b/subliminal/refiners/tvdb.py
@@ -1,4 +1,5 @@
-# -*- coding: utf-8 -*-
+from __future__ import annotations
+
 from datetime import datetime, timedelta, timezone
 from functools import wraps
 import logging
@@ -30,7 +31,7 @@ def requires_auth(func):
     return wrapper
 
 
-class TVDBClient(object):
+class TVDBClient:
     """TVDB REST API Client
 
     :param str apikey: API key to use.

--- a/subliminal/score.py
+++ b/subliminal/score.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 This module provides the default implementation of the `compute_score` parameter in
 :meth:`~subliminal.core.ProviderPool.download_best_subtitles` and :func:`~subliminal.core.download_best_subtitles`.
@@ -29,7 +28,8 @@ Available matches:
   * tvdb_id
 
 """
-from __future__ import division, print_function
+from __future__ import annotations
+
 import logging
 
 from .video import Episode, Movie

--- a/subliminal/subtitle.py
+++ b/subliminal/subtitle.py
@@ -1,12 +1,11 @@
-# -*- coding: utf-8 -*-
+from __future__ import annotations
+
 import codecs
 import logging
 import os
 
 import chardet
 import srt
-
-from six import text_type
 
 logger = logging.getLogger(__name__)
 
@@ -72,7 +71,7 @@ class Subtitle(object):
         if not self.content:
             return
 
-        if not isinstance(self.content, text_type):
+        if isinstance(self.content, bytes):
             if self.encoding:
                 return self.content.decode(self.encoding, errors='replace')
 

--- a/subliminal/subtitle.py
+++ b/subliminal/subtitle.py
@@ -13,7 +13,7 @@ logger = logging.getLogger(__name__)
 SUBTITLE_EXTENSIONS = ('.srt', '.sub', '.smi', '.txt', '.ssa', '.ass', '.mpl')
 
 
-class Subtitle(object):
+class Subtitle:
     """Base class for subtitle.
 
     :param language: language of the subtitle.

--- a/subliminal/utils.py
+++ b/subliminal/utils.py
@@ -1,15 +1,16 @@
-# -*- coding: utf-8 -*-
+from __future__ import annotations
+
 import logging
-from datetime import datetime
 import hashlib
 import os
 import re
 import socket
 import struct
+from datetime import datetime
 
 import requests
 from requests.exceptions import SSLError
-from six.moves.xmlrpc_client import ProtocolError
+from xmlrpc.client import ProtocolError
 
 from .exceptions import ServiceUnavailable
 

--- a/subliminal/video.py
+++ b/subliminal/video.py
@@ -1,6 +1,6 @@
-# -*- coding: utf-8 -*-
-from __future__ import division
-from datetime import datetime, timedelta
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
 import logging
 import os
 
@@ -83,7 +83,10 @@ class Video(object):
     def age(self):
         """Age of the video"""
         if self.exists:
-            return datetime.utcnow() - datetime.utcfromtimestamp(os.path.getmtime(self.name))
+            return (
+                datetime.now(timezone.utc)
+                - datetime.fromtimestamp(os.path.getmtime(self.name), timezone.utc)
+            )
 
         return timedelta()
 
@@ -133,7 +136,7 @@ class Episode(Video):
     :param bool original_series: whether the series is the first with this name.
     :param int tvdb_id: TVDB id of the episode.
     :param list alternative_series: alternative names of the series
-    :param \*\*kwargs: additional parameters for the :class:`Video` constructor.
+    :param kwargs: additional parameters for the :class:`Video` constructor.
 
     """
     def __init__(self, name, series, season, episodes, title=None, year=None, country=None, original_series=True,
@@ -218,7 +221,7 @@ class Movie(Video):
     :param country: Country of the movie.
     :type country: :class:`~babelfish.country.Country`
     :param list alternative_titles: alternative titles of the movie
-    :param \*\*kwargs: additional parameters for the :class:`Video` constructor.
+    :param kwargs: additional parameters for the :class:`Video` constructor.
 
     """
     def __init__(self, name, title, year=None, country=None, alternative_titles=None, **kwargs):

--- a/subliminal/video.py
+++ b/subliminal/video.py
@@ -21,7 +21,7 @@ VIDEO_EXTENSIONS = ('.3g2', '.3gp', '.3gp2', '.3gpp', '.60d', '.ajp', '.asf', '.
                     '.vivo', '.vob', '.vro', '.webm', '.wm', '.wmv', '.wmx', '.wrap', '.wvx', '.wx', '.x264', '.xvid')
 
 
-class Video(object):
+class Video:
     """Base class for videos.
 
     Represent a video, existing or not.
@@ -141,7 +141,7 @@ class Episode(Video):
     """
     def __init__(self, name, series, season, episodes, title=None, year=None, country=None, original_series=True,
                  tvdb_id=None, series_tvdb_id=None, series_imdb_id=None, alternative_series=None, **kwargs):
-        super(Episode, self).__init__(name, **kwargs)
+        super().__init__(name, **kwargs)
 
         #: Series of the episode
         self.series = series
@@ -225,7 +225,7 @@ class Movie(Video):
 
     """
     def __init__(self, name, title, year=None, country=None, alternative_titles=None, **kwargs):
-        super(Movie, self).__init__(name, **kwargs)
+        super().__init__(name, **kwargs)
 
         #: Title of the movie
         self.title = title

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import subprocess
 from io import BytesIO
 import os

--- a/tests/test_addic7ed.py
+++ b/tests/test_addic7ed.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 
 from babelfish import Language, language_converters

--- a/tests/test_argenteam.py
+++ b/tests/test_argenteam.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from babelfish import Language
 import os
 import pytest

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from datetime import datetime, timedelta
 import io
 import os

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from pkg_resources import EntryPoint, iter_entry_points
 
 from subliminal.extensions import RegistrableExtensionManager, provider_manager, default_providers, disabled_providers

--- a/tests/test_gestdown.py
+++ b/tests/test_gestdown.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 
 from babelfish import Language, language_converters

--- a/tests/test_matches.py
+++ b/tests/test_matches.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from subliminal.matches import guess_matches
 
 

--- a/tests/test_napiprojekt.py
+++ b/tests/test_napiprojekt.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 
 from babelfish import Language

--- a/tests/test_omdb.py
+++ b/tests/test_omdb.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 
 import pytest

--- a/tests/test_opensubtitles.py
+++ b/tests/test_opensubtitles.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 
 from babelfish import Language

--- a/tests/test_opensubtitlescom.py
+++ b/tests/test_opensubtitlescom.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 
 from babelfish import Language

--- a/tests/test_podnapisi.py
+++ b/tests/test_podnapisi.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 
 from babelfish import Language

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from bs4 import FeatureNotFound
 import pytest
 

--- a/tests/test_score.py
+++ b/tests/test_score.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from __future__ import division
 
 from babelfish import Language

--- a/tests/test_shooter.py
+++ b/tests/test_shooter.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 
 from babelfish import Language, language_converters

--- a/tests/test_subtitle.py
+++ b/tests/test_subtitle.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 
 import six

--- a/tests/test_thesubdb.py
+++ b/tests/test_thesubdb.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 
 from babelfish import Language, language_converters

--- a/tests/test_tvdb.py
+++ b/tests/test_tvdb.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from datetime import datetime, timedelta
 import os
 import time

--- a/tests/test_tvsubtitles.py
+++ b/tests/test_tvsubtitles.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 import os
 
 from babelfish import Language, language_converters

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from six import text_type as str
 
 from subliminal.utils import hash_opensubtitles, hash_thesubdb, sanitize

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 from datetime import datetime, timedelta
 
 import pytest

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = {py27,py35,py36,py37,py38}-{native,lxml}
+envlist = {py38,py39,py310,py311,py312}-{native,lxml}
 
 [testenv]
 deps =


### PR DESCRIPTION
In this PR:
- [x] removed the `# -*- coding: utf-8 -*-` line
- [x] remove the `six` reference and requirement
- [x] remove the `sys.version` check for python version older than 3.8
- [x] remove  `--pep8 --flakes` options from `pytest` addopts
- [x] remove subclassing from `object`
- [x] remove full usage of `super()` 
- [x] remove `pkg_resources` dependency
- [x] remove call to `datetime.utcnow()`
- [x] remove escaped `**` from docstrings
- [x] add a `NotInitializedProviderError` Exception (#1070)
- [x] add `from __future__ import annotations` line for easier type annotations
- [x] update dependencies [EDITED]

Partially solves #1071 