### PR TITLE
[Opensubtitlescom Provider] use dogpile.cache instead of requests-cache

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ def find_version(*file_paths):
 setup_requirements = ['pytest-runner'] if {'pytest', 'test', 'ptr'}.intersection(sys.argv) else []
 
 install_requirements = ['guessit>=3.0.0', 'babelfish>=0.5.2', 'enzyme>=0.4.1', 'beautifulsoup4>=4.4.0',
-                        'rebulk>=3.0', 'requests>=2.0', 'requests_cache', 'click>=4.0', 'dogpile.cache>=1.0',
+                        'rebulk>=3.0', 'requests>=2.0', 'click>=4.0', 'dogpile.cache>=1.0',
                         'stevedore>=3.0', 'chardet>=5.0', 'srt>=3.5.0', 'appdirs>=1.3', 'rarfile>=2.7']
 
 test_requirements = ['sympy', 'vcrpy>=1.6.1', 'pytest', 'pytest-pep8', 'pytest-flakes', 'pytest-cov']

--- a/tests/cassettes/opensubtitlescom/test_download_subtitle.yaml
+++ b/tests/cassettes/opensubtitlescom/test_download_subtitle.yaml
@@ -5,7 +5,7 @@ interactions:
       Accept:
       - '*/*'
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Api-Key:
       - mij33pjc3kOlup1qOKxnWWxvle2kFbMH
       Connection:
@@ -18,48 +18,40 @@ interactions:
     uri: https://api.opensubtitles.com/api/v1/subtitles?imdb_id=770828&languages=de%2Cfr&moviehash=5b8f8f4e41ccb21e&query=man+of+steel
   response:
     body:
-      string: "{\"total_pages\":1,\"total_count\":10,\"per_page\":60,\"page\":1,\"data\":[{\"id\":\"879122\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"879122\",\"language\":\"fr\",\"download_count\":20172,\"new_download_count\":203,\"hearing_impaired\":false,\"hd\":true,\"fps\":23.976,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2013-10-16T16:56:06Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"man.of.steel.2013.720p.bluray.x264-felony\",\"comments\":\"\",\"legacy_subtitle_id\":5226251,\"legacy_uploader_id\":0,\"uploader\":{\"uploader_id\":3282,\"name\":\"os-auto\",\"rank\":\"Application
-        Developers\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/fr/subtitles/legacy/5226251\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/fr/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":960683,\"cd_number\":1,\"file_name\":\"man.of.steel.2013.720p.bluray.x264-felony.www.subsynchro.com\"}],\"moviehash_match\":true}},{\"id\":\"880717\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"880717\",\"language\":\"de\",\"download_count\":2670,\"new_download_count\":194,\"hearing_impaired\":false,\"hd\":true,\"fps\":23.976,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2013-10-19T00:53:25Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Man.of.Steel.German.720p.BluRay.x264-EXQUiSiTE\",\"comments\":\"\",\"legacy_subtitle_id\":5229998,\"legacy_uploader_id\":0,\"uploader\":{\"uploader_id\":3282,\"name\":\"os-auto\",\"rank\":\"Application
-        Developers\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/de/subtitles/legacy/5229998\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/de/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":962352,\"cd_number\":1,\"file_name\":\"Man.of.Steel.German.720p.BluRay.x264-EXQUiSiTE\"}],\"moviehash_match\":true}},{\"id\":\"880511\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"880511\",\"language\":\"fr\",\"download_count\":35322,\"new_download_count\":264,\"hearing_impaired\":false,\"hd\":true,\"fps\":0.0,\"votes\":0,\"ratings\":0.0,\"from_trusted\":true,\"foreign_parts_only\":false,\"upload_date\":\"2013-10-18T14:26:47Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"man.of.steel.2013.720p.bluray.x264-felony.www.subsynchro.com\",\"comments\":\"\",\"legacy_subtitle_id\":5229112,\"legacy_uploader_id\":1430515,\"uploader\":{\"uploader_id\":59162,\"name\":\"smailpouri\",\"rank\":\"Trusted
-        member\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/fr/subtitles/legacy/5229112\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/fr/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":962144,\"cd_number\":1,\"file_name\":\"man.of.steel.2013.720p.bluray.x264-felony.www.subsynchro.com\"}],\"moviehash_match\":false}},{\"id\":\"870964\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"870964\",\"language\":\"fr\",\"download_count\":22032,\"new_download_count\":89,\"hearing_impaired\":false,\"hd\":true,\"fps\":0.0,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2013-07-26T08:47:00Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Man.of.Steel.2013.720p.R6.LiNE.x264.AAC-DiGiTAL\",\"comments\":\"\",\"legacy_subtitle_id\":5105960,\"legacy_uploader_id\":0,\"uploader\":{\"uploader_id\":3282,\"name\":\"os-auto\",\"rank\":\"Application
-        Developers\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/fr/subtitles/legacy/5105960\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/fr/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":952177,\"cd_number\":1,\"file_name\":\"Man.of.Steel.2013.R6.LiNE.All.Version-fr\"}],\"moviehash_match\":false}},{\"id\":\"877697\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"877697\",\"language\":\"fr\",\"download_count\":17037,\"new_download_count\":130,\"hearing_impaired\":false,\"hd\":true,\"fps\":0.0,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2013-10-16T09:35:02Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"man.of.steel.2013.1080p.bluray.x264-sector7\",\"comments\":\"\",\"legacy_subtitle_id\":5225852,\"legacy_uploader_id\":0,\"uploader\":{\"uploader_id\":3282,\"name\":\"os-auto\",\"rank\":\"Application
-        Developers\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/fr/subtitles/legacy/5225852\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/fr/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":959227,\"cd_number\":1,\"file_name\":\"man.of.steel.2013.1080p.bluray.x264-sector7\"}],\"moviehash_match\":false}},{\"id\":\"880332\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"880332\",\"language\":\"de\",\"download_count\":7182,\"new_download_count\":216,\"hearing_impaired\":true,\"hd\":true,\"fps\":23.976,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2013-10-17T13:26:46Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Man.of.Steel.German.DL.1080p.BluRay.x264-EXQUiSiTE\",\"comments\":\"\",\"legacy_subtitle_id\":5227599,\"legacy_uploader_id\":0,\"uploader\":{\"uploader_id\":3282,\"name\":\"os-auto\",\"rank\":\"Application
-        Developers\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/de/subtitles/legacy/5227599\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/de/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":961964,\"cd_number\":1,\"file_name\":\"Man.of.Steel.German.DL.1080p.BluRay.x264-EXQUiSiTE\"}],\"moviehash_match\":false}},{\"id\":\"883552\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"883552\",\"language\":\"de\",\"download_count\":4283,\"new_download_count\":10,\"hearing_impaired\":false,\"hd\":true,\"fps\":25.0,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2016-07-31T14:29:17Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Man
-        of Steel (2013) Dtv 2h07min\",\"comments\":\"\",\"legacy_subtitle_id\":6698593,\"legacy_uploader_id\":2563175,\"uploader\":{\"uploader_id\":69315,\"name\":\"bergert_\",\"rank\":\"Trusted
-        member\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/de/subtitles/legacy/6698593\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/de/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":965287,\"cd_number\":1,\"file_name\":\"Man
-        of Steel (DT-2013)\"}],\"moviehash_match\":false}},{\"id\":\"5166256\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"5166256\",\"language\":\"de\",\"download_count\":1794,\"new_download_count\":14,\"hearing_impaired\":false,\"hd\":true,\"fps\":23.976,\"votes\":1,\"ratings\":10.0,\"from_trusted\":true,\"foreign_parts_only\":false,\"upload_date\":\"2020-03-29T11:40:37Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Man.of.Steel.2013.720p.german.srt\",\"comments\":\"--\\u003e
-        HI-Items entfernt, Timing teilweise korrigiert, Kursivsetzung korrigiert\\r\\n--\\u003e
-        passend f\xFCr Versionen mit Laufzeit 2h 23min 2s 688ms\",\"legacy_subtitle_id\":8148911,\"legacy_uploader_id\":1189705,\"uploader\":{\"uploader_id\":54111,\"name\":\"arcchancellor\",\"rank\":\"translator\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/de/subtitles/legacy/8148911\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/de/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":5276290,\"cd_number\":1,\"file_name\":\"Man.of.Steel.2013.720p.german\"}],\"moviehash_match\":false}},{\"id\":\"883560\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"883560\",\"language\":\"de\",\"download_count\":938,\"new_download_count\":9,\"hearing_impaired\":true,\"hd\":true,\"fps\":23.976,\"votes\":2,\"ratings\":10.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2016-08-01T19:13:17Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Man
-        of Steel German DL 1080p BluRay x264-EXQUiSiTE\",\"comments\":\"Duration:
-        2:23:03\\r\\nvia SubTools from idx to srt\\r\\nFull German\\r\\nHandmade corrected\",\"legacy_subtitle_id\":6699712,\"legacy_uploader_id\":1471910,\"uploader\":{\"uploader_id\":60439,\"name\":\"PissPott\",\"rank\":\"Silver
-        Member\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/de/subtitles/legacy/6699712\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/de/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":965292,\"cd_number\":1,\"file_name\":\"exq-manofsteel-1080p.idx.mkv\"}],\"moviehash_match\":false}},{\"id\":\"6632511\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"6632511\",\"language\":\"de\",\"download_count\":61,\"new_download_count\":7,\"hearing_impaired\":false,\"hd\":true,\"fps\":23.976,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2022-06-26T19:32:54Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Should
-        work with 4k BD rips\",\"comments\":\"Source German Retail 4k BD\\r\\nRetail
-        PGS to SSA + improvements\\r\\n\\r\\ncoloured parts\\r\\n\\r\\nIf the timing
-        is off, just correct it with SubtitleEdit.\\r\\n-\\u003e Synchronization \\r\\n-\\u003e
-        Adjust all times \\r\\n-\\u003e all lines\\r\\n\\r\\nWorks best with MPC-BE
-        + XySubFilter + madvr\\r\\nbecause there the font is not in the image,\\r\\nbut
-        at the bottom in the black bars.\",\"legacy_subtitle_id\":9150443,\"legacy_uploader_id\":9372469,\"uploader\":{\"uploader_id\":null,\"name\":\"Anonymous\",\"rank\":\"anonymous\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/de/subtitles/legacy/9150443\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/de/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":7601680,\"cd_number\":1,\"file_name\":\"Man
-        of Steel.Full - German\"}],\"moviehash_match\":false}}]}"
+      string: !!binary |
+        4ZhsASDXNP+tWmarHEjmECDo/nnauZ3RYAvZxAgUQPY75tVdukzt1366lKSRUumWGNIN6YZ0oa1g
+        nlSj6R7vdhHVKpZEQ9FGKBayaHIJkRBhVBpD0hD/914ung1zkon/KnFyA1pP9ghH1N/NsNiTK2Ao
+        vursHWhIMJRgWFwexRcYSTB0HSmKYbTVgvnrEfwIBnqlKWOAod4vDgyU9VB9DQ4wVII9mMeBsQxe
+        cYLCgYEpA4ac4cRMBSNUMQzR3YbBw8MxnJ3NPp4GPy/WZzeCmWwoDsN5BFPz6jBMSwHDeKuVxHBN
+        adpKgiHb6uOpgCEtwTDlNA81r6WGM4gpZedPcVhsrmVIMdxfLNYlOVs/2urAACOUN5Q0VO6oNEIa
+        Iv8EDNYPB1yYItiQveNhOI7Fjhc/4RxxjLILzhYHBmYb2zS1pToXWkYobxUjS3sIa7b37R2TXTO5
+        kOI9YKjwiYMBwBDcyR7vh9IPKBiTTNARYF4sXHbGJG81ugzmET5HmLOeYYh2dmAglcauNQGGbOMF
+        DDxbluCPtvoU0f6p+ne5wBOGhU6Mhw3jAXbAvUGaqvVESTIqYqVOP6Wrd4Dh3tnMCDYcA2/118An
+        G1Ga0LY6FwDDnK7eDYmrHSOUowaN5uzn8RBjeKVIz3oMtecQOy0YfcKw5gAGzrUuxWw2t9utTYuL
+        pRetnCYC+ylvnOGmCI02RWoAldaJrW4cgo+X0kbIY3MMCAaehYBC84WmlNGcRJnCIgEgsxZlw2/+
+        ZxubNDWhlOLn0xBSmkXnAtZHqLIhG7lRm/Injwcy1NPfGCYfXOqtJs8x49GSyJ5jOI7DXtIC1gWj
+        oEJnw6G9aW+3W1vWQ7mPx3NO7THNMYMq7OJsy3mYbT2eG67d0xPGGG3uiaIKeyWdiqPLh1Tk9rZQ
+        rUnM0DtCjOCGCZL+JLWNbPUysBoVnof1e0t59fu3X/zW717hzJdba92TyqN751rrnl7g6IhnxgVj
+        yaYMkEXTBaXQK+m4JRd+uJRCqJMSAD8Y4AoCJLYfMaPf0c4waTpFUfe/wARkNEApq1/acSKogJpi
+        QlMpz4yjzNaHJa3Zvw13JRsN7Ynz2UeU+aJoShl9IEa7jkDzIVFHmxXRssNeqVx5GCNcV3p+mn5Q
+        IAwFGQmQqIbJHelNpwwhRKCOz++y/eg/vxJFZ4X22bMXzUv/xu+efZRkfhigRGhJtCVYpGcTx7dg
+        VCkOPsUsukA8C6H91eXiU2ymDClaraRWyCuV44MqwtUbQbm4Q7vLH5Vow4UhjHKjpP9PaCzFHWvK
+        Siv6HhC9YHgCi/SM4ipRM6YsLyLyKL2EUtk94dySi71SWVp4UIzrtBm/QvPKKTS0OKsd5VrRNZQy
+        CrpYvfxYcSJosiyg5cuthNYkirHli6KE1qSlVMuOhlUZIIymcyGQVyrHQ8d6nlmUmnGvr5BXfMqG
+        qIZTi8sr0YaSkKC/nqMfGKH8R/SyXhE7EzX7CCaCkFL3QvN6ZkJyqowqSlJzKpo5uHxyuQ5TiM4s
+        P84rKtIziiuQYL2+Q/Kl9ctd86YXRxqvoFIyIdUbwi8VZPBCle6Sppvqo5xmNSUmWomHkYbwhukd
+        paYjhoMGYVInJtsZnjA/l5Kr/HFMNs1+JYQ79PZd8666uSAX6+RyrBjt/OzjCVXnw8354tAl5exP
+        3uWK0Yc1F38trj6s8TTUfZ/3MeDuF1uKiyOa/v8vI0V473ERzb6ij3adHpyviJ0R47OPiBUk+34u
+        pmHB9LTrNaX8014rothRSsdn8/F4tvHoQkgZzrDqeNdJUIbK9EziGqNgSjJN7DZkc0kUkH+A5Ysh
+        oul4pbrmQ/PeVMM9AZtatUoIQzMEPCzlHzGzbwjdUW0oJyi0yqKXH5E0ijfSraxfrlnVWXKDmGHc
+        EL7P+3j1Fm3Xwy6lcMg6ofx4h2pCBb/sXq8hwgj7vI9vbRyPI0h4/93KeaxuFLTSqdWUq3Irqqne
+        Zi1Jp0hD7mzmqy/la6pV0PqPtPXh6jL6dHv2Wk22OqUu/nrKeEh3928z25im5Bg29oSG9+NdO1+u
+        8FTpUnI2JZzwSwVQ6ZDUjJw0vah1suw+kgdjDZENkzuqDWdGdLQTtue0hhHdUr6gm69n1F3Q85co
+        +6UYePxt05qPDsIMvrdY6MF1n/exX6++vtmimtB2+wz9jPy85HR1gVjv8x6KQh5TSGt2I8o4HpL8
+        3XQ6MwyrrNajLyhNE0b/rKVClg3yNYlGW6b1fjX62spp6Ga4ndxpE/2DWUhouMWzMTx3GwI69ijh
+        bwQbAgo+unTW4reULwXtTSuIdsd9+vqief4K/Yx+v9+uh9c+VJfRz2i24zXv8z6uyVpn/z3mXc8O
+        TSlW5AuKqaJDnPLhZ3ty2Euua0Xrt8J734VHI8/7Rr2gg82lnaugXjQVpOuUYMFqrlgntXtcQ7Cp
+        Nfcspng/p7U4E9v7bIPNqDTPJPpvAylJqOwFR52vQSswGDUNXHQl2PzvJw==
     headers:
       Access-Control-Allow-Headers:
       - Origin, Authorization, Accept, Api-Key, Content-Type, X-User-Agent
@@ -68,23 +60,23 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '3'
+      - '48857'
       CF-Cache-Status:
       - HIT
       CF-RAY:
-      - 87c704619891532a-LHR
+      - 883aac568d1af0bb-CDG
       Cache-Control:
       - public, max-age=86400
       Connection:
       - keep-alive
       Content-Encoding:
-      - gzip
+      - br
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 30 Apr 2024 10:58:31 GMT
+      - Tue, 14 May 2024 11:50:53 GMT
       Last-Modified:
-      - Tue, 30 Apr 2024 10:58:28 GMT
+      - Mon, 13 May 2024 22:16:36 GMT
       NEL:
       - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
       RateLimit-Limit:
@@ -94,7 +86,7 @@ interactions:
       RateLimit-Reset:
       - '1'
       Report-To:
-      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=uTdAwelq7MghY80fpFsziwOwrpVug4KVLcWnuAWlbd1zMnTzll%2B3ZCzJsVND3D%2BwlTWGwLCBDkUGF9SI6j%2F%2BeVpMKjOU1AmQgoAxB8F%2By7xWJTk7zInqVAA7Aujxa1UWZg%2BFv%2FV0BZs%3D"}],"group":"cf-nel","max_age":604800}'
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=7oYZx2oPYe%2FrXLzkMGexLa2oPBAvHPveLzIOq4wqoOtTtMQ%2Ff5FjLFizEQELizB%2F57Kav3hoKHuMczdgM15%2FkFcpndBr6kqpmj4YCjlWR%2FPzluAAWdfKtPAm5iC%2Fj7tyZj0ZFNU%2F7es%3D"}],"group":"cf-nel","max_age":604800}'
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -104,7 +96,7 @@ interactions:
       Vary:
       - Accept-Encoding
       X-Cache-Backend:
-      - apigw1_8000 rb11
+      - apigw1_8000 rb7
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -114,15 +106,17 @@ interactions:
       X-Kong-Proxy-Latency:
       - '1'
       X-Kong-Upstream-Latency:
-      - '114'
+      - '259'
       X-RateLimit-Limit-Second:
       - '5'
       X-RateLimit-Remaining-Second:
       - '3'
       X-Request-Id:
-      - 3e3b1a3f-12c0-48d3-8c29-c7eb0731399c
+      - 5bbec10f-8cfe-4ef8-845c-3460f69d8d3c
       X-Runtime:
-      - '0.111334'
+      - '0.088874'
+      X-StackifyID:
+      - V1|9166a000-6453-4931-acd6-ecf150259d01|C98087|CD1
       X-Var-Cache:
       - MISS
       X-Via:
@@ -146,7 +140,7 @@ interactions:
       Accept:
       - '*/*'
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Api-Key:
       - mij33pjc3kOlup1qOKxnWWxvle2kFbMH
       Connection:
@@ -159,48 +153,40 @@ interactions:
     uri: https://api.opensubtitles.com/api/v1/subtitles?imdb_id=770828&languages=de%2Cfr
   response:
     body:
-      string: "{\"total_pages\":1,\"total_count\":10,\"per_page\":60,\"page\":1,\"data\":[{\"id\":\"880511\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"880511\",\"language\":\"fr\",\"download_count\":35322,\"new_download_count\":264,\"hearing_impaired\":false,\"hd\":true,\"fps\":0.0,\"votes\":0,\"ratings\":0.0,\"from_trusted\":true,\"foreign_parts_only\":false,\"upload_date\":\"2013-10-18T14:26:47Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"man.of.steel.2013.720p.bluray.x264-felony.www.subsynchro.com\",\"comments\":\"\",\"legacy_subtitle_id\":5229112,\"legacy_uploader_id\":1430515,\"uploader\":{\"uploader_id\":59162,\"name\":\"smailpouri\",\"rank\":\"Trusted
-        member\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/fr/subtitles/legacy/5229112\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/fr/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":962144,\"cd_number\":1,\"file_name\":\"man.of.steel.2013.720p.bluray.x264-felony.www.subsynchro.com\"}]}},{\"id\":\"870964\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"870964\",\"language\":\"fr\",\"download_count\":22032,\"new_download_count\":89,\"hearing_impaired\":false,\"hd\":true,\"fps\":0.0,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2013-07-26T08:47:00Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Man.of.Steel.2013.720p.R6.LiNE.x264.AAC-DiGiTAL\",\"comments\":\"\",\"legacy_subtitle_id\":5105960,\"legacy_uploader_id\":0,\"uploader\":{\"uploader_id\":3282,\"name\":\"os-auto\",\"rank\":\"Application
-        Developers\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/fr/subtitles/legacy/5105960\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/fr/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":952177,\"cd_number\":1,\"file_name\":\"Man.of.Steel.2013.R6.LiNE.All.Version-fr\"}]}},{\"id\":\"879122\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"879122\",\"language\":\"fr\",\"download_count\":20172,\"new_download_count\":203,\"hearing_impaired\":false,\"hd\":true,\"fps\":23.976,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2013-10-16T16:56:06Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"man.of.steel.2013.720p.bluray.x264-felony\",\"comments\":\"\",\"legacy_subtitle_id\":5226251,\"legacy_uploader_id\":0,\"uploader\":{\"uploader_id\":3282,\"name\":\"os-auto\",\"rank\":\"Application
-        Developers\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/fr/subtitles/legacy/5226251\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/fr/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":960683,\"cd_number\":1,\"file_name\":\"man.of.steel.2013.720p.bluray.x264-felony.www.subsynchro.com\"}]}},{\"id\":\"877697\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"877697\",\"language\":\"fr\",\"download_count\":17037,\"new_download_count\":130,\"hearing_impaired\":false,\"hd\":true,\"fps\":0.0,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2013-10-16T09:35:02Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"man.of.steel.2013.1080p.bluray.x264-sector7\",\"comments\":\"\",\"legacy_subtitle_id\":5225852,\"legacy_uploader_id\":0,\"uploader\":{\"uploader_id\":3282,\"name\":\"os-auto\",\"rank\":\"Application
-        Developers\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/fr/subtitles/legacy/5225852\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/fr/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":959227,\"cd_number\":1,\"file_name\":\"man.of.steel.2013.1080p.bluray.x264-sector7\"}]}},{\"id\":\"880332\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"880332\",\"language\":\"de\",\"download_count\":7182,\"new_download_count\":216,\"hearing_impaired\":true,\"hd\":true,\"fps\":23.976,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2013-10-17T13:26:46Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Man.of.Steel.German.DL.1080p.BluRay.x264-EXQUiSiTE\",\"comments\":\"\",\"legacy_subtitle_id\":5227599,\"legacy_uploader_id\":0,\"uploader\":{\"uploader_id\":3282,\"name\":\"os-auto\",\"rank\":\"Application
-        Developers\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/de/subtitles/legacy/5227599\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/de/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":961964,\"cd_number\":1,\"file_name\":\"Man.of.Steel.German.DL.1080p.BluRay.x264-EXQUiSiTE\"}]}},{\"id\":\"883552\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"883552\",\"language\":\"de\",\"download_count\":4283,\"new_download_count\":10,\"hearing_impaired\":false,\"hd\":true,\"fps\":25.0,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2016-07-31T14:29:17Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Man
-        of Steel (2013) Dtv 2h07min\",\"comments\":\"\",\"legacy_subtitle_id\":6698593,\"legacy_uploader_id\":2563175,\"uploader\":{\"uploader_id\":69315,\"name\":\"bergert_\",\"rank\":\"Trusted
-        member\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/de/subtitles/legacy/6698593\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/de/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":965287,\"cd_number\":1,\"file_name\":\"Man
-        of Steel (DT-2013)\"}]}},{\"id\":\"880717\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"880717\",\"language\":\"de\",\"download_count\":2670,\"new_download_count\":194,\"hearing_impaired\":false,\"hd\":true,\"fps\":23.976,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2013-10-19T00:53:25Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Man.of.Steel.German.720p.BluRay.x264-EXQUiSiTE\",\"comments\":\"\",\"legacy_subtitle_id\":5229998,\"legacy_uploader_id\":0,\"uploader\":{\"uploader_id\":3282,\"name\":\"os-auto\",\"rank\":\"Application
-        Developers\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/de/subtitles/legacy/5229998\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/de/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":962352,\"cd_number\":1,\"file_name\":\"Man.of.Steel.German.720p.BluRay.x264-EXQUiSiTE\"}]}},{\"id\":\"5166256\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"5166256\",\"language\":\"de\",\"download_count\":1794,\"new_download_count\":14,\"hearing_impaired\":false,\"hd\":true,\"fps\":23.976,\"votes\":1,\"ratings\":10.0,\"from_trusted\":true,\"foreign_parts_only\":false,\"upload_date\":\"2020-03-29T11:40:37Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Man.of.Steel.2013.720p.german.srt\",\"comments\":\"--\\u003e
-        HI-Items entfernt, Timing teilweise korrigiert, Kursivsetzung korrigiert\\r\\n--\\u003e
-        passend f\xFCr Versionen mit Laufzeit 2h 23min 2s 688ms\",\"legacy_subtitle_id\":8148911,\"legacy_uploader_id\":1189705,\"uploader\":{\"uploader_id\":54111,\"name\":\"arcchancellor\",\"rank\":\"translator\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/de/subtitles/legacy/8148911\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/de/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":5276290,\"cd_number\":1,\"file_name\":\"Man.of.Steel.2013.720p.german\"}]}},{\"id\":\"883560\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"883560\",\"language\":\"de\",\"download_count\":938,\"new_download_count\":9,\"hearing_impaired\":true,\"hd\":true,\"fps\":23.976,\"votes\":2,\"ratings\":10.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2016-08-01T19:13:17Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Man
-        of Steel German DL 1080p BluRay x264-EXQUiSiTE\",\"comments\":\"Duration:
-        2:23:03\\r\\nvia SubTools from idx to srt\\r\\nFull German\\r\\nHandmade corrected\",\"legacy_subtitle_id\":6699712,\"legacy_uploader_id\":1471910,\"uploader\":{\"uploader_id\":60439,\"name\":\"PissPott\",\"rank\":\"Silver
-        Member\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/de/subtitles/legacy/6699712\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/de/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":965292,\"cd_number\":1,\"file_name\":\"exq-manofsteel-1080p.idx.mkv\"}]}},{\"id\":\"6632511\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"6632511\",\"language\":\"de\",\"download_count\":61,\"new_download_count\":7,\"hearing_impaired\":false,\"hd\":true,\"fps\":23.976,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2022-06-26T19:32:54Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Should
-        work with 4k BD rips\",\"comments\":\"Source German Retail 4k BD\\r\\nRetail
-        PGS to SSA + improvements\\r\\n\\r\\ncoloured parts\\r\\n\\r\\nIf the timing
-        is off, just correct it with SubtitleEdit.\\r\\n-\\u003e Synchronization \\r\\n-\\u003e
-        Adjust all times \\r\\n-\\u003e all lines\\r\\n\\r\\nWorks best with MPC-BE
-        + XySubFilter + madvr\\r\\nbecause there the font is not in the image,\\r\\nbut
-        at the bottom in the black bars.\",\"legacy_subtitle_id\":9150443,\"legacy_uploader_id\":9372469,\"uploader\":{\"uploader_id\":null,\"name\":\"Anonymous\",\"rank\":\"anonymous\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/de/subtitles/legacy/9150443\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/de/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":7601680,\"cd_number\":1,\"file_name\":\"Man
-        of Steel.Full - German\"}]}}]}"
+      string: !!binary |
+        4ShlASB/U/3vq5Y51QYkEwQIuhejvdlvNNhCNnsRaAHZN4zr7nd/+v1aoUCpECnVE5UhLZt2SBva
+        E8yTuH4xRCWKJtGKV0Khk02S2oV4Ia7E82Y6/aL1QtyzMdSwP7c4KX+QpSn0BDPqn2JY7MkVMBTf
+        mI0ONDUYSjAsLkeJA0YSDD89URTDaKsF888T+BEM9D0RlAKG+rA4MFDWQ/U1OMDQCZ5gnv6YzcCK
+        C5QBDEwZMNQMF2YjuZRCYIjuOvx5RZgSGM7OZh9Pg58X67MbwUw2FIfhPIKpeXUYpqWAIS3BcEkF
+        ykgwZFt9PL2vZcppHmpeS3WcM6fs/CkOi821DCmGh+Sd1qUolz/a6sAAI5Q3lDS039HOMGk69Tdg
+        sH6YbGHlYGvJQuNhOI5Njjc9oY24erILzhYHBmYb2zS1pToXWkYobxUjS3sIa7YP7T2TXTO5kOJD
+        e71e27IeykM8nnNqj2kGDP2/fjAAGII72ePD0BmJBWOaUhYBVs/J5ZCQdpwIKirdrctgniDWBEJT
+        yTBEO/f/ombrw5LW7AFDtvEODOxaVoDGtBoANwxbodgOR8oD8oF/DZLt1BMlSVQkWwv6lC7eAYYH
+        ZzMYRijHIFNLBgOfbERpQtvqXAAMc7p4N5SrZ4xQjhoUzdfP46ESGZUiPesx1F8us9OC0RuGNQcw
+        cK51KWazuV6vbVpcFGRBOW8EnlPeBOtNI9psGtUKenICW904BB/vypWGOFnHxGDgWQiIOQ6aUkZz
+        LdQLFwUAlXUqGyFMONvYpKlJpRk/n4ZqlFj0B2zoNGVDNnKjNu1PnCBkmtsPDJMPrvQuk5eZtWjJ
+        aNdhOI7DsGmB+gBRUKPzJ7YRtx+3G9YupqyIlh1mZRUkYIxw9vppeosS4fBFxSCqYXJHetMpQwip
+        fdJtG/u7bD/6z6/udoT22bMXzUv/xu+efVQoUqBEaElyS1RJJc76265Saexa0+Oany1L8EdbfYpo
+        7LsfOi4XdQKbVDkJEgtGlaKRUyyiB/QshPZ3l4tPsZmy6hC3powhVnbBKISqemKEg5JfLuOtVlJ9
+        /IdR0lC5o9IIaYgEJpygkJ8DkgmqOGCTKikY5FsgsuckbiW1QqysggRUEa7eE5SLO6hJfqtEGy4M
+        YVQdJX1nDZTijjVl9fazQPSC0QeK6IUtY4pCM6YYyigZg4i7J5xjVqLqMGx0rVGMa59Iztx0gY4Q
+        OUQgvmpHuVtERgIZGFLtDtO9ffmxgzSeh/X7cHn157ff/NbvXkGRH24ltCbDR/eVK6E1vYGjo/ah
+        Wnb2CweiSqFJjJ0LgVhZBRE61vP8ov6P15cJ/BFbNkQ1nLpW3xJtKJEQ+VmOfmKE8p/Ry3pB7EzU
+        7KPtIg0pdS8072MmJKfKe6olNadiiIPLJ5fr4PhQWl5plQZqUiUlmESwXpl1SCj66eWuEU1KeGHs
+        iirIykoxiMKkIuWl9Z0c4ItHrt4RYgQ3TBCwIPnDFj8LtNY9/aBorXsSK+OCMRVTkgoZuIJKyYQE
+        FgReVkpEFKp0VzDdrXZa0ZQsslUNGWkIb5jeUWo6YrgKBP+T9amrqim5qo2nZNPsV0K4Q2/fNe+q
+        mwtysU4ux4rRzs8+nlB1PlydLw7dpZz9ybtcMfqw5uIvxdXHNZ7+GrjP+5jw1IstxcURTf//X0YO
+        89vHRTT7ij7adXp0viJ2RozPPiJWkOz7uQCePulp12vqqO1zSnutyKJizY5Sujabj8ezjUcXQsqL
+        ejBqe9ZJiAe1qVJiIg1EwZRkmizfIV5dqM0hsCSMQ81lxsrquRaa99YQPeyBq5Ww0FoGYTyYQ4/M
+        viF0R7WhnOD/FF/08iOyVdVQrhH0cX25ZiRy6AYxw7ghfJ/38eIt2q6HXUph0jdp/HiPakJFT3m8
+        XkOGmfZ5H9/aOM7EhzwCtlYeqxvtrlJqtcZKqxXVFFa5StL5zyB8GeKrL+VrqnVh8z+krQ8Xl9En
+        s+u112p1FTkNudd4KrW7/6+ZbUxTcawb/0z3frxv57sLemp3KTlb043Ay0oRlUJSj0zB9NBJtkwv
+        1YOxhsiGyR3VhjMjOroO23Naw4iuKd+hq69n1N2h5y9R9kuxsxJs05qPTlVZfbdyIIP/Pu/j747D
+        1zdbVBPabp+hX5Gfl5wuQyz1Lfu8VzmpjymkNbsR+aHwXwq/m078hXXFXtP6gtI0YfTvWqpqckO+
+        FtFmK5yhr0ZfW9yFsJz1dnGiW/SP1hnp707PxvQCbQholk7kl0w2BBR8dCXqwR8p3xU07lSQ7bX7
+        9PVF8/wV+hX9+bBdD699qC6jX9Fsx0ve533c57PZSDf2XM8OTSlW5AuKqaLJQMXysz05zFLtWtGe
+        oPA4tXA04hnS6BN0sLm0vi+paCpI10lXc8U6qQPjGoJpO9SzmOLDnNaywo+d/bVyo4NRayolQHCg
+        KEmo7Infy6oFBjbNQ0y4/bjdftwA
     headers:
       Access-Control-Allow-Headers:
       - Origin, Authorization, Accept, Api-Key, Content-Type, X-User-Agent
@@ -209,23 +195,23 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '2'
+      - '48856'
       CF-Cache-Status:
       - HIT
       CF-RAY:
-      - 87c70462c8ae48bf-LHR
+      - 883aac56dd8bf0bb-CDG
       Cache-Control:
       - public, max-age=86400
       Connection:
       - keep-alive
       Content-Encoding:
-      - gzip
+      - br
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 30 Apr 2024 10:58:31 GMT
+      - Tue, 14 May 2024 11:50:53 GMT
       Last-Modified:
-      - Tue, 30 Apr 2024 10:58:29 GMT
+      - Mon, 13 May 2024 22:16:37 GMT
       NEL:
       - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
       RateLimit-Limit:
@@ -235,113 +221,7 @@ interactions:
       RateLimit-Reset:
       - '1'
       Report-To:
-      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=hYTpnpTzSwkST2Af9CJavG5np%2FgBhWH4rxEYRxcDkqZDeEsQ7FnJraC9cENzimvKRdmL52t%2BL4dNknfVpVuDz9y0gHpGNmbTOs7ggQI1tltcc%2FKbD58YO7SPiVPRUIZ%2FMPbAGplsyfA%3D"}],"group":"cf-nel","max_age":604800}'
-      Server:
-      - cloudflare
-      Strict-Transport-Security:
-      - max-age=15552000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-Cache-Backend:
-      - apigw1_8000 rb1-temp
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Kong-Proxy-Latency:
-      - '1'
-      X-Kong-Upstream-Latency:
-      - '63'
-      X-RateLimit-Limit-Second:
-      - '5'
-      X-RateLimit-Remaining-Second:
-      - '4'
-      X-Request-Id:
-      - 1e7d599a-2975-4830-ad98-2786dab7c67c
-      X-Runtime:
-      - '0.061490'
-      X-Var-Cache:
-      - MISS
-      X-Via:
-      - fw1
-      X-Vip:
-      - 'false'
-      X-Vip-Consumer:
-      - 'false'
-      X-Vip-User:
-      - 'false'
-      X-XSS-Protection:
-      - 1; mode=block
-      alt-svc:
-      - h3=":443"; ma=86400
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Api-Key:
-      - mij33pjc3kOlup1qOKxnWWxvle2kFbMH
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Subliminal v2.1
-    method: GET
-    uri: https://api.opensubtitles.com/api/v1/subtitles?languages=de%2Cfr&moviehash=5b8f8f4e41ccb21e
-  response:
-    body:
-      string: '{"total_pages":1,"total_count":2,"per_page":60,"page":1,"data":[{"id":"879122","type":"subtitle","attributes":{"subtitle_id":"879122","language":"fr","download_count":20172,"new_download_count":203,"hearing_impaired":false,"hd":true,"fps":23.976,"votes":0,"ratings":0.0,"from_trusted":false,"foreign_parts_only":false,"upload_date":"2013-10-16T16:56:06Z","ai_translated":false,"nb_cd":1,"machine_translated":false,"release":"man.of.steel.2013.720p.bluray.x264-felony","comments":"","legacy_subtitle_id":5226251,"legacy_uploader_id":0,"uploader":{"uploader_id":3282,"name":"os-auto","rank":"Application
-        Developers"},"feature_details":{"feature_id":580760,"feature_type":"Movie","year":2013,"title":"Man
-        of Steel","movie_name":"2013 - Man of Steel","imdb_id":770828,"tmdb_id":49521},"url":"https://www.opensubtitles.com/fr/subtitles/legacy/5226251","related_links":[{"label":"All
-        subtitles for man of steel","url":"https://www.opensubtitles.com/fr/movies/2013-man-of-steel","img_url":"https://s9.opensubtitles.com/features/0/6/7/580760.jpg"}],"files":[{"file_id":960683,"cd_number":1,"file_name":"man.of.steel.2013.720p.bluray.x264-felony.www.subsynchro.com"}],"moviehash_match":true}},{"id":"880717","type":"subtitle","attributes":{"subtitle_id":"880717","language":"de","download_count":2670,"new_download_count":194,"hearing_impaired":false,"hd":true,"fps":23.976,"votes":0,"ratings":0.0,"from_trusted":false,"foreign_parts_only":false,"upload_date":"2013-10-19T00:53:25Z","ai_translated":false,"nb_cd":1,"machine_translated":false,"release":"Man.of.Steel.German.720p.BluRay.x264-EXQUiSiTE","comments":"","legacy_subtitle_id":5229998,"legacy_uploader_id":0,"uploader":{"uploader_id":3282,"name":"os-auto","rank":"Application
-        Developers"},"feature_details":{"feature_id":580760,"feature_type":"Movie","year":2013,"title":"Man
-        of Steel","movie_name":"2013 - Man of Steel","imdb_id":770828,"tmdb_id":49521},"url":"https://www.opensubtitles.com/de/subtitles/legacy/5229998","related_links":[{"label":"All
-        subtitles for man of steel","url":"https://www.opensubtitles.com/de/movies/2013-man-of-steel","img_url":"https://s9.opensubtitles.com/features/0/6/7/580760.jpg"}],"files":[{"file_id":962352,"cd_number":1,"file_name":"Man.of.Steel.German.720p.BluRay.x264-EXQUiSiTE"}],"moviehash_match":true}}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Origin, Authorization, Accept, Api-Key, Content-Type, X-User-Agent
-      Access-Control-Allow-Methods:
-      - GET, HEAD, POST, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Age:
-      - '2'
-      CF-Cache-Status:
-      - HIT
-      CF-RAY:
-      - 87c70463ed91068a-LHR
-      Cache-Control:
-      - public, max-age=86400
-      Connection:
-      - keep-alive
-      Content-Encoding:
-      - gzip
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Tue, 30 Apr 2024 10:58:31 GMT
-      Last-Modified:
-      - Tue, 30 Apr 2024 10:58:29 GMT
-      NEL:
-      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
-      RateLimit-Limit:
-      - '5'
-      RateLimit-Remaining:
-      - '3'
-      RateLimit-Reset:
-      - '1'
-      Report-To:
-      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=pll6ahfV7MAMwiE%2FZ8GvDIv8FCgyhNbkFByJxRbYFc%2BGDZNwp7ZQDDwFnnFOmtEd0qAiDxkZwmNTNufQLkvRrwFrbs7Sg27Ess3D4PjHhnbwQANeraTsYTDJUT6ITIHtJhFEyCiTSj4%3D"}],"group":"cf-nel","max_age":604800}'
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=KUfCt05rk%2BrValiPKPPZ8CXBCBvCM1BwQDRaQN8bHt7Df53Auwk%2BbC9b20g7rlFsrMrPnYH7HTSL1UuFntLwS%2B%2BJHue4qE54A54OHy1R3j6ZjGO6FN2LpvCDDGvA4Q7hxpOoD53aIyU%3D"}],"group":"cf-nel","max_age":604800}'
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -361,15 +241,15 @@ interactions:
       X-Kong-Proxy-Latency:
       - '0'
       X-Kong-Upstream-Latency:
-      - '39'
+      - '37'
       X-RateLimit-Limit-Second:
       - '5'
       X-RateLimit-Remaining-Second:
-      - '3'
+      - '4'
       X-Request-Id:
-      - 9cb3b4d1-2a62-42db-9f56-dcf192f691dc
+      - 9f6ac863-7815-4030-80f6-2d880c903987
       X-Runtime:
-      - '0.037389'
+      - '0.035332'
       X-Var-Cache:
       - MISS
       X-Via:
@@ -393,7 +273,7 @@ interactions:
       Accept:
       - '*/*'
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Api-Key:
       - mij33pjc3kOlup1qOKxnWWxvle2kFbMH
       Connection:
@@ -403,87 +283,23 @@ interactions:
       User-Agent:
       - Subliminal v2.1
     method: GET
-    uri: https://api.opensubtitles.com/api/v1/subtitles?languages=de%2Cfr&query=man+of+steel
+    uri: https://api.opensubtitles.com/api/v1/subtitles?languages=de%2Cfr&moviehash=5b8f8f4e41ccb21e
   response:
     body:
-      string: "{\"total_pages\":1,\"total_count\":18,\"per_page\":60,\"page\":1,\"data\":[{\"id\":\"880511\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"880511\",\"language\":\"fr\",\"download_count\":35322,\"new_download_count\":264,\"hearing_impaired\":false,\"hd\":true,\"fps\":0.0,\"votes\":0,\"ratings\":0.0,\"from_trusted\":true,\"foreign_parts_only\":false,\"upload_date\":\"2013-10-18T14:26:47Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"man.of.steel.2013.720p.bluray.x264-felony.www.subsynchro.com\",\"comments\":\"\",\"legacy_subtitle_id\":5229112,\"legacy_uploader_id\":1430515,\"uploader\":{\"uploader_id\":59162,\"name\":\"smailpouri\",\"rank\":\"Trusted
-        member\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/fr/subtitles/legacy/5229112\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/fr/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":962144,\"cd_number\":1,\"file_name\":\"man.of.steel.2013.720p.bluray.x264-felony.www.subsynchro.com\"}]}},{\"id\":\"870964\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"870964\",\"language\":\"fr\",\"download_count\":22032,\"new_download_count\":89,\"hearing_impaired\":false,\"hd\":true,\"fps\":0.0,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2013-07-26T08:47:00Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Man.of.Steel.2013.720p.R6.LiNE.x264.AAC-DiGiTAL\",\"comments\":\"\",\"legacy_subtitle_id\":5105960,\"legacy_uploader_id\":0,\"uploader\":{\"uploader_id\":3282,\"name\":\"os-auto\",\"rank\":\"Application
-        Developers\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/fr/subtitles/legacy/5105960\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/fr/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":952177,\"cd_number\":1,\"file_name\":\"Man.of.Steel.2013.R6.LiNE.All.Version-fr\"}]}},{\"id\":\"879122\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"879122\",\"language\":\"fr\",\"download_count\":20172,\"new_download_count\":203,\"hearing_impaired\":false,\"hd\":true,\"fps\":23.976,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2013-10-16T16:56:06Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"man.of.steel.2013.720p.bluray.x264-felony\",\"comments\":\"\",\"legacy_subtitle_id\":5226251,\"legacy_uploader_id\":0,\"uploader\":{\"uploader_id\":3282,\"name\":\"os-auto\",\"rank\":\"Application
-        Developers\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/fr/subtitles/legacy/5226251\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/fr/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":960683,\"cd_number\":1,\"file_name\":\"man.of.steel.2013.720p.bluray.x264-felony.www.subsynchro.com\"}]}},{\"id\":\"877697\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"877697\",\"language\":\"fr\",\"download_count\":17037,\"new_download_count\":130,\"hearing_impaired\":false,\"hd\":true,\"fps\":0.0,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2013-10-16T09:35:02Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"man.of.steel.2013.1080p.bluray.x264-sector7\",\"comments\":\"\",\"legacy_subtitle_id\":5225852,\"legacy_uploader_id\":0,\"uploader\":{\"uploader_id\":3282,\"name\":\"os-auto\",\"rank\":\"Application
-        Developers\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/fr/subtitles/legacy/5225852\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/fr/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":959227,\"cd_number\":1,\"file_name\":\"man.of.steel.2013.1080p.bluray.x264-sector7\"}]}},{\"id\":\"880332\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"880332\",\"language\":\"de\",\"download_count\":7182,\"new_download_count\":216,\"hearing_impaired\":true,\"hd\":true,\"fps\":23.976,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2013-10-17T13:26:46Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Man.of.Steel.German.DL.1080p.BluRay.x264-EXQUiSiTE\",\"comments\":\"\",\"legacy_subtitle_id\":5227599,\"legacy_uploader_id\":0,\"uploader\":{\"uploader_id\":3282,\"name\":\"os-auto\",\"rank\":\"Application
-        Developers\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/de/subtitles/legacy/5227599\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/de/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":961964,\"cd_number\":1,\"file_name\":\"Man.of.Steel.German.DL.1080p.BluRay.x264-EXQUiSiTE\"}]}},{\"id\":\"883552\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"883552\",\"language\":\"de\",\"download_count\":4283,\"new_download_count\":10,\"hearing_impaired\":false,\"hd\":true,\"fps\":25.0,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2016-07-31T14:29:17Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Man
-        of Steel (2013) Dtv 2h07min\",\"comments\":\"\",\"legacy_subtitle_id\":6698593,\"legacy_uploader_id\":2563175,\"uploader\":{\"uploader_id\":69315,\"name\":\"bergert_\",\"rank\":\"Trusted
-        member\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/de/subtitles/legacy/6698593\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/de/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":965287,\"cd_number\":1,\"file_name\":\"Man
-        of Steel (DT-2013)\"}]}},{\"id\":\"4614499\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"4614499\",\"language\":\"fr\",\"download_count\":4213,\"new_download_count\":98,\"hearing_impaired\":false,\"hd\":true,\"fps\":23.976,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2018-11-01T17:26:02Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Supergirl.S04E03.720p.HDTV.x264-AVS\",\"comments\":\"\",\"legacy_subtitle_id\":7528072,\"legacy_uploader_id\":2592971,\"uploader\":{\"uploader_id\":69404,\"name\":\"maxoudela\",\"rank\":\"Gold
-        member\"},\"feature_details\":{\"feature_id\":429415,\"feature_type\":\"Episode\",\"year\":2015,\"title\":\"Man
-        of Steel\",\"movie_name\":\"Supergirl - S04E03  L'\xE2ge de l'acier\",\"imdb_id\":8685330,\"tmdb_id\":1593206,\"season_number\":4,\"episode_number\":3,\"parent_imdb_id\":4016454,\"parent_title\":\"Supergirl\",\"parent_tmdb_id\":62688,\"parent_feature_id\":15301},\"url\":\"https://www.opensubtitles.com/fr/subtitles/legacy/7528072\",\"related_links\":[{\"label\":\"All
-        subtitles for Tv Show Supergirl\",\"url\":\"https://www.opensubtitles.com/fr/features/redirect/15301\",\"img_url\":\"https://s9.opensubtitles.com/features/5/1/4/429415.jpg\"},{\"label\":\"All
-        subtitles for Episode man of steel\",\"url\":\"https://www.opensubtitles.com/fr/features/redirect/429415\"}],\"files\":[{\"file_id\":4737481,\"cd_number\":1,\"file_name\":\"Supergirl.S04E03.720p.HDTV.x264-AVS\"}]}},{\"id\":\"880717\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"880717\",\"language\":\"de\",\"download_count\":2670,\"new_download_count\":194,\"hearing_impaired\":false,\"hd\":true,\"fps\":23.976,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2013-10-19T00:53:25Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Man.of.Steel.German.720p.BluRay.x264-EXQUiSiTE\",\"comments\":\"\",\"legacy_subtitle_id\":5229998,\"legacy_uploader_id\":0,\"uploader\":{\"uploader_id\":3282,\"name\":\"os-auto\",\"rank\":\"Application
-        Developers\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/de/subtitles/legacy/5229998\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/de/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":962352,\"cd_number\":1,\"file_name\":\"Man.of.Steel.German.720p.BluRay.x264-EXQUiSiTE\"}]}},{\"id\":\"4620011\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"4620011\",\"language\":\"de\",\"download_count\":2208,\"new_download_count\":48,\"hearing_impaired\":false,\"hd\":false,\"fps\":23.976,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2018-11-09T23:18:45Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Supergirl.S04E03.HDTV.x264-SVA.de-SubCentral\",\"comments\":\"\",\"legacy_subtitle_id\":7536643,\"legacy_uploader_id\":0,\"uploader\":{\"uploader_id\":3282,\"name\":\"os-auto\",\"rank\":\"Application
-        Developers\"},\"feature_details\":{\"feature_id\":429415,\"feature_type\":\"Episode\",\"year\":2015,\"title\":\"Man
-        of Steel\",\"movie_name\":\"Supergirl - S04E03  Man of Steel\",\"imdb_id\":8685330,\"tmdb_id\":1593206,\"season_number\":4,\"episode_number\":3,\"parent_imdb_id\":4016454,\"parent_title\":\"Supergirl\",\"parent_tmdb_id\":62688,\"parent_feature_id\":15301},\"url\":\"https://www.opensubtitles.com/de/subtitles/legacy/7536643\",\"related_links\":[{\"label\":\"All
-        subtitles for Tv Show Supergirl\",\"url\":\"https://www.opensubtitles.com/de/features/redirect/15301\",\"img_url\":\"https://s9.opensubtitles.com/features/5/1/4/429415.jpg\"},{\"label\":\"All
-        subtitles for Episode man of steel\",\"url\":\"https://www.opensubtitles.com/de/features/redirect/429415\"}],\"files\":[{\"file_id\":4743011,\"cd_number\":1,\"file_name\":\"Supergirl.S04E03.HDTV.x264-SVA.de-SubCentral\"}]}},{\"id\":\"5166256\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"5166256\",\"language\":\"de\",\"download_count\":1794,\"new_download_count\":14,\"hearing_impaired\":false,\"hd\":true,\"fps\":23.976,\"votes\":1,\"ratings\":10.0,\"from_trusted\":true,\"foreign_parts_only\":false,\"upload_date\":\"2020-03-29T11:40:37Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Man.of.Steel.2013.720p.german.srt\",\"comments\":\"--\\u003e
-        HI-Items entfernt, Timing teilweise korrigiert, Kursivsetzung korrigiert\\r\\n--\\u003e
-        passend f\xFCr Versionen mit Laufzeit 2h 23min 2s 688ms\",\"legacy_subtitle_id\":8148911,\"legacy_uploader_id\":1189705,\"uploader\":{\"uploader_id\":54111,\"name\":\"arcchancellor\",\"rank\":\"translator\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/de/subtitles/legacy/8148911\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/de/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":5276290,\"cd_number\":1,\"file_name\":\"Man.of.Steel.2013.720p.german\"}]}},{\"id\":\"883560\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"883560\",\"language\":\"de\",\"download_count\":938,\"new_download_count\":9,\"hearing_impaired\":true,\"hd\":true,\"fps\":23.976,\"votes\":2,\"ratings\":10.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2016-08-01T19:13:17Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Man
-        of Steel German DL 1080p BluRay x264-EXQUiSiTE\",\"comments\":\"Duration:
-        2:23:03\\r\\nvia SubTools from idx to srt\\r\\nFull German\\r\\nHandmade corrected\",\"legacy_subtitle_id\":6699712,\"legacy_uploader_id\":1471910,\"uploader\":{\"uploader_id\":60439,\"name\":\"PissPott\",\"rank\":\"Silver
-        Member\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/de/subtitles/legacy/6699712\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/de/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":965292,\"cd_number\":1,\"file_name\":\"exq-manofsteel-1080p.idx.mkv\"}]}},{\"id\":\"6556241\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"6556241\",\"language\":\"de\",\"download_count\":550,\"new_download_count\":75,\"hearing_impaired\":false,\"hd\":false,\"fps\":0.0,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2021-10-09T01:24:06Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Man
-        of Steel\",\"comments\":\"\",\"legacy_subtitle_id\":8834730,\"legacy_uploader_id\":9055317,\"uploader\":{\"uploader_id\":null,\"name\":\"Anonymous\",\"rank\":\"anonymous\"},\"feature_details\":{\"feature_id\":1373215,\"feature_type\":\"Episode\",\"year\":2021,\"title\":\"Man
-        of Steel\",\"movie_name\":\"Superman \\u0026amp; Lois - S01E07  Man of Steel\",\"imdb_id\":11949922,\"tmdb_id\":2787118,\"season_number\":1,\"episode_number\":7,\"parent_imdb_id\":11192306,\"parent_title\":\"Superman
-        \\u0026 Lois\",\"parent_tmdb_id\":95057,\"parent_feature_id\":1205428},\"url\":\"https://www.opensubtitles.com/de/subtitles/legacy/8834730\",\"related_links\":[{\"label\":\"All
-        subtitles for Tv Show Superman \\u0026 Lois\",\"url\":\"https://www.opensubtitles.com/de/features/redirect/1205428\",\"img_url\":\"https://s9.opensubtitles.com/features/5/1/2/1373215.jpg\"},{\"label\":\"All
-        subtitles for Episode man of steel\",\"url\":\"https://www.opensubtitles.com/de/features/redirect/1373215\"}],\"files\":[{\"file_id\":7525661,\"cd_number\":1,\"file_name\":\"sal17\"}]}},{\"id\":\"2627042\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"2627042\",\"language\":\"de\",\"download_count\":404,\"new_download_count\":16,\"hearing_impaired\":false,\"hd\":false,\"fps\":25.0,\"votes\":0,\"ratings\":0.0,\"from_trusted\":true,\"foreign_parts_only\":false,\"upload_date\":\"2013-06-30T20:00:55Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Superman.Die.Abenteuer.von.Lois.und.Clark.S01E09.German.DVDRip.Retail\",\"comments\":\"\",\"legacy_subtitle_id\":5066959,\"legacy_uploader_id\":464273,\"uploader\":{\"uploader_id\":41812,\"name\":\"Ralle1\",\"rank\":\"translator\"},\"feature_details\":{\"feature_id\":172454,\"feature_type\":\"Episode\",\"year\":1993,\"title\":\"The
-        Man of Steel Bars\",\"movie_name\":\"Lois \\u0026amp; Clark: The New Adventures
-        of Superman - S01E09  \\\"Lois \\u0026amp; Clark: The New Adventures of Superman\\\"
-        The Man of Steel Bars\",\"imdb_id\":635199,\"tmdb_id\":322021,\"season_number\":1,\"episode_number\":9,\"parent_imdb_id\":106057,\"parent_title\":\"Lois
-        \\u0026 Clark: The New Adventures of Superman\",\"parent_tmdb_id\":4515,\"parent_feature_id\":8874},\"url\":\"https://www.opensubtitles.com/de/subtitles/legacy/5066959\",\"related_links\":[{\"label\":\"All
-        subtitles for Tv Show Lois \\u0026 Clark: The New Adventures of Superman\",\"url\":\"https://www.opensubtitles.com/de/features/redirect/8874\",\"img_url\":\"https://s9.opensubtitles.com/features/4/5/4/172454.jpg\"},{\"label\":\"All
-        subtitles for Episode the man of steel bars\",\"url\":\"https://www.opensubtitles.com/de/features/redirect/172454\"}],\"files\":[{\"file_id\":2701439,\"cd_number\":1,\"file_name\":\"Superman.Die.Abenteuer.von.Lois.und.Clark.S01E09.German.DVDRip.Retail\"}]}},{\"id\":\"1546744\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"1546744\",\"language\":\"fr\",\"download_count\":87,\"new_download_count\":3,\"hearing_impaired\":false,\"hd\":true,\"fps\":0.0,\"votes\":0,\"ratings\":0.0,\"from_trusted\":true,\"foreign_parts_only\":false,\"upload_date\":\"2012-05-11T12:51:44Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Standoff[1].S01E07.hdtv.xvid-xor.VF\",\"comments\":\"\",\"legacy_subtitle_id\":4545822,\"legacy_uploader_id\":1465168,\"uploader\":{\"uploader_id\":60242,\"name\":\"subth1ck\",\"rank\":\"trusted\"},\"feature_details\":{\"feature_id\":116746,\"feature_type\":\"Episode\",\"year\":2006,\"title\":\"Man
-        of Steele\",\"movie_name\":\"Standoff - S1E7 \\\"Standoff\\\" Man of Steele\",\"imdb_id\":852891,\"tmdb_id\":1210425,\"season_number\":1,\"episode_number\":7,\"parent_imdb_id\":756582,\"parent_title\":\"Standoff\",\"parent_tmdb_id\":630,\"parent_feature_id\":8050},\"url\":\"https://www.opensubtitles.com/fr/subtitles/legacy/4545822\",\"related_links\":[{\"label\":\"All
-        subtitles for Tv Show Standoff\",\"url\":\"https://www.opensubtitles.com/fr/features/redirect/8050\",\"img_url\":\"https://s9.opensubtitles.com/features/6/4/7/116746.jpg\"},{\"label\":\"All
-        subtitles for Episode man of steele\",\"url\":\"https://www.opensubtitles.com/fr/features/redirect/116746\"}],\"files\":[{\"file_id\":1638900,\"cd_number\":1,\"file_name\":\"Standoff[1].S01E07.hdtv.xvid-xor.VF\"}]}},{\"id\":\"2627058\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"2627058\",\"language\":\"de\",\"download_count\":71,\"new_download_count\":1,\"hearing_impaired\":true,\"hd\":false,\"fps\":25.0,\"votes\":0,\"ratings\":0.0,\"from_trusted\":true,\"foreign_parts_only\":false,\"upload_date\":\"2013-06-30T18:01:04Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Superman.Die.Abenteuer.von.Lois.und.Clark.S01E09.German.SDH.DVDRip.Retail\",\"comments\":\"\",\"legacy_subtitle_id\":5066960,\"legacy_uploader_id\":464273,\"uploader\":{\"uploader_id\":41812,\"name\":\"Ralle1\",\"rank\":\"administrator\"},\"feature_details\":{\"feature_id\":172454,\"feature_type\":\"Episode\",\"year\":1993,\"title\":\"The
-        Man of Steel Bars\",\"movie_name\":\"Lois \\u0026amp; Clark: The New Adventures
-        of Superman - S1E9 \\\"Lois \\u0026amp; Clark: The New Adventures of Superman\\\"
-        The Man of Steel Bars\",\"imdb_id\":635199,\"tmdb_id\":322021,\"season_number\":1,\"episode_number\":9,\"parent_imdb_id\":106057,\"parent_title\":\"Lois
-        \\u0026 Clark: The New Adventures of Superman\",\"parent_tmdb_id\":4515,\"parent_feature_id\":8874},\"url\":\"https://www.opensubtitles.com/de/subtitles/legacy/5066960\",\"related_links\":[{\"label\":\"All
-        subtitles for Tv Show Lois \\u0026 Clark: The New Adventures of Superman\",\"url\":\"https://www.opensubtitles.com/de/features/redirect/8874\",\"img_url\":\"https://s9.opensubtitles.com/features/4/5/4/172454.jpg\"},{\"label\":\"All
-        subtitles for Episode the man of steel bars\",\"url\":\"https://www.opensubtitles.com/de/features/redirect/172454\"}],\"files\":[{\"file_id\":2701455,\"cd_number\":1,\"file_name\":\"Superman.Die.Abenteuer.von.Lois.und.Clark.S01E09.German.SDH.DVDRip.Retail\"}]}},{\"id\":\"6632511\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"6632511\",\"language\":\"de\",\"download_count\":61,\"new_download_count\":7,\"hearing_impaired\":false,\"hd\":true,\"fps\":23.976,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2022-06-26T19:32:54Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Should
-        work with 4k BD rips\",\"comments\":\"Source German Retail 4k BD\\r\\nRetail
-        PGS to SSA + improvements\\r\\n\\r\\ncoloured parts\\r\\n\\r\\nIf the timing
-        is off, just correct it with SubtitleEdit.\\r\\n-\\u003e Synchronization \\r\\n-\\u003e
-        Adjust all times \\r\\n-\\u003e all lines\\r\\n\\r\\nWorks best with MPC-BE
-        + XySubFilter + madvr\\r\\nbecause there the font is not in the image,\\r\\nbut
-        at the bottom in the black bars.\",\"legacy_subtitle_id\":9150443,\"legacy_uploader_id\":9372469,\"uploader\":{\"uploader_id\":null,\"name\":\"Anonymous\",\"rank\":\"anonymous\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/de/subtitles/legacy/9150443\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/de/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":7601680,\"cd_number\":1,\"file_name\":\"Man
-        of Steel.Full - German\"}]}},{\"id\":\"823209\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"823209\",\"language\":\"de\",\"download_count\":46,\"new_download_count\":5,\"hearing_impaired\":false,\"hd\":false,\"fps\":25.0,\"votes\":0,\"ratings\":0.0,\"from_trusted\":true,\"foreign_parts_only\":false,\"upload_date\":\"2013-06-25T20:11:18Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Superman.50th.Anniversary.1988.German.DOKU.DVDRip.Retail\",\"comments\":\"\",\"legacy_subtitle_id\":5058619,\"legacy_uploader_id\":464273,\"uploader\":{\"uploader_id\":41812,\"name\":\"Ralle1\",\"rank\":\"translator\"},\"feature_details\":{\"feature_id\":584412,\"feature_type\":\"Movie\",\"year\":1988,\"title\":\"Superman's
-        50th Anniversary: A Celebration of the Man of Steel\",\"movie_name\":\"1988
-        - Superman's 50th Anniversary: A Celebration of the Man of Steel\",\"imdb_id\":303111,\"tmdb_id\":464654},\"url\":\"https://www.opensubtitles.com/de/subtitles/legacy/5058619\",\"related_links\":[{\"label\":\"All
-        subtitles for superman's 50th anniversary: a celebration of the man of steel\",\"url\":\"https://www.opensubtitles.com/de/movies/1988-superman-50th-anniversary\",\"img_url\":\"https://s9.opensubtitles.com/features/2/1/4/584412.jpg\"}],\"files\":[{\"file_id\":901498,\"cd_number\":1,\"file_name\":\"Superman.50th.Anniversary.1988.German.DOKU.DVDRip.Retail\"}]}},{\"id\":\"7164656\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"7164656\",\"language\":\"de\",\"download_count\":1,\"new_download_count\":57,\"hearing_impaired\":true,\"hd\":false,\"fps\":25.0,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2023-05-08T16:42:39Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Superman.and.Lois.S01E07.German.DL.DVDRiP.x264-NAiB\",\"comments\":\"\",\"legacy_subtitle_id\":9544178,\"legacy_uploader_id\":0,\"uploader\":{\"uploader_id\":3282,\"name\":\"os-auto\",\"rank\":\"Application
-        Developers\"},\"feature_details\":{\"feature_id\":1373215,\"feature_type\":\"Episode\",\"year\":2021,\"title\":\"Man
-        of Steel\",\"movie_name\":\"Superman \\u0026amp; Lois - S01E07  Man of Steel\",\"imdb_id\":11949922,\"tmdb_id\":2787118,\"season_number\":1,\"episode_number\":7,\"parent_imdb_id\":11192306,\"parent_title\":\"Superman
-        \\u0026 Lois\",\"parent_tmdb_id\":95057,\"parent_feature_id\":1205428},\"url\":\"https://www.opensubtitles.com/de/subtitles/legacy/9544178\",\"related_links\":[{\"label\":\"All
-        subtitles for Tv Show Superman \\u0026 Lois\",\"url\":\"https://www.opensubtitles.com/de/features/redirect/1205428\",\"img_url\":\"https://s9.opensubtitles.com/features/5/1/2/1373215.jpg\"},{\"label\":\"All
-        subtitles for Episode man of steel\",\"url\":\"https://www.opensubtitles.com/de/features/redirect/1373215\"}],\"files\":[{\"file_id\":8100472,\"cd_number\":1,\"file_name\":\"Superman.and.Lois.S01E07.German.DL.DVDRiP.x264-NAiB\"}]}}]}"
+      string: !!binary |
+        E/YIAMT/5uy/ap1TowJG6H4qY2ZYva7MxzCAG14YOTXeVrQoBS1X5B9rd3F6zqGno9F0i58HdG0g
+        D/iJFIs6HT0gma05vJxaU8QH0M3SWh5xov4VZrdnitCCXfTuQFOgJcNOgSMMuuUMT64SDKNNFvr3
+        I9wIjb5TQkowpPtO0IjHKbnkCQw+8EI/VjYxTSk8WdCYAhgUo7E8gItOMqx0NdXHqRhmssGtZ+OW
+        3bpAI/RkfSSGeYRO4SCGaY/QsipU1zJcNkxOcoZgk1vPEZoXnGEK22JSOGKSs8e0BXLn1ew2pGi2
+        1d+70I8djvOjTQQNyUWVC56L9otoddNq3v4Cg3XmvIVt3koOrSczjFanVp+UZLxQIE82EjQWuxbb
+        VMRE5AvJRVV0ku/FyR/B3oubbOt8Ir+tdzD4+3ZogMHT2Q53Y/3YRspWNoKB0EWnkCSu21AK0I+4
+        XVzJXjKsdiFobDG3R9rAEOz6Hxov9t27wSa3rdn2VKMpRDwzrDmRzHfx8HCginFMAz3vWs5KhtLC
+        t9vFERjuZEMgWBVDbG2r8dau2TZlnxORB8OyXRwZcKNJLqosz9iCbhlPPWZ3He9lz5AKD6xVI8Uz
+        wxE8NOaU9qjL8nq9FttOq/Xq4l8i8E6hTEJpQrE0KQ+nLbCJRuPd+j+OkfyjOcZC44X3mbSwbNpC
+        tkCEYjUA4MrqsYy36MWu+TblUvq45WwkdY0qE/5IiyUv27Ir7Z9/HMi0578Mk/OE3pxcxFyjWt72
+        FcMwmk3S4pMFzkIavToRuk5xvV6LeJzifR3msBXDtvSMu3DJbONsFpuGeeB6np/ZHINxzzvRUU3z
+        E+JIPbQdz69FKEV/hvrCuW4qLRsC3wKfi71dhnAj/NIfn8blzY+PX91n9+XNPPNzK6V6Qh7pzZVS
+        PT3hSIRaVo2sZpiWO7Nof58B
     headers:
       Access-Control-Allow-Headers:
       - Origin, Authorization, Accept, Api-Key, Content-Type, X-User-Agent
@@ -492,33 +308,33 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '1'
+      - '48858'
       CF-Cache-Status:
       - HIT
       CF-RAY:
-      - 87c70464fd0852ab-LHR
+      - 883aac572dd6f0bb-CDG
       Cache-Control:
       - public, max-age=86400
       Connection:
       - keep-alive
       Content-Encoding:
-      - gzip
+      - br
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 30 Apr 2024 10:58:31 GMT
+      - Tue, 14 May 2024 11:50:53 GMT
       Last-Modified:
-      - Tue, 30 Apr 2024 10:58:30 GMT
+      - Mon, 13 May 2024 22:16:35 GMT
       NEL:
       - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
       RateLimit-Limit:
       - '5'
       RateLimit-Remaining:
-      - '4'
+      - '3'
       RateLimit-Reset:
       - '1'
       Report-To:
-      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=aQsngrb%2B5MFhZKjfkMk6zg76EFnQozdj2pxbuVQIkvMUYKM5ZH4q3b6PjXreDVmnsBXd1PCPwlMlsHrlPR8lyiDiRuWt4Opr9X6GLWlH2OnWKngyWg9GmHFhWGMGe80YuJFkL4tUKKw%3D"}],"group":"cf-nel","max_age":604800}'
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=OEcaD6c736KezauGxdrSY%2FtfAgS%2BfZ2qQRJ1Mcp%2BH70EBRVGLLhhpaYGAl50q71MMHDd7mTlAINJIa0kdqHzka0%2Fqpk%2B3t2I9ov9K1X28BvXz0SSNoACKAoZ5uD1wVJDt8%2B7n%2FqBzBI%3D"}],"group":"cf-nel","max_age":604800}'
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -538,17 +354,175 @@ interactions:
       X-Kong-Proxy-Latency:
       - '0'
       X-Kong-Upstream-Latency:
-      - '132'
+      - '322'
       X-RateLimit-Limit-Second:
       - '5'
       X-RateLimit-Remaining-Second:
-      - '4'
+      - '3'
       X-Request-Id:
-      - f3905e70-b75b-4103-b9b4-abc956b02ef8
+      - 8b1792c8-8642-406c-81b5-ac72bdd7b2de
       X-Runtime:
-      - '0.129223'
+      - '0.056598'
       X-StackifyID:
-      - V1|189d3ea4-f96f-4a90-9ede-a8530b84054a|C98087|CD1
+      - V1|bb019018-c764-415a-ac55-d9a093fe8be4|C98087|CD1
+      X-Var-Cache:
+      - MISS
+      X-Via:
+      - fw1
+      X-Vip:
+      - 'false'
+      X-Vip-Consumer:
+      - 'false'
+      X-Vip-User:
+      - 'false'
+      X-XSS-Protection:
+      - 1; mode=block
+      alt-svc:
+      - h3=":443"; ma=86400
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Api-Key:
+      - mij33pjc3kOlup1qOKxnWWxvle2kFbMH
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Subliminal v2.1
+    method: GET
+    uri: https://api.opensubtitles.com/api/v1/subtitles?languages=de%2Cfr&query=man+of+steel
+  response:
+    body:
+      string: !!binary |
+        E6RYAORS0ypKUdi7n6S6G/gvkp+ZfTz7SftrSgWLkIQ1SehAULZ3yllySXzZTq6VwnyNbeUbWyA8
+        VWBhAivunpCT2032iQtEW2SFLEx9NYFCFLJCAuN4UOTNy6vKmAU/t6JlGENb/vSyfeJn1D+f/SWc
+        4sw9NrfC0YHG5R5twy+xzBKOew0N/+2iwob3oQbuf/vEU889txYUIm94fb1E7vm8PNZUh8gbXglO
+        3H+amMo+KRYoEff8WHjDc4aF2ZFCa6UaPsXn/eQtQkY1/BxDSdNpn8ZLSCX23B/DMMeGn3vua1li
+        w4+XmXvooOHXLFBiaHgJNU2nj205ljzua1nmGlMuOZeYTtP+Ekqd93kaXhdvtlxEOfl9qJF7ToCi
+        RWjRblF60l6aX3nDQ9qfbGHnQ6iS+U2P+0Nf5HjoieiMW0+JQwxz5J6PYerysZtrjENHgKIzBJfu
+        cVhKeO1eSMv2GIc8vXbPz8/dvDzOr9PhXHJ3yCNveP1vP/ecN3yIp3B43VdGVEXkEGkGmD2zWGJk
+        lAIUqkyPMRbuP/G55qIcamr4FMb6X6kxpOGSl5J4w0uYnrjn25JNxo5p1ZO/NXwUiuH+kvJA+8B/
+        BosdzILRMCtqWyv0IV9T5A1/jaFwT4Ci4W1qlbnnH8LE8pFtaowDb/iYrynu5Ro7AhSsZbO5pbF/
+        zERiY8CSbXj942ZKpwjfGr6UgXt+rvUy+9Xq+fm5y5c4NeRk8/VG4HQsq6hZFaLBqlDVvCbnEmrs
+        90OanuaNhjxZx6jc8/UwsMTh2DEXNuai2MxDAJBZs3nVCCOPYWrzsV1KX9J42mcjz9l9woKON69g
+        pVdmVf7kCULGe/vY8GMaovQWx9RmtsVpQikbfuj3h00L4APMggpdvmYb+Pbx7a1Bl5ZswGmJkzLF
+        5iACQY+fwzu0EI6vOgaYlvQWrJfGAwS9D6XbhP1edw/p6/v7PUK3Xt+2d+l92q4fAKU9ICinIb0A
+        JZ0Jsnejy3Mblpqftnl9uQzpEGrKEzv23XedWGY4gUV6bRKbWxEaI9JOcRM9QOth6H6MZU55ao8F
+        OlTtkAglZYt1A2h6EoEgJT9cEp0zGj7+wxBa1FvUXmkPmphwYSHfBzQpBA5YpNcoHORLAG1FULXR
+        zqCkTLE50IAwbwkU6h4iyW8VnBfKA4WuIdjKmlDmeKi5mPfvBcoqCu8oyqq+TEtUjshIbKM0B1G1
+        BSFwUhI6qtTH/jEknE4kbdF1gYqQK5CBuJktCrXIZRJpYqjt32E6dHcPFVT8Zli+n1Huf/7uh7RJ
+        23sq8s1tlHOhyn38zI1yLjyBfQwDB52W/RcOTVULktR3oRRKyhSbQpIVmYX6j8eXFP8Iq1swrUDV
+        6mviPAaKkR/L2T8IUPyT3dUrozOYMU19l/ahtbPKCYVJaYFGe6qvnUA1icdYTrHUveLjmuVNFDRQ
+        kV6jxGZRZI1QIX7sH3fbtmnS9MJPapQSWDkiA5GWqV/SPZIQGqqXs5c1wZiDbRFbwC2acLl0TBa1
+        WS6xnFIZug3Ie+g/un9+t/0RsHt8/eNGsaGIUWTBmFbaLylHzqC+dhLkpMbwkpc+DkEt2rPe5wEe
+        2lqSk6jGeH9Jc+4fy4MSisqetezxoDL28Pc//3eKrI9s+Hs4pFg4xxi91VYJAZixJFROEOiGzzHM
+        eerRu8uGR9mETv5CRMMvocSp7pcZVQJqqeRELLhQh8n4ZCxHkCZt7SSqjAYZKgF6F1TjPAnPZLZX
+        tjnnZyY3DykECMpW4imEqFfZ4I1h4dQKV3LVSCDpSXcjN2o2cuiMhDULosNPSUxLaWmEkRbvhQKU
+        utFq4VaqBoMGJWWKTUPawNPCORSFXbQirtsCeCU8qQA+5euefS9wztnwjeKcs0GlJBRJbaYUhIxs
+        qQnA5YVIywYidUFgMyTvcC/r8n+FNKwI6rYkPFovVSAY2II2P667Prab5fH2GB0yY+Bj/SO0lp21
+        K83IBPd7lzMjk4Qo1whkTBTeUHVfCTdP3z4GcdGZogqlAJS86VKw2vEq1JqUJtIy8bKmQeNkZkl9
+        lxZULRk7NYIjoW5I0IJoyW0RvQQvDC0jrKKaE0HrylwqlF4i23a3AIjIPv+i/aLGcWZxqsdYptqw
+        bRrTdGI1puE5pjmyp1xKOqVYasO+WsqcrnOsfyzTaarXruymBc//EuY5Tj07/vn/wtw4zj5xYmOq
+        7CEsxz9iqozOjMSYJkYz09aOc09bEYvSOnQfUBzROgMOjCUkIm5bKIfDOUyHOAy5OCBhXeIzTi7s
+        EJXpNUmccBQZTQ4096nR5qJdSQ/8szgil5CU6SU/TlBB8TtmO19GCLUQZeOppFdbXdzn6TyKCHuS
+        buzugVlQ9FjpGE0H7e6Wws4OumfkSXgQu7KbrimwzfK4zXk4FbF4qX9hNbMZpxzfLcMKk+zKbvo8
+        TP35odHHZdk/hxp7hd9wau2c8aPub4MOqaadBmnVhYRuEt+mef421+oC+Q9pk4ZrLOyDMeCxd8aJ
+        +orsota9Ihc3vvy3HcOUj8RO3bb7yXapf+nGp6tJYALWSmmS4y+ItExAlB+lFFqFZWx/9LYFQ6EO
+        Q9gitOC2gJ6kq6M2JTijN6Mi1gpphAu0sg6UEmgU/17TMgxdzkmtpzy9jnmZscAo/JnR+3nEURhB
+        av/qRbgiY5jYbgEgHcbLf9hDTrMVoD/xHky/c5KITjpHZDEcezLWIFoLQBmwDCYJIjoSoPuROBPa
+        BAVCilkDmsMpUGaiIlCSrPMDagiy2QNEMiFP1w7lKQu4ccCCVm3pyep+75SitUuCUsWNIqW1eaAv
+        cxjQPWsCJk0GpGcFkZYJNKHpTrS3mWlagXcbqwFrRSfQrYAtgQfw6gO4ZG1wit36MU41LrF01zx1
+        DznN3TL13e0QylOHGkbONSbsj3ffp0v3PaVhV+spokBrpxy2FJVakhGkqzeJFpV7E8P3YRgi8k6f
+        HRoyReJZpUBt5+gc4+pye46+FUNlN6HMmAvwFSIBwFtQeIN5tj3H6w2OGDILFoVKHwPyIHCM7ZbS
+        XTvORBQw3U4LZdAS1IjmgvYljIBeJpcDNCLjgiJzwCH/YlZftRzAKAb1g8xaIx3cYBOUw+bLPXfy
+        7ARGsrVGcl+4cHKlVnLVwnntAHKpZ62kOXtsPvJkAUohaUfgRgaw/8SimpQXl6gdyQSMSmojxyYS
+        aUnmLe6Ikx47MoDXAKPbFkY86xzUgmoRt0heoZcyzGtTw9Tn4/E3/Fglx3DTnft67V6uqW9fcul+
+        fGf1UUwqqSwNbG5erVDbhjWQHNPyWM94eNpLwOJj/Wgx1Ebq/iAA3SFPPVJxVExJWcs2eG/Y7q9d
+        3XGWmrD8DK7IOkTtiQMJQZLi4KMxSitLmIs0CVgaUf8bKwFJqEIaVBYUjJJElS2L8w0hMw8hUj+C
+        1MC2oABjw+mVXJlVE8mCzvUmy6LocO2SCHb7Ri2sA8DlJ3lzpZAT0OhOoCz9BmmZ9BX5MKgzZRkX
+        cYVx7z82Wg/oQYZesrn7nH9LGugtZ9Ry4ZRX5ef3HHjv4nMgDeGxUyqIYBOt+e7pWtB/HSLSMt2k
+        R+9NrhZe8DoLUQu6Jb1F5wV59XkanPMy9Ow5lyf2nOqZySd2c8dKusweV5E2eSmHaKCDlQUTeOzK
+        bvrb4fDt+w2rmW02a/ZvlsZLydfTXXGbd2VnaIt7yENeSuyZuh9PMfvi2KQ11eNggWlm+Xhs2O/L
+        XA1y9ixVEQ02Fe1336faeRugO81maLf9lP5w86Smm6375XmFYWBnTE2/JgnDwIY0RYnG4qdcnmZ2
+        DjBgtafdh29v25t79m/28+tmeXyXhhoL+zcbQ38tu7KbLn9bOOrQfa7nyI55qizNbMqVnZh1mDSG
+        U2ySdHWp7FK58DGD49nIa6sLbMrp6fbHw+VQgXRv+zk4YUhqZ3W4mlseUWnyVOtcHW8UNxpQW1ZP
+        Fbe6M4cbtBs4TeZHsiVBMAxJSMpkdsyH1K4PmaXeLncuXxQjtSXwiB5tWDMF9dytpyldY5lDee3Q
+        Wasx7/nffPUDdf/SldWoNh8vykqJBBYNobMWk4lJ/n1mCuqZFU98z9bsNg7x0ecjOTsDeclODRMv
+        OmtZyxYsaFjsBAhnMgKQBqGWWimZQYXxjKnNuSol1CGwg3wYFojO2na9o20V1HP7wJv8qmk8Emwj
+        0t0oRhxQOss+uW5NlNpiZBvUUjunEmnZohS4uw2t2oI31dTJRAuqBbtF7SV54V7tw9RrKpDSFyOd
+        5qF2NN+6EQ/41+t04/D/C+GUlGjGC12nccZArUEW/bCETPAQCO3fqKEB9yLkjDH+LQJIQ4jMa3sP
+        9fbx7e3jGw==
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Authorization, Accept, Api-Key, Content-Type, X-User-Agent
+      Access-Control-Allow-Methods:
+      - GET, HEAD, POST, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Age:
+      - '48856'
+      CF-Cache-Status:
+      - HIT
+      CF-RAY:
+      - 883aac577e1ff0bb-CDG
+      Cache-Control:
+      - public, max-age=86400
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - br
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 14 May 2024 11:50:53 GMT
+      Last-Modified:
+      - Mon, 13 May 2024 22:16:37 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      RateLimit-Limit:
+      - '5'
+      RateLimit-Remaining:
+      - '3'
+      RateLimit-Reset:
+      - '1'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=L10iwdY84udAPUCFERi8%2FiMluB9a4ynBTXGXKwEtmXklliTIuy8Q%2BrR1JL%2BDHDEO%2BSfOR4qnAL5quc8GBHmLvcux3FW6D9%2FtkMIf7LjlQGMc01P9F6BlX%2FEXnjoOZhcZ08OTpjN3d0s%3D"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Cache-Backend:
+      - apigw1_8000 rb11
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Kong-Proxy-Latency:
+      - '0'
+      X-Kong-Upstream-Latency:
+      - '105'
+      X-RateLimit-Limit-Second:
+      - '5'
+      X-RateLimit-Remaining-Second:
+      - '3'
+      X-Request-Id:
+      - 4d483b03-e407-47db-8a16-d85fc868517b
+      X-Runtime:
+      - '0.102130'
       X-Var-Cache:
       - MISS
       X-Via:
@@ -572,13 +546,13 @@ interactions:
       Accept:
       - '*/*'
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Api-Key:
       - mij33pjc3kOlup1qOKxnWWxvle2kFbMH
       Connection:
       - keep-alive
       Content-Length:
-      - '64'
+      - '69'
       Content-Type:
       - application/json
       User-Agent:
@@ -587,8 +561,13 @@ interactions:
     uri: https://api.opensubtitles.com/api/v1/login
   response:
     body:
-      string: '{"user":{"allowed_translations":1,"allowed_downloads":20,"level":"Sub
-        leecher","user_id":699022,"ext_installed":false,"vip":false},"token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJBcGZGZHAya09pYllGMm01cWpYRDdkUnJzSTA0WEx5bSIsImV4cCI6MTcxNDU2MTExMn0.URWWANxho_7dXQrD3OPfa-HdOI0Baf9GLXuPFugkWA4","status":200,"base_url":"api.opensubtitles.com"}'
+      string: !!binary |
+        IXQFACCXufX63uw700E0P/AG18oebOskAXeMA7dRJx1tWOxaiAaP4XNIUY5rzAe0xBvwD7CoKrqn
+        a4AusBTFkQSeZSbKWALPZRjgpEbgMNP2X4DoXPEGLHF0Ihd4qVrN5HIM8KlOFEllBQG6wP+tQCKD
+        OyX68Y+Bin2MgAO+RAbXNRqR6C2zE+o3xNXuODQiYS7eZnZIomrgSyROfkAjEnq+3r4WfjWcZtvv
+        weqqrJV7Q//5svNBOOtkMsP80No2N8UtmdIMlwWnYZYGc+c5nDuv4byVH3YzxjZe9d+nVzopDjOP
+        zVyM8FUwL+EzqelAN5evh9vOlMyx2l4mwEAqS+kROhkGtiXxpG8BcLASMuIEI6ltRSpAaThxCD8D
+        Aw==
     headers:
       Access-Control-Allow-Headers:
       - Origin, Authorization, Accept, Api-Key, Content-Type, X-User-Agent
@@ -601,17 +580,17 @@ interactions:
       CF-Cache-Status:
       - DYNAMIC
       CF-RAY:
-      - 87c70466293406cd-LHR
+      - 883aac57de6ef0bb-CDG
       Cache-Control:
       - max-age=0, private, must-revalidate, s-maxage=600
       Connection:
       - keep-alive
       Content-Encoding:
-      - gzip
+      - br
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 30 Apr 2024 10:58:32 GMT
+      - Tue, 14 May 2024 11:50:53 GMT
       NEL:
       - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
       RateLimit-Limit:
@@ -621,7 +600,7 @@ interactions:
       RateLimit-Reset:
       - '1'
       Report-To:
-      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=vpShBiyHpVtwMasfoyRDhceXmPuAQp3o2GwGJTr8hHIoNAm1sJoZepPHOHVbOllNJS4zuFD2PAI6txYTLcmCFAuxp64dAcwyZHPY3xxoh7gwj48VKpgdy2JWmDXZdZjH4ezjPUgzfN8%3D"}],"group":"cf-nel","max_age":604800}'
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=15bJ5QmNfkiKAC%2BokN%2F0lZZu9KSS2jsS7tESRdV8ioQpwof3A2tS93IhV1MAstw6gubzIPehTP%2BHeAPQnzQP31YB3uiZyEJ5pJIKMb8YnDJbpWnyMx21c6GwniF%2F9gJCP2oodxvePwI%3D"}],"group":"cf-nel","max_age":604800}'
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -629,7 +608,7 @@ interactions:
       Transfer-Encoding:
       - chunked
       X-Cache-Backend:
-      - apigw1_8000 rb1-temp
+      - apigw1_8000 rb7
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -639,7 +618,7 @@ interactions:
       X-Kong-Proxy-Latency:
       - '1'
       X-Kong-Upstream-Latency:
-      - '332'
+      - '265'
       X-RateLimit-Limit-Hour:
       - '60'
       X-RateLimit-Limit-Second:
@@ -649,9 +628,11 @@ interactions:
       X-RateLimit-Remaining-Second:
       - '0'
       X-Request-Id:
-      - b3970363-2f26-42cb-8e1c-135ebb260bcb
+      - d52cfbaf-00a9-45b4-9bdb-1b86c485c634
       X-Runtime:
-      - '0.330905'
+      - '0.263222'
+      X-StackifyID:
+      - V1|92801b86-fa64-4d5b-955d-b4ac0a2705cf|C98087|CD1
       X-Var-Cache:
       - MISS
       X-Via:
@@ -674,11 +655,11 @@ interactions:
       Accept:
       - '*/*'
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Api-Key:
       - mij33pjc3kOlup1qOKxnWWxvle2kFbMH
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJBcGZGZHAya09pYllGMm01cWpYRDdkUnJzSTA0WEx5bSIsImV4cCI6MTcxNDU2MTExMn0.URWWANxho_7dXQrD3OPfa-HdOI0Baf9GLXuPFugkWA4
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJuTXZyUk9mR1FzMWhtaWdrekxyb3lmSG00N3NaZDY5ZiIsImV4cCI6MTcxNTcyNTE3NH0.ZoWLz_yqQ5N0wYTJOey4IgmxpAuluDVywdF06IPtZgQ
       Connection:
       - keep-alive
       Content-Length:
@@ -691,9 +672,21 @@ interactions:
     uri: https://api.opensubtitles.com/api/v1/download
   response:
     body:
-      string: '{"link":"https://www.opensubtitles.com/download/4D60B13121E05BD19708EE4F18DA9159B19875AE8E5BD6E070B35260B69D51A3122B3B53C391D6366DBF91F188D0B51DFDCA4A08EF9F7034E40D634071CB7FA39FF48C6485DD707370A02840F17BA96B831BC5AF416822498A363EB6A27F1B7345FEA2ED203D2CBF70EFDBFC3F677B292D866ED85FBA85973E3A6CF86EE31BCD8191BF6E35E62ADDE611E982C3126B10136E6E10AA745C067FD969FAE48772B1C6FEF747397E117DB87BB512BC9CD5470EE9E75C50A0DCBFDB7054561068FFB59D4BAAC7AEC851DB3620C26550D293AF526AF5E8C9E706D3187AF899392ECFD2716862050DC78EF84E8E31DE2B0C0C2C527FC9742C44FFCB2888DD87D10ED1B5603E9B7B979B9FEB65218348F1D6076BF9AAC275BCCDEC95E06B61758BFAE304DD0819FB7DD1D11AAE76905BF7ABAFA86BD5ED7EA23B58EBE232E72C4EB1E91E8AFFEDDA9F8BC7DA/subfile/man.of.steel.2013.720p.bluray.x264-felony.www.subsynchro.com.srt","file_name":"man.of.steel.2013.720p.bluray.x264-felony.www.subsynchro.com.srt","requests":1,"remaining":99,"message":"Your
-        quota will be renewed in 13 hours and 01 minutes (2024-04-30 23:59:59 UTC)
-        ts=1714474712 ","reset_time":"13 hours and 01 minutes","reset_time_utc":"2024-04-30T23:59:59.000Z","uk":"app_ud_96948","uid":699022,"ts":1714474712}'
+      string: !!binary |
+        MYgRACCbadrrq+Erd7crgw0g9ioJko/Xle5Kx5qoOCqzqeCQA7d/S0RjCVjqTNtWA5/VOMzv1EW9
+        7Pvrdrm5uV6v/fLa5u142Id9bNsaP6DPviEfjFTIFL1kywhkdIIcQ/aIRXvAVMlVDBYs1+BLyeKT
+        VDAAEHKqFTlByVjIafRe0BXnWGw0VVjnJD7FiC5Q4RJ1CV4sIGvSnK0XIAJwlIqUEmt1lVwC8iFb
+        KtnWooMGiS5DtgkoZilOmDJLFm8luFjFBi5AHiBQJFfZZUGtsdaSpVhKEYu1LjI4Z0GjVJSCLqCJ
+        ZHSqzjgXWDyTRQoo4HIEkogarEMJ2gYdGTImpwMkMsY6Y6j4bHPlko0RRAM5sDZem+ANWKJkI4E1
+        BWugWq2WHG0kV7NOiTI6Y9CBy6VGzD6nGo34oNFksC5XzGA1Z1+8pwygC4q4WJ3OORpjLdZiKoI1
+        paC1gTh4TC4Kx8A1aqaayAgBCxdXCqUqyCxgciCKxTBzLpIIvEYKNoEw6QxogzdkjROboFbDEWKM
+        SQowGta2EmukkMWCzeSd8y4FyYl8CuJJtLEYSkTKVQgZOehQjE5RIkmFmLWQTc7EksGSyy5V1F5z
+        wOqFIoAp5mY7Hp6Hsd1M93O/PPfb3trYG9C2JwOv/cN4rPcf+w8G3fm5jcv8sb9er/12PGwf58eX
+        dekfl6nf1l2d1PMwttv5fmrqoqb7uV+e+21vbewNaNuTgdf+YTzW+4/9B4Pu/NzGZf7YX6/Xfjse
+        to/z48u69I/L1G/rrk5qbe+Ptu2buuiTWtt0P8zD/FZdmE9qatt2/7api/prOdbu/bHs9911GMfu
+        oXVrm9u1PXXD3GnTvSzHunX381PH3TTMx9627o0B487gz9p1xl48Xzx3v/0q33T79qMm7TGQ87ZT
+        J7W2re23+zA1dVHadC/LsW7d/fzUcTcN87G3TZ3U2ra23+7D1G6P/VFdlAHjzuDP2v1qIL2emf9W
+        J3W8Uxd1//p6ezzdMrIL6qSO4UldkBmMOalsRfLVAAM=
     headers:
       Access-Control-Allow-Headers:
       - Origin, Authorization, Accept, Api-Key, Content-Type, X-User-Agent
@@ -706,21 +699,21 @@ interactions:
       CF-Cache-Status:
       - DYNAMIC
       CF-RAY:
-      - 87c70469ecb003b9-LHR
+      - 883aac5a18d7f0bb-CDG
       Cache-Control:
       - max-age=0, private, must-revalidate, s-maxage=600
       Connection:
       - keep-alive
       Content-Encoding:
-      - gzip
+      - br
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 30 Apr 2024 10:58:32 GMT
+      - Tue, 14 May 2024 11:50:53 GMT
       Expires:
       - '0'
       Last-Modified:
-      - Tue, 30 Apr 2024 10:58:32 GMT
+      - Tue, 14 May 2024 11:50:53 GMT
       NEL:
       - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
       Pragma:
@@ -732,7 +725,7 @@ interactions:
       RateLimit-Reset:
       - '1'
       Report-To:
-      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=inzgiZ8uSNY0GOCJ687cImVFmb9D%2F9Ed3WPcRcDZQIz4kywA11G%2FzDxdAab1l9aoOr%2FgclPwyOxBIs4fltTFx%2Bu7gbu41zrfl%2Bpn0CWwqtlIdBbN7fvl9nbQNtxlH1LpupE1jxpxjT8%3D"}],"group":"cf-nel","max_age":604800}'
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=Hy%2BttxhfheOmMmjmo4qcRxfpM9uOx2Y2OWtKdkAgLpZCWptkvBJmRkjaBPnQUh8qkmyftwv7Cv%2FUBeKOILU9WnMpTowS3b931070olMH3OoBLPTiqISVMwdzy9kxg3qMFBmVX0%2Fsmh4%3D"}],"group":"cf-nel","max_age":604800}'
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -740,7 +733,7 @@ interactions:
       Transfer-Encoding:
       - chunked
       X-Cache-Backend:
-      - apigw1_8000 rb8
+      - apigw1_8000 rb11
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -750,17 +743,15 @@ interactions:
       X-Kong-Proxy-Latency:
       - '0'
       X-Kong-Upstream-Latency:
-      - '77'
+      - '15'
       X-RateLimit-Limit-Second:
       - '5'
       X-RateLimit-Remaining-Second:
       - '4'
       X-Request-Id:
-      - a78f374c-5b3f-49ea-8850-aa14b1c0eb98
+      - 63d781ba-a185-4452-b25c-f5b1a15b73c8
       X-Runtime:
-      - '0.062204'
-      X-StackifyID:
-      - V1|20938480-82a1-4271-9cda-0b65d8580dba|C98087|CD1
+      - '0.011689'
       X-Var-Cache:
       - MISS
       X-Via:
@@ -784,11 +775,11 @@ interactions:
       Accept:
       - '*/*'
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Api-Key:
       - mij33pjc3kOlup1qOKxnWWxvle2kFbMH
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJBcGZGZHAya09pYllGMm01cWpYRDdkUnJzSTA0WEx5bSIsImV4cCI6MTcxNDU2MTExMn0.URWWANxho_7dXQrD3OPfa-HdOI0Baf9GLXuPFugkWA4
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJuTXZyUk9mR1FzMWhtaWdrekxyb3lmSG00N3NaZDY5ZiIsImV4cCI6MTcxNTcyNTE3NH0.ZoWLz_yqQ5N0wYTJOey4IgmxpAuluDVywdF06IPtZgQ
       Connection:
       - keep-alive
       Content-Type:
@@ -796,1031 +787,595 @@ interactions:
       User-Agent:
       - Subliminal v2.1
     method: GET
-    uri: https://www.opensubtitles.com/download/4D60B13121E05BD19708EE4F18DA9159B19875AE8E5BD6E070B35260B69D51A3122B3B53C391D6366DBF91F188D0B51DFDCA4A08EF9F7034E40D634071CB7FA39FF48C6485DD707370A02840F17BA96B831BC5AF416822498A363EB6A27F1B7345FEA2ED203D2CBF70EFDBFC3F677B292D866ED85FBA85973E3A6CF86EE31BCD8191BF6E35E62ADDE611E982C3126B10136E6E10AA745C067FD969FAE48772B1C6FEF747397E117DB87BB512BC9CD5470EE9E75C50A0DCBFDB7054561068FFB59D4BAAC7AEC851DB3620C26550D293AF526AF5E8C9E706D3187AF899392ECFD2716862050DC78EF84E8E31DE2B0C0C2C527FC9742C44FFCB2888DD87D10ED1B5603E9B7B979B9FEB65218348F1D6076BF9AAC275BCCDEC95E06B61758BFAE304DD0819FB7DD1D11AAE76905BF7ABAFA86BD5ED7EA23B58EBE232E72C4EB1E91E8AFFEDDA9F8BC7DA/subfile/man.of.steel.2013.720p.bluray.x264-felony.www.subsynchro.com.srt
+    uri: https://www.opensubtitles.com/download/7582CF0D7A5CD3960721B0DA8D566E1506BF74F683039F85EEDC5BCF020008DBFF69B0ED6E741655C64E449C3A2FC91DBC5BAA6487E9EA1E85C30691719D35C0770047BECEEAFF4F74B0758D37ED3FE1810CA4D0D3B07ADCE4C97D9CDC53C84AFC389E0750087A74F94DC6116FFEDCE37BA6E334A90443016CF6CE64862A721BF424489C59736786C04DA07CA610346C81381A90D6B4180B72234227E5D3DF9ED22C6620D89125128520377B3A7032E6F87FF31CDA3A74FD1BB7D64226404DEFA6D5DBFA2C58162D034DF6D0319D5E557D001E6CC4AF41DDA22336FE2F6032EE633879856B4AC9A89FA197FB72C709C9E4EE7BFC699C02D877AE2999DECB70516783B0C971D0638527324C3B0FF29A0AAABCE0962913F791678DC303D754454B8CDB75B8C57C12368EA67DFC76969818E21BACA7CF0AD1C73B42AED0374D4BF6151986F5C7A002E2/subfile/man.of.steel.2013.720p.bluray.x264-felony.www.subsynchro.com.srt
   response:
     body:
-      string: "1\n00:02:11,047 --> 00:02:14,967\nNe comprenez-vous pas ?\nLe noyau
-        de Krypton s'effondre.\n\n2\n00:02:15,218 --> 00:02:18,554\nCe n'est qu'une
-        question de semaines.\nJe l'avais dit.\n\n3\n00:02:18,805 --> 00:02:22,307\nExploiter
-        le noyau, c'\xE9tait du suicide.\n\xC7a a acc\xE9l\xE9r\xE9\n\n4\n00:02:22,559
-        --> 00:02:25,269\n- le processus d'implosion.\n- Nos r\xE9serves d'\xE9nergie\n\n5\n00:02:25,520
-        --> 00:02:27,896\n\xE9taient taries.\nQu'aurions-nous d\xFB faire ?\n\n6\n00:02:28,148
-        --> 00:02:31,567\nRecourir aux \xE9toiles,\ncomme l'ont fait nos anc\xEAtres.\n\n7\n00:02:31,818
-        --> 00:02:35,696\nIl y a d'autres mondes habitables.\nCommen\xE7ons par les
-        avant-postes.\n\n8\n00:02:35,947 --> 00:02:39,658\nEnvisagez-vous s\xE9rieusement\nd'\xE9vacuer
-        toute la plan\xE8te ?\n\n9\n00:02:39,909 --> 00:02:43,328\nTout le monde ici
-        est d\xE9j\xE0 mort.\n\n10\n00:02:44,164 --> 00:02:47,708\nConfiez-moi le
-        codex\net j'assurerai la survie de notre race.\n\n11\n00:02:48,668 --> 00:02:49,751\nIl
-        reste de l'espoir.\n\n12\n00:02:50,003 --> 00:02:52,504\nJ'ai tenu cet espoir
-        entre mes mains.\n\n13\n00:03:07,437 --> 00:03:09,563\nCe conseil a \xE9t\xE9
-        dissous.\n\n14\n00:03:10,064 --> 00:03:11,899\nAu nom de quelle autorit\xE9
-        ?\n\n15\n00:03:12,275 --> 00:03:13,400\nLa mienne.\n\n16\n00:03:18,156 -->
-        00:03:21,450\nVous autres serez jug\xE9s\net punis en cons\xE9quence.\n\n17\n00:03:23,453
-        --> 00:03:25,996\n- Que fais-tu, Zod ? Tu es fou !\n- Je n'ai que trop\n\n18\n00:03:26,247
-        --> 00:03:26,914\nattendu.\n\n19\n00:03:27,165 --> 00:03:28,207\nCes l\xE9gislateurs\n\n20\n00:03:28,458
-        --> 00:03:29,541\net leurs d\xE9bats sans fin\n\n21\n00:03:29,792 --> 00:03:30,918\nont
-        conduit\n\xE0 la ruine de Krypton.\n\n22\n00:03:34,297 --> 00:03:35,964\nSi
-        tes forces triomphent,\n\n23\n00:03:36,216 --> 00:03:38,842\n- tu r\xE9gneras
-        sur du vide !\n- Alors rejoins-moi,\n\n24\n00:03:39,093 --> 00:03:42,179\naide-moi
-        \xE0 sauver notre race.\nRecommen\xE7ons \xE0 z\xE9ro.\n\n25\n00:03:42,430
-        --> 00:03:43,472\nS\xE9parons-nous\n\n26\n00:03:43,723 --> 00:03:46,475\ndes
-        lign\xE9es d\xE9g\xE9n\xE9ratives\nqui nous ont men\xE9s l\xE0.\n\n27\n00:03:46,726
-        --> 00:03:49,978\nQui d\xE9cidera\nquelles lign\xE9es survivront, Zod ?\n\n28\n00:03:51,522
-        --> 00:03:52,356\nToi ?\n\n29\n00:03:54,901 --> 00:03:56,610\nNe fais pas
-        \xE7a, El.\n\n30\n00:03:56,861 --> 00:03:59,321\nJe ne veux pas\nque nous
-        devenions ennemis.\n\n31\n00:03:59,572 --> 00:04:02,199\nTu as renonc\xE9
-        aux principes\nqui nous unissaient.\n\n32\n00:04:02,450 --> 00:04:03,450\nTu
-        t'es retourn\xE9\n\n33\n00:04:03,701 --> 00:04:05,911\ncontre les tiens.\n\n34\n00:04:06,496
-        --> 00:04:09,373\nJ'honorerai l'homme\nque tu \xE9tais jadis.\n\n35\n00:04:09,832
-        --> 00:04:11,792\nPas le monstre que tu es devenu.\n\n36\n00:04:15,088 -->
-        00:04:16,421\nEmmenez-le.\n\n37\n00:04:22,595 --> 00:04:23,929\nMonsieur,
-        tout va bien ?\n\n38\n00:04:24,180 --> 00:04:25,472\n\xC9carte-toi.\n\n39\n00:04:26,349
-        --> 00:04:26,932\nJ'ai dit...\n\n40\n00:04:43,825 --> 00:04:44,866\nAppelle
-        Lara.\n\n41\n00:04:46,202 --> 00:04:48,370\nJor, derri\xE8re toi !\n\n42\n00:04:52,250
-        --> 00:04:54,251\nLara, pr\xE9pare le lancement.\n\n43\n00:04:54,502 --> 00:04:56,169\nJe
-        te rejoins au plus vite.\n\n44\n00:05:10,977 --> 00:05:12,144\nH'Raka !\n\n45\n00:05:51,601
-        --> 00:05:54,311\n- Vois-tu le codex ?\n- Sous la branche centrale.\n\n46\n00:05:54,562
-        --> 00:05:55,687\nMais je dois vous pr\xE9venir.\n\n47\n00:05:55,938 --> 00:05:58,231\nForcer
-        la chambre de gen\xE8se\nest un crime...\n\n48\n00:05:58,483 --> 00:06:02,069\n\xC7a
-        n'a plus d'importance, Kelex.\nLe monde touche \xE0 sa fin.\n\n49\n00:07:07,218
-        --> 00:07:09,886\nJor-El,\nau nom de l'autorit\xE9 du g\xE9n\xE9ral Zod,\n\n50\n00:07:10,138
-        --> 00:07:12,013\nrendez le codex.\n\n51\n00:08:00,021 --> 00:08:01,563\nTout
-        doux, H'Raka.\n\n52\n00:08:22,502 --> 00:08:23,752\nVous avez trouv\xE9 la
-        plan\xE8te ?\n\n53\n00:08:24,337 --> 00:08:26,630\n- Oui.\n- Gravitant autour
-        d'une \xE9toile jaune,\n\n54\n00:08:29,884 --> 00:08:31,468\nUne \xE9toile
-        jeune.\n\n55\n00:08:31,844 --> 00:08:33,512\nIl se nourrira de ses radiations.\n\n56\n00:08:36,641
-        --> 00:08:38,892\nCette population semble intelligente.\n\n57\n00:08:39,810
-        --> 00:08:40,894\nIl sera un paria.\n\n58\n00:08:41,896 --> 00:08:43,313\nUn
-        monstre.\n\n59\n00:08:44,565 --> 00:08:45,357\nIls le tueront.\n\n60\n00:08:45,608
-        --> 00:08:47,025\nComment ?\n\n61\n00:08:47,902 --> 00:08:49,110\nPour eux,
-        il sera un dieu.\n\n62\n00:08:51,447 --> 00:08:53,573\nEt si le vaisseau l\xE2che
-        ?\n\n63\n00:08:54,534 --> 00:08:55,534\nIl mourra.\n\n64\n00:08:56,953 -->
-        00:08:58,286\nSeul.\n\n65\n00:09:00,081 --> 00:09:01,831\nC'est au-dessus
-        de mes forces.\n\n66\n00:09:02,083 --> 00:09:03,458\nJe pensais en \xEAtre
-        capable...\n\n67\n00:09:03,709 --> 00:09:05,460\nMaintenant qu'il est l\xE0...\n\n68\n00:09:05,920
-        --> 00:09:07,629\nKrypton est condamn\xE9e.\n\n69\n00:09:08,839 --> 00:09:10,674\nC'est
-        sa seule chance.\n\n70\n00:09:11,384 --> 00:09:13,468\nC'est le seul espoir
-        de notre peuple.\n\n71\n00:09:14,428 --> 00:09:15,637\nOui, Kelex ?\n\n72\n00:09:15,888
-        --> 00:09:17,847\nCinq vaisseaux d'attaque\narrivent de l'est.\n\n73\n00:09:18,099
-        --> 00:09:20,433\nLes d\xE9fenses de la citadelle\nsont analys\xE9es.\n\n74\n00:09:20,685
-        --> 00:09:21,601\nJe vais t\xE9l\xE9charger le codex.\n\n75\n00:09:22,353
-        --> 00:09:23,770\nAttends.\n\n76\n00:09:25,481 --> 00:09:28,358\nLaisse-moi
-        le regarder.\n\n77\n00:09:31,779 --> 00:09:34,281\nNous ne le verrons jamais
-        marcher.\n\n78\n00:09:36,701 --> 00:09:38,618\nNi ne l'entendrons nous appeler.\n\n79\n00:09:44,041
-        --> 00:09:45,458\nMais l\xE0-bas,\n\n80\n00:09:45,710 --> 00:09:47,627\nparmi
-        les \xE9toiles...\n\n81\n00:09:49,005 --> 00:09:50,505\nil vivra.\n\n82\n00:10:48,564
-        --> 00:10:49,856\nAdieu, mon fils.\n\n83\n00:10:51,192 --> 00:10:53,735\nTu
-        emportes\nnos r\xEAves et nos espoirs.\n\n84\n00:11:32,441 --> 00:11:35,235\nVisez
-        surtout les portes principales.\n\n85\n00:11:50,584 --> 00:11:51,543\nDame
-        Lara,\n\n86\n00:11:51,794 --> 00:11:54,838\n- les Phantom propulseurs sont
-        pr\xEAts.\n- Proc\xE9dez \xE0 l'allumage.\n\n87\n00:11:55,631 --> 00:11:56,631\nMon
-        g\xE9n\xE9ral.\n\n88\n00:11:56,882 --> 00:12:00,260\nUn allumage de moteur\na
-        \xE9t\xE9 rep\xE9r\xE9 dans la citadelle.\n\n89\n00:12:01,220 --> 00:12:02,637\nUn
-        lancement.\n\n90\n00:12:03,806 --> 00:12:06,182\nProt\xE9gez cette plateforme,
-        commandant.\n\n91\n00:12:18,612 --> 00:12:20,530\nJe sais que tu as vol\xE9
-        le codex.\n\n92\n00:12:21,699 --> 00:12:22,699\nRends-le\n\n93\n00:12:22,950
-        --> 00:12:24,951\net je te laisserai la vie sauve.\n\n94\n00:12:25,578 -->
-        00:12:28,121\nC'est une nouvelle chance\npour Krypton,\n\n95\n00:12:28,372
-        --> 00:12:30,707\npas seulement\npour les lign\xE9es \xE9lues.\n\n96\n00:12:32,251
-        --> 00:12:33,418\nQu'as-tu fait ?\n\n97\n00:12:33,669 --> 00:12:35,962\nNous
-        avons eu un enfant.\n\n98\n00:12:36,964 --> 00:12:38,339\nUn fils.\n\n99\n00:12:38,591
-        --> 00:12:41,593\nLa premi\xE8re naissance naturelle\ndepuis des si\xE8cles.\n\n100\n00:12:42,553
-        --> 00:12:44,262\nEt il sera libre.\n\n101\n00:12:44,764 --> 00:12:47,223\nLibre
-        de forger sa propre destin\xE9e.\n\n102\n00:12:48,100 --> 00:12:49,559\nH\xE9r\xE9sie
-        !\n\n103\n00:12:51,479 --> 00:12:52,145\nD\xE9truisez-le !\n\n104\n00:13:45,616
-        --> 00:13:46,616\nLara !\n\n105\n00:13:46,784 --> 00:13:48,159\n\xC9coutez-moi.\n\n106\n00:13:48,410
-        --> 00:13:52,038\nLe codex repr\xE9sente\nl'avenir de Krypton.\n\n107\n00:13:52,289
-        --> 00:13:54,749\nAnnulez le lancement.\n\n108\n00:14:45,634 --> 00:14:46,885\nVotre
-        fils...\n\n109\n00:14:48,178 --> 00:14:50,096\no\xF9 l'avez-vous envoy\xE9
-        ?\n\n110\n00:14:53,601 --> 00:14:55,351\nIl s'appelle\n\n111\n00:14:55,603
-        --> 00:14:56,686\nKal...\n\n112\n00:14:57,354 --> 00:14:59,188\nfils d'El.\n\n113\n00:15:02,318
-        --> 00:15:04,652\nEt il est hors de votre port\xE9e.\n\n114\n00:15:15,289
-        --> 00:15:16,789\nAbattez ce vaisseau.\n\n115\n00:15:25,132 --> 00:15:26,507\nCible
-        verrouill\xE9e.\n\n116\n00:15:38,228 --> 00:15:39,687\nRendez vos armes.\n\n117\n00:15:39,939
-        --> 00:15:42,023\nVos troupes sont cern\xE9es.\n\n118\n00:15:52,117 --> 00:15:53,576\nG\xE9n\xE9ral
-        Zod...\n\n119\n00:15:53,827 --> 00:15:56,579\npour les crimes de meurtre\net
-        de haute trahison,\n\n120\n00:15:56,830 --> 00:16:00,041\nle conseil vous
-        condamne,\nainsi que vos insurg\xE9s,\n\n121\n00:16:01,210 --> 00:16:04,671\n\xE0
-        300 cycles\nde reconditionnement somatique.\n\n122\n00:16:06,173 --> 00:16:07,966\nDes
-        derni\xE8res volont\xE9s ?\n\n123\n00:16:11,261 --> 00:16:12,220\nVous refusez
-        de nous tuer !\n\n124\n00:16:13,722 --> 00:16:15,848\nVous vous saliriez les
-        mains.\nVous pr\xE9f\xE9rez nous condamner\n\n125\n00:16:16,100 --> 00:16:18,267\nau
-        trou noir pour l'\xE9ternit\xE9.\n\n126\n00:16:20,354 --> 00:16:21,396\nJor-El
-        avait raison.\n\n127\n00:16:21,647 --> 00:16:25,316\nVous n'\xEAtes qu'une
-        bande d'imb\xE9ciles.\nTous jusqu'au dernier.\n\n128\n00:16:26,235 --> 00:16:27,402\nEt
-        vous.\n\n129\n00:16:29,113 --> 00:16:31,572\nVous pensez que votre fils\nest
-        \xE0 l'abri ?\n\n130\n00:16:32,282 --> 00:16:33,992\nJe le retrouverai.\n\n131\n00:16:34,243
-        --> 00:16:37,537\nJe r\xE9cup\xE9rerai\nce que vous nous avez vol\xE9.\n\n132\n00:16:39,957
-        --> 00:16:41,541\nJe le retrouverai.\n\n133\n00:16:42,751 --> 00:16:44,836\nJe
-        le retrouverai, Lara.\n\n134\n00:16:47,923 --> 00:16:50,466\nJe le retrouverai
-        !\n\n135\n00:18:31,693 --> 00:18:34,821\nDame Lara,\nne devriez-vous pas chercher
-        refuge ?\n\n136\n00:18:35,614 --> 00:18:38,574\nIl n'y a pas de refuge, Kelor.\n\n137\n00:18:39,535
-        --> 00:18:41,494\nJor-El avait raison.\n\n138\n00:18:43,914 --> 00:18:45,331\nC'est
-        la fin.\n\n139\n00:18:57,386 --> 00:19:00,263\nCr\xE9e un monde meilleur\nque
-        le n\xF4tre, Kal.\n\n140\n00:20:32,439 --> 00:20:33,940\nFais gaffe, abruti.\n\n141\n00:20:34,191
-        --> 00:20:36,692\nOuvre les yeux\nou tu finiras en bouillie.\n\n142\n00:20:38,695
-        --> 00:20:41,155\nO\xF9 est-ce qu'ils t'ont d\xE9gott\xE9,\nblanc-bec ?\n\n143\n00:20:41,406
-        --> 00:20:42,865\nFaut remonter la cage.\n\n144\n00:20:43,116 --> 00:20:44,659\nS\xE9curisez
-        le pont.\n\n145\n00:20:44,910 --> 00:20:47,912\nOn a re\xE7u un appel de d\xE9tresse\nd'une
-        plateforme p\xE9troli\xE8re.\n\n146\n00:20:48,163 --> 00:20:49,455\nS\xE9curisez
-        le pont.\n\n147\n00:20:54,169 --> 00:20:55,711\nLes bateaux civils, restez
-        \xE0 distance.\n\n148\n00:20:55,963 --> 00:20:58,631\nLa plateforme va exploser.\n\n149\n00:20:58,882
-        --> 00:21:01,217\nBien re\xE7u.\nEt les hommes \xE0 l'int\xE9rieur ?\n\n150\n00:21:01,468
-        --> 00:21:03,803\n- Oubliez. Ils sont morts.\n- Blanc-bec,\n\n151\n00:21:04,054
-        --> 00:21:06,097\napporte-moi mes jumelles.\n\n152\n00:21:07,641 --> 00:21:08,975\nBlanc-bec
-        !\n\n153\n00:21:17,317 --> 00:21:20,861\nC'est tout ce qui reste d'oxyg\xE8ne.\nOn
-        tiendra pas longtemps !\n\n154\n00:21:31,206 --> 00:21:33,916\nIci le garde-c\xF4te
-        6510.\nUn dernier passage et on se tire.\n\n155\n00:21:36,753 --> 00:21:38,879\nAttendez
-        !\nY a des gars sur l'h\xE9liport !\n\n156\n00:21:59,693 --> 00:22:00,860\nFais-le
-        monter.\n\n157\n00:22:01,111 --> 00:22:02,486\nFaut y aller.\n\n158\n00:22:02,738
-        --> 00:22:04,405\nAllez ! T'attends quoi ?\n\n159\n00:22:49,534 --> 00:22:51,577\n...
-        le Kansas devint un territoire ?\n\n160\n00:22:53,789 --> 00:22:54,747\nClark.\n\n161\n00:22:56,750
-        --> 00:22:57,708\nTu m'\xE9coutes ?\n\n162\n00:23:02,923 --> 00:23:04,840\nSais-tu
-        qui a colonis\xE9\n\n163\n00:23:05,092 --> 00:23:06,133\nle Kansas ?\n\n164\n00:23:19,356
-        --> 00:23:20,523\nTout va bien ?\n\n165\n00:23:41,086 --> 00:23:42,628\nClark,
-        sors de l\xE0.\n\n166\n00:23:42,879 --> 00:23:44,213\nLaissez-moi tranquille.\n\n167\n00:23:45,257
-        --> 00:23:46,841\nJ'ai appel\xE9 ta m\xE8re.\n\n168\n00:23:52,347 --> 00:23:53,347\nJe
-        suis l\xE0.\n\n169\n00:23:53,598 --> 00:23:55,558\nClark, mon ch\xE9ri.\nC'est
-        maman.\n\n170\n00:23:57,978 --> 00:23:59,019\nTu m'ouvres ?\n\n171\n00:23:59,271
-        --> 00:24:01,230\n- Il est pas normal.\n- Monstre.\n\n172\n00:24:01,481 -->
-        00:24:02,314\nPleurnicheur.\n\n173\n00:24:02,566 --> 00:24:05,025\nSes parents
-        refusent\nqu'il joue avec les autres.\n\n174\n00:24:05,277 --> 00:24:06,277\nJe
-        sais.\n\n175\n00:24:06,528 --> 00:24:07,361\nMon c\x9Cur.\n\n176\n00:24:08,530
-        --> 00:24:10,656\nComment t'aider\nsi tu n'ouvres pas ?\n\n177\n00:24:10,907
-        --> 00:24:13,242\nLe monde est trop grand, maman.\n\n178\n00:24:13,493 -->
-        00:24:15,119\nAlors, rapetisse-le.\n\n179\n00:24:21,585 --> 00:24:22,710\nConcentre-toi\nsur
-        ma voix.\n\n180\n00:24:25,255 --> 00:24:27,214\nImagine que c'est une \xEEle,\n\n181\n00:24:27,382
-        --> 00:24:29,258\ndans l'oc\xE9an.\n\n182\n00:24:30,802 --> 00:24:32,094\nTu
-        la vois ?\n\n183\n00:24:35,807 --> 00:24:36,849\nJe la vois.\n\n184\n00:24:38,185
-        --> 00:24:40,186\nNage dans sa direction, mon ch\xE9ri.\n\n185\n00:24:53,450
-        --> 00:24:55,284\nQu'est-ce qui va pas chez moi ?\n\n186\n00:26:23,456 -->
-        00:26:24,999\nTrouduc.\n\n187\n00:26:25,542 --> 00:26:27,209\nAlors, t'as
-        vu le match ?\n\n188\n00:26:27,460 --> 00:26:29,962\n- Fiche-lui la paix.\n-
-        T'es sa nana ?\n\n189\n00:26:30,213 --> 00:26:31,880\nJe veux son avis.\n\n190\n00:26:34,259
-        --> 00:26:34,925\nAllez,\n\n191\n00:26:35,176 --> 00:26:35,843\nsale merdeux.\n\n192\n00:28:16,820
-        --> 00:28:17,820\nMon fils \xE9tait l\xE0.\n\n193\n00:28:18,071 --> 00:28:20,280\nIl
-        \xE9tait dans le bus.\n\n194\n00:28:20,532 --> 00:28:23,325\n- Il a vu ce
-        que Clark a fait.\n- Je sais.\n\n195\n00:28:24,285 --> 00:28:28,288\n- Ce
-        qu'il a cru voir \xE9tait...\n- Une action divine, Jonathan.\n\n196\n00:28:29,332
-        --> 00:28:31,709\nLa providence.\n\n197\n00:28:35,463 --> 00:28:37,506\nVous
-        exag\xE9rez un peu.\n\n198\n00:28:37,757 --> 00:28:41,009\nAbsolument pas.\nLana
-        l'a vu aussi.\n\n199\n00:28:41,261 --> 00:28:42,261\nEt le petit Fordham.\n\n200\n00:28:42,512
-        --> 00:28:43,721\nCe n'est pas la premi\xE8re fois\n\n201\n00:28:43,972 -->
-        00:28:45,889\nqu'il fait une telle chose.\n\n202\n00:29:01,239 --> 00:29:03,073\nJe
-        voulais aider.\n\n203\n00:29:03,533 --> 00:29:06,285\nJe sais,\nmais on en
-        a d\xE9j\xE0 parl\xE9.\n\n204\n00:29:06,536 --> 00:29:07,828\nPas vrai ?\n\n205\n00:29:08,288
-        --> 00:29:10,998\nOn en a parl\xE9. Tu dois...\n\n206\n00:29:11,499 --> 00:29:14,918\nCette
-        partie de toi\ndoit rester secr\xE8te.\n\n207\n00:29:15,378 --> 00:29:19,256\nJ'aurais
-        d\xFB faire quoi ?\nLes laisser mourir ?\n\n208\n00:29:24,053 --> 00:29:25,471\nPeut-\xEAtre.\n\n209\n00:29:27,390
-        --> 00:29:31,393\nL'enjeu est plus important que nous\nou ceux qui nous entourent.\n\n210\n00:29:34,355
-        --> 00:29:35,731\nQuand le monde...\n\n211\n00:29:36,691 --> 00:29:40,694\nQuand
-        le monde d\xE9couvrira\ntes capacit\xE9s, \xE7a changera tout.\n\n212\n00:29:40,945
-        --> 00:29:43,530\nNos croyances, notre conception\n\n213\n00:29:43,782 -->
-        00:29:46,492\nde ce qu'est un \xEAtre humain.\nTout.\n\n214\n00:29:46,743
-        --> 00:29:49,536\nTu as vu la r\xE9action de la m\xE8re de Pete.\n\n215\n00:29:49,788
-        --> 00:29:51,997\nElle \xE9tait effray\xE9e.\n\n216\n00:29:53,124 --> 00:29:53,957\nPourquoi
-        ?\n\n217\n00:29:55,835 --> 00:29:58,670\nLes gens ont peur\nde ce qu'ils ne
-        comprennent pas.\n\n218\n00:29:58,922 --> 00:29:59,838\nElle a raison ?\n\n219\n00:30:01,966
-        --> 00:30:03,801\nC'est Dieu qui m'a fait \xE7a ?\n\n220\n00:30:05,386 -->
-        00:30:06,887\nR\xE9ponds-moi.\n\n221\n00:30:21,653 --> 00:30:23,320\nOn t'a
-        trouv\xE9 l\xE0-dedans.\n\n222\n00:30:25,281 --> 00:30:28,242\nOn s'attendait\n\xE0
-        une visite du gouvernement.\n\n223\n00:30:28,493 --> 00:30:30,452\nMais personne
-        n'est venu.\n\n224\n00:30:44,968 --> 00:30:46,635\nIl y avait \xE7a avec toi.\n\n225\n00:30:49,180
-        --> 00:30:50,556\nUn chimiste\n\n226\n00:30:50,807 --> 00:30:52,140\nde l'universit\xE9
-        du Kansas\n\n227\n00:30:52,392 --> 00:30:54,977\nm'a dit que c'\xE9tait fait\nd'une
-        mati\xE8re...\n\n228\n00:30:55,937 --> 00:30:58,689\nqui n'existait pas\ndans
-        le tableau p\xE9riodique.\n\n229\n00:31:00,650 --> 00:31:01,817\nAutrement
-        dit,\n\n230\n00:31:02,068 --> 00:31:04,319\nce n'est pas de ce monde.\n\n231\n00:31:06,447
-        --> 00:31:07,698\nEt toi non plus.\n\n232\n00:31:10,410 --> 00:31:11,952\nTu
-        es la r\xE9ponse, fiston.\n\n233\n00:31:12,203 --> 00:31:14,580\nLa r\xE9ponse
-        \xE0\n\"Sommes-nous seuls dans l'univers ?\"\n\n234\n00:31:16,749 --> 00:31:18,166\nJe
-        veux pas l'\xEAtre.\n\n235\n00:31:18,418 --> 00:31:20,294\nEt je te comprends.\n\n236\n00:31:20,879
-        --> 00:31:23,589\nCe serait un lourd fardeau\npour n'importe qui.\n\n237\n00:31:23,840
-        --> 00:31:27,259\nMais tu n'es pas n'importe qui.\nTout porte \xE0 croire...\n\n238\n00:31:28,428
-        --> 00:31:30,262\nqu'on t'a envoy\xE9 pour une raison.\n\n239\n00:31:31,514
-        --> 00:31:34,099\nTous ces bouleversements, un jour,\n\n240\n00:31:34,350
-        --> 00:31:37,686\ntu les verras comme une b\xE9n\xE9diction.\nCe jour-l\xE0,\n\n241\n00:31:37,937
-        --> 00:31:39,354\nil te faudra faire un choix.\n\n242\n00:31:39,606 --> 00:31:43,609\nLe
-        choix de t'assumer fi\xE8rement\ndevant les humains ou pas.\n\n243\n00:31:45,361
-        --> 00:31:48,030\nSi je continuais \xE0 dire\nque je suis ton fils ?\n\n244\n00:31:48,740
-        --> 00:31:50,657\nTu es mon fils.\n\n245\n00:31:55,121 --> 00:31:57,122\nMais
-        quelque part, l\xE0-bas,\n\n246\n00:31:57,832 --> 00:32:01,043\ntu as un autre
-        p\xE8re\nqui t'a donn\xE9 un autre nom.\n\n247\n00:32:04,130 --> 00:32:04,963\nIl
-        t'a envoy\xE9 ici\n\n248\n00:32:08,760 --> 00:32:12,429\nEt quitte \xE0 y
-        consacrer\nle reste de ta vie, tu te dois\n\n249\n00:32:12,680 --> 00:32:14,806\nde
-        d\xE9couvrir laquelle.\n\n250\n00:32:30,281 --> 00:32:32,449\nT'es pas l\xE0
-        pour la man\x9Cuvre ?\n\n251\n00:32:32,700 --> 00:32:34,368\nChangement de
-        programme.\n\n252\n00:32:34,619 --> 00:32:36,703\nIls ont d\xE9couvert un
-        truc \xE0 Ellesmere.\n\n253\n00:32:37,246 --> 00:32:39,915\n- Aircom s'y active
-        depuis une semaine.\n- Dans ce trou ?\n\n254\n00:32:40,166 --> 00:32:42,250\nJe
-        sais. Dingue !\n\n255\n00:32:42,502 --> 00:32:44,211\nEt y a plein d'Am\xE9ricains.\n\n256\n00:32:44,462
-        --> 00:32:47,047\nIls appellent \xE7a un objet anormal.\n\n257\n00:32:47,298
-        --> 00:32:49,549\n- Va savoir.\n- L\xE2che-moi, Ludlow. S\xE9rieux.\n\n258\n00:32:49,801
-        --> 00:32:51,593\n- Allez, Chrissie.\n- Arr\xEAte !\n\n259\n00:32:51,844 -->
-        00:32:53,261\n- Assieds-toi.\n- L\xE2che-moi.\n\n260\n00:32:53,513 --> 00:32:55,180\nLaissez-la.\n\n261\n00:32:59,519
-        --> 00:33:01,228\nSinon quoi, gros dur ?\n\n262\n00:33:01,771 --> 00:33:05,190\nSinon
-        vous devrez partir.\n\n263\n00:33:06,401 --> 00:33:09,444\nJe pense que je
-        partirai\nquand je le sentirai.\n\n264\n00:33:19,414 --> 00:33:21,081\nIl
-        se r\xE9veille.\n\n265\n00:33:28,381 --> 00:33:30,382\n\xC7a vaut pas le coup,
-        mon chou.\n\n266\n00:33:38,516 --> 00:33:40,892\nOublie pas ton pourboire,
-        connard.\n\n267\n00:33:43,062 --> 00:33:44,855\nStrike.\n\n268\n00:34:35,406
-        --> 00:34:36,823\nMerci.\n\n269\n00:34:39,118 --> 00:34:40,827\nMlle Lane.
-        Comment allez-vous ?\n\n270\n00:34:41,079 --> 00:34:43,288\n- Bien.\n- Jed
-        Eubanks, d'Arctic Cargo.\n\n271\n00:34:43,539 --> 00:34:45,791\nOn est loin
-        de la station ?\n\n272\n00:34:46,250 --> 00:34:49,336\n- Elle est apr\xE8s
-        la c\xF4te. Je vous accompagne.\n- Parfait.\n\n273\n00:34:49,587 --> 00:34:51,797\nJoe
-        va prendre vos sacs.\n\n274\n00:34:52,048 --> 00:34:53,298\nDonne-lui un coup
-        de main.\n\n275\n00:34:53,549 --> 00:34:56,051\nAttention. C'est lourd.\n\n276\n00:34:58,513
-        --> 00:35:00,138\nJe dois vous avouer, Mlle Lane,\n\n277\n00:35:00,389 -->
-        00:35:03,225\nque j'aime pas trop le Daily Planet.\n\n278\n00:35:03,643 -->
-        00:35:07,604\nMais vos papiers quand vous suiviez\nla division blind\xE9e,\n\n279\n00:35:07,855
-        --> 00:35:09,689\n\xE7a m'a vachement impressionn\xE9.\n\n280\n00:35:09,941
-        --> 00:35:13,902\nJ'ai l'angoisse de la page blanche\nsi j'ai pas mon gilet
-        pare-balles.\n\n281\n00:35:19,617 --> 00:35:20,617\nMlle Lane.\n\n282\n00:35:20,868
-        --> 00:35:23,495\nColonel Hardy, US Northcom.\nPr Emil Hamilton,\n\n283\n00:35:23,746
-        --> 00:35:24,871\nde DARPA.\n\n284\n00:35:25,123 --> 00:35:26,289\nVous \xEAtes
-        en avance.\n\n285\n00:35:26,541 --> 00:35:27,999\nOn vous attendait demain.\n\n286\n00:35:28,251
-        --> 00:35:30,710\nC'est pourquoi\nj'ai d\xE9barqu\xE9 aujourd'hui.\n\n287\n00:35:31,379
-        --> 00:35:33,547\nMettons les choses au clair.\n\n288\n00:35:33,798 --> 00:35:36,633\nJe
-        suis l\xE0 car nous sommes\nsur le sol canadien\n\n289\n00:35:36,884 --> 00:35:40,303\net
-        la cour d'appel a rejet\xE9\nl'injonction de me tenir \xE0 l'\xE9cart.\n\n290\n00:35:40,555
-        --> 00:35:42,681\nSi le concours de bites est fini,\n\n291\n00:35:42,932 -->
-        00:35:45,267\nvous me montrez votre d\xE9couverte ?\n\n292\n00:35:47,353 -->
-        00:35:48,478\nLes satellites de la NASA\n\n293\n00:35:48,729 --> 00:35:50,480\nont
-        relev\xE9 l'anomalie.\n\n294\n00:35:50,731 --> 00:35:53,191\nLa barri\xE8re
-        de glace g\xEAne l'\xE9chosondage\n\n295\n00:35:53,442 --> 00:35:55,777\n-
-        mais on voit \xE7a.\n- Un sous-marin\n\n296\n00:35:56,028 --> 00:35:56,820\nde
-        l'\xE8re sovi\xE9tique ?\n\n297\n00:35:57,071 --> 00:35:58,655\nPeu probable.
-        \xC7a fait 300 m.\n\n298\n00:35:58,906 --> 00:36:01,867\nIls n'ont rien construit
-        de si grand.\n\n299\n00:36:02,118 --> 00:36:03,368\nLe plus flippant...\n\n300\n00:36:04,579
-        --> 00:36:07,038\nLa glace qui entoure l'objet\n\n301\n00:36:07,290 --> 00:36:10,375\na
-        pr\xE8s de 20 000 ans.\n\n302\n00:36:11,836 --> 00:36:12,669\nMlle Lane !\n\n303\n00:36:14,046
-        --> 00:36:15,297\nNe vous \xE9loignez pas.\n\n304\n00:36:15,548 --> 00:36:18,633\nIl
-        fait jusqu'\xE0 - 40\xB0 la nuit.\n\n305\n00:36:18,885 --> 00:36:21,136\nOn
-        retrouverait votre corps\nqu'au printemps.\n\n306\n00:36:24,140 --> 00:36:25,640\nEt
-        voil\xE0.\n\n307\n00:36:29,228 --> 00:36:30,687\nEt pour le pipi-room ?\n\n308\n00:36:31,397
-        --> 00:36:33,023\nIl y a un seau, l\xE0.\n\n309\n00:37:07,225 --> 00:37:09,392\nO\xF9
-        vas-tu comme \xE7a ?\n\n310\n00:40:55,578 --> 00:40:57,205\nTout va bien.\n\n311\n00:40:57,371
-        --> 00:40:58,705\nTout va bien.\n\n312\n00:41:13,012 --> 00:41:14,888\nVous
-        faites une h\xE9morragie interne.\n\n313\n00:41:15,139 --> 00:41:17,515\nJe
-        dois caut\xE9riser, sinon...\n\n314\n00:41:18,684 --> 00:41:19,350\nComment...\n\n315\n00:41:19,602
-        --> 00:41:22,145\nJe peux faire des choses\nhors du commun.\n\n316\n00:41:23,147
-        --> 00:41:24,272\nPrenez ma main.\n\n317\n00:41:25,107 --> 00:41:26,691\n\xC7a
-        va faire mal.\n\n318\n00:42:28,379 --> 00:42:30,505\nCe que le colonel Hardy\net
-        son \xE9quipe\n\n319\n00:42:30,756 --> 00:42:32,257\nont pris pour\nun sous-marin
-        sovi\xE9tique\n\n320\n00:42:32,508 --> 00:42:34,968\n\xE9tait en fait bien
-        plus exotique.\n\n321\n00:42:35,219 --> 00:42:39,055\nL'analyse isotopique
-        de la glace\nsugg\xE8re qu'un objet\n\n322\n00:42:39,306 --> 00:42:43,142\na
-        \xE9t\xE9 pris dans le glacier\npendant plus de 18000 ans.\n\n323\n00:42:43,394
-        --> 00:42:44,936\nMon sauveur, quant \xE0 lui,\n\n324\n00:42:45,187 --> 00:42:47,564\na
-        disparu lors du d\xE9part de l'objet.\n\n325\n00:42:47,982 --> 00:42:50,358\nJ'ai
-        d\xE9couvert que son parcours\n\n326\n00:42:50,609 --> 00:42:52,694\net son
-        identit\xE9 avaient \xE9t\xE9 falsifi\xE9s.\n\n327\n00:42:52,945 --> 00:42:54,821\nLes
-        questions que son existence soul\xE8ve\n\n328\n00:42:55,072 --> 00:42:56,906\nsont
-        terrifiantes\n\n329\n00:42:57,157 --> 00:42:58,783\nmais je sais ce que j'ai
-        vu.\n\n330\n00:43:00,703 --> 00:43:03,288\n\"J'en suis arriv\xE9e\n\xE0 la
-        conclusion in\xE9luctable\n\n331\n00:43:03,539 --> 00:43:05,540\n\"que l'objet
-        et son occupant\n\n332\n00:43:05,791 --> 00:43:07,709\n\"ne sont pas terrestres.\"\n\n333\n00:43:09,461
-        --> 00:43:12,755\nJe ne peux pas publier\nle fruit d'une hallucination.\n\n334\n00:43:13,007
-        --> 00:43:15,091\nLes entrepreneurs ont corrobor\xE9...\n\n335\n00:43:15,342
-        --> 00:43:18,511\nLe Pentagone nie\nla pr\xE9sence d'un vaisseau.\n\n336\n00:43:18,762
-        --> 00:43:20,597\n\xC9videmment.\nC'est son travail.\n\n337\n00:43:20,848
-        --> 00:43:22,348\nC'est le Pentagone.\n\n338\n00:43:22,600 --> 00:43:24,267\nPerry,
-        voyons. C'est moi.\n\n339\n00:43:24,518 --> 00:43:27,186\n- J'ai eu le Pulitzer.\n-
-        Agis en cons\xE9quence.\n\n340\n00:43:27,438 --> 00:43:29,564\n- Publiez ou
-        je pars.\n- Impossible.\n\n341\n00:43:29,815 --> 00:43:30,857\nTu es sous
-        contrat.\n\n342\n00:43:33,319 --> 00:43:37,322\nJe ne publierai pas un article\nsur
-        la pr\xE9sence d'aliens parmi nous.\n\n343\n00:43:43,621 --> 00:43:45,204\nNe
-        compte pas sur moi.\n\n344\n00:43:48,459 --> 00:43:50,835\nUn whisky sec pour
-        la petite dame.\n\n345\n00:43:51,086 --> 00:43:52,378\nJe t'envoie l'article.\n\n346\n00:43:52,630
-        --> 00:43:55,089\nS'il pouvait se retrouver sur le Net...\n\n347\n00:43:55,341
-        --> 00:43:56,633\nC'est bon.\n\n348\n00:43:56,884 --> 00:43:59,302\nCe n'est
-        pas toi\nqui qualifiais mon site\n\n349\n00:43:59,553 --> 00:44:02,347\nde
-        tissu naus\xE9abond de mensonges.\n\n350\n00:44:02,931 --> 00:44:05,516\nJe
-        maintiens mes propos, Woodburn,\nmais je veux\n\n351\n00:44:05,768 --> 00:44:06,934\n-
-        le publier.\n- Pourquoi ?\n\n352\n00:44:07,978 --> 00:44:11,314\nPour que
-        mon homme-myst\xE8re\nsache que je connais la v\xE9rit\xE9.\n\n353\n00:44:25,663
-        --> 00:44:27,622\nDiagnostics r\xE9cursifs termin\xE9s.\n\n354\n00:44:28,457
-        --> 00:44:30,667\nPr\xE9sence pilote authentifi\xE9e.\n\n355\n00:44:30,918
-        --> 00:44:33,461\nTous syst\xE8mes op\xE9rationnels.\n\n356\n00:44:45,557
-        --> 00:44:49,477\nTe voir devant moi,\naujourd'hui adulte...\n\n357\n00:44:51,730
-        --> 00:44:53,564\nSi Lara avait pu voir \xE7a.\n\n358\n00:44:54,692 --> 00:44:55,900\nQui
-        \xEAtes-vous ?\n\n359\n00:44:56,902 --> 00:44:58,861\nJe suis ton p\xE8re,
-        Kal.\n\n360\n00:45:00,239 --> 00:45:02,115\nOu du moins, son ombre.\n\n361\n00:45:02,616
-        --> 00:45:04,325\nSa conscience.\n\n362\n00:45:06,120 --> 00:45:09,205\nJe
-        m'appelais Jor-El.\n\n363\n00:45:11,875 --> 00:45:13,501\nEt Kal ?\n\n364\n00:45:16,755
-        --> 00:45:17,964\nC'est mon nom.\n\n365\n00:45:18,841 --> 00:45:22,051\nKal-El.
-        Oui.\n\n366\n00:45:22,761 --> 00:45:24,804\nJ'ai tellement de questions.\n\n367\n00:45:27,516
-        --> 00:45:29,142\nJe viens d'o\xF9 ?\n\n368\n00:45:30,853 --> 00:45:32,729\nPourquoi
-        m'avoir envoy\xE9 ici ?\n\n369\n00:45:33,564 --> 00:45:35,440\nTu viens de
-        Krypton.\n\n370\n00:45:38,152 --> 00:45:42,155\nUn monde \xE0 l'environnement\nbien
-        plus rigoureux que sur Terre.\n\n371\n00:45:45,951 --> 00:45:47,577\nIl y
-        a longtemps,\n\n372\n00:45:47,828 --> 00:45:50,037\nen pleine \xE8re d'expansion,\n\n373\n00:45:50,289
-        --> 00:45:53,499\nnotre race a parcouru les \xE9toiles\n\n374\n00:45:53,751
-        --> 00:45:56,461\nen qu\xEAte de nouveaux mondes\nsur lesquels s'\xE9tablir.\n\n375\n00:45:57,588
-        --> 00:46:01,090\nDes milliers de vaisseaux comme celui-ci\nont \xE9t\xE9
-        envoy\xE9s dans l'espace.\n\n376\n00:46:03,677 --> 00:46:06,262\nOn a b\xE2ti
-        des avant-postes\nsur des plan\xE8tes\n\n377\n00:46:06,513 --> 00:46:10,224\navec
-        des machines\nqui les refa\xE7onnaient \xE0 nos besoins.\n\n378\n00:46:12,436
-        --> 00:46:16,439\nPendant 100 000 ans,\nnotre civilisation a prosp\xE9r\xE9...\n\n379\n00:46:17,983
-        --> 00:46:19,984\naccomplissant des merveilles.\n\n380\n00:46:21,153 --> 00:46:22,779\nQue
-        s'est-il pass\xE9 ?\n\n381\n00:46:24,782 --> 00:46:27,867\nUn contr\xF4le
-        artificiel de la population\na \xE9t\xE9 \xE9tabli.\n\n382\n00:46:28,577 -->
-        00:46:32,205\nLes avant-postes d'exploration spatiale\nont \xE9t\xE9 abandonn\xE9s.\n\n383\n00:46:32,790
-        --> 00:46:35,374\nNous avons \xE9puis\xE9\nnos ressources naturelles.\n\n384\n00:46:35,626
-        --> 00:46:39,629\nR\xE9sultat, le noyau de notre plan\xE8te\nest devenu instable.\n\n385\n00:46:42,090
-        --> 00:46:44,634\nUn jour, le chef de notre arm\xE9e,\n\n386\n00:46:44,885
-        --> 00:46:48,763\nle g\xE9n\xE9ral Zod,\na tent\xE9 un coup d'\xC9tat.\n\n387\n00:46:50,724
-        --> 00:46:52,892\nMais il \xE9tait d\xE9j\xE0 trop tard.\n\n388\n00:46:54,144
-        --> 00:46:56,771\nTa m\xE8re et moi\navions pr\xE9vu le d\xE9sastre\n\n389\n00:46:57,022
-        --> 00:46:59,816\net avons fait en sorte\nd'assurer ta survie.\n\n390\n00:47:01,902
-        --> 00:47:03,528\nVoici une chambre de gen\xE8se.\n\n391\n00:47:04,404 -->
-        00:47:07,532\nTous les Kryptoniens \xE9taient con\xE7us\ndans de telles chambres.\n\n392\n00:47:07,783
-        --> 00:47:11,494\nChaque enfant avait\nun r\xF4le pr\xE9d\xE9termin\xE9 dans
-        la soci\xE9t\xE9.\n\n393\n00:47:11,745 --> 00:47:12,578\nOuvrier,\n\n394\n00:47:12,830
-        --> 00:47:15,957\nguerrier, chef, et cetera.\n\n395\n00:47:16,208 --> 00:47:19,460\nPour
-        ta m\xE8re et moi,\nKrypton avait perdu une chose pr\xE9cieuse.\n\n396\n00:47:19,711
-        --> 00:47:21,921\nLa part de choix, de hasard.\n\n397\n00:47:22,422 --> 00:47:24,590\nEt
-        si un enfant avait d'autres r\xEAves\n\n398\n00:47:24,842 --> 00:47:27,343\nque
-        ceux impos\xE9s par la soci\xE9t\xE9 ?\n\n399\n00:47:28,887 --> 00:47:31,472\nS'il
-        avait de plus grandes aspirations ?\n\n400\n00:47:32,266 --> 00:47:34,267\nTu
-        incarnais cette conviction.\n\n401\n00:47:34,518 --> 00:47:36,978\nEnfin une
-        naissance naturelle\nsur Krypton.\n\n402\n00:47:38,105 --> 00:47:40,773\nC'est
-        pourquoi nous avons tout risqu\xE9\npour te sauver.\n\n403\n00:47:41,900 -->
-        00:47:43,317\nIl fallait m'accompagner.\n\n404\n00:47:46,864 --> 00:47:48,614\nNous
-        ne pouvions pas.\n\n405\n00:47:49,658 --> 00:47:50,658\nM\xEAme si\n\n406\n00:47:50,909
-        --> 00:47:52,118\nnous le d\xE9sirions ardemment.\n\n407\n00:47:52,619 -->
-        00:47:54,620\nM\xEAme si nous t'aimions plus que tout.\n\n408\n00:47:55,372
-        --> 00:47:56,747\nTa m\xE8re Lara et moi\n\n409\n00:47:56,999 --> 00:48:00,126\n\xE9tions
-        le r\xE9sultat des erreurs\nde notre monde, comme Zod.\n\n410\n00:48:00,377
-        --> 00:48:02,044\nLi\xE9s \xE0 son destin.\n\n411\n00:48:02,296 --> 00:48:04,338\n-
-        Donc, je suis seul.\n- Non.\n\n412\n00:48:06,091 --> 00:48:09,760\nAujourd'hui,
-        tu es autant\nun enfant de la Terre que de Krypton.\n\n413\n00:48:10,012 -->
-        00:48:13,180\nTu peux incarner\nle meilleur de ces deux mondes.\n\n414\n00:48:13,432
-        --> 00:48:17,059\nTa m\xE8re et moi avons vou\xE9 notre vie\n\xE0 pr\xE9server
-        ce r\xEAve.\n\n415\n00:48:21,607 --> 00:48:24,567\nIl est vrai que les Terriens\nsont
-        diff\xE9rents.\n\n416\n00:48:24,818 --> 00:48:27,737\nMais finalement,\nc'est
-        une bonne chose.\n\n417\n00:48:27,988 --> 00:48:30,406\nIls ne commettront
-        pas forc\xE9ment\nnos erreurs.\n\n418\n00:48:30,657 --> 00:48:32,617\nPas
-        si tu les guides.\n\n419\n00:48:34,202 --> 00:48:36,245\nPas si tu leur donnes
-        de l'espoir.\n\n420\n00:48:39,666 --> 00:48:41,834\nC'est ce que ce symbole
-        signifie.\n\n421\n00:48:42,544 --> 00:48:44,879\nLe symbole des El signifie
-        espoir.\n\n422\n00:48:45,130 --> 00:48:47,632\nIl renferme la certitude fondamentale\n\n423\n00:48:47,883
-        --> 00:48:51,802\nque chacun a le potentiel\nd'\xEAtre une force du bien.\n\n424\n00:48:52,930
-        --> 00:48:54,972\nVoil\xE0 ce que tu peux leur apporter.\n\n425\n00:49:15,160
-        --> 00:49:16,994\nPourquoi suis-je si diff\xE9rent ?\n\n426\n00:49:18,246
-        --> 00:49:20,748\nLeur soleil est plus jeune,\nplus \xE9clatant que celui
-        de Krypton.\n\n427\n00:49:22,668 --> 00:49:25,044\nTes cellules ont bu ses
-        radiations,\n\n428\n00:49:25,295 --> 00:49:29,298\nfortifiant tes muscles,\nta
-        peau, tes sens.\n\n429\n00:49:29,841 --> 00:49:33,844\nLa gravit\xE9 terrestre
-        est faible\nmais son atmosph\xE8re est nourrissante.\n\n430\n00:49:35,138
-        --> 00:49:38,140\nIci, tu es devenu plus fort\nque je n'aurais pu l'imaginer.\n\n431\n00:49:38,392
-        --> 00:49:39,976\nPour savoir \xE0 quel point...\n\n432\n00:49:41,061 -->
-        00:49:44,188\ntu dois continuer \xE0 tester tes limites.\n\n433\n00:50:36,450
-        --> 00:50:40,453\nTu donneras aux Terriens\nun id\xE9al \xE0 atteindre.\n\n434\n00:50:42,122
-        --> 00:50:43,914\nIls se rueront derri\xE8re toi.\n\n435\n00:50:44,166 -->
-        00:50:45,541\nIls tr\xE9bucheront.\n\n436\n00:50:45,792 --> 00:50:46,917\nIls
-        tomberont.\n\n437\n00:50:47,169 --> 00:50:48,878\nMais le moment venu...\n\n438\n00:50:50,422
-        --> 00:50:53,049\nils te rejoindront dans le soleil.\n\n439\n00:50:54,551
-        --> 00:50:56,260\nLe moment venu,\n\n440\n00:50:56,595 --> 00:50:59,180\ntu
-        les aideras\n\xE0 accomplir des miracles.\n\n441\n00:52:21,596 --> 00:52:25,558\nComment
-        retrouver quelqu'un\nqui a toujours brouill\xE9 les pistes ?\n\n442\n00:52:25,934
-        --> 00:52:27,560\nEn commen\xE7ant\npar les l\xE9gendes urbaines\n\n443\n00:52:27,811
-        --> 00:52:30,146\nqu'il a suscit\xE9es.\n\n444\n00:52:30,397 --> 00:52:31,772\nLes
-        amis de quelqu'un\n\n445\n00:52:32,023 --> 00:52:34,024\nqui pr\xE9tend l'avoir
-        vu.\n\n446\n00:52:34,276 --> 00:52:37,111\nPour certains, c'\xE9tait un ange
-        gardien.\nPour d'autres, une \xE9nigme,\n\n447\n00:52:37,362 --> 00:52:39,113\nun
-        fant\xF4me,\ntoujours un peu \xE0 l'\xE9cart.\n\n448\n00:52:41,741 --> 00:52:42,950\nVers
-        la plateforme...\n\n449\n00:52:43,201 --> 00:52:46,328\nEn remontant le temps,\nles
-        histoires finissent par prendre corps.\n\n450\n00:52:47,080 --> 00:52:49,123\nVous
-        connaissez Pete Ross ?\n\n451\n00:52:49,374 --> 00:52:52,209\nIl travaille
-        au IHOP.\nPlus bas...\n\n452\n00:52:54,129 --> 00:52:54,837\nPete Ross ?\n\n453\n00:52:57,174
-        --> 00:53:00,384\nJ'aimerais vous parler\nd'un accident dans votre enfance.\n\n454\n00:53:00,635
-        --> 00:53:03,137\nUn bus scolaire,\ntomb\xE9 dans le fleuve ?\n\n455\n00:53:08,643
-        --> 00:53:10,060\nDusty.\n\n456\n00:53:10,937 --> 00:53:11,979\nMme Kent ?\n\n457\n00:53:12,939
-        --> 00:53:15,399\nJe suis Lois Lane, du Daily Planet.\n\n458\n00:53:15,942
-        --> 00:53:16,650\nTais-toi.\n\n459\n00:53:18,278 --> 00:53:21,739\nJe travaille
-        au Daily Planet.\nJ'aimerais parler de votre fils.\n\n460\n00:53:39,841 -->
-        00:53:43,844\nJ'ai pens\xE9 que si je fouinais partout,\nvous me trouveriez.\n\n461\n00:53:49,434
-        --> 00:53:52,478\nD'o\xF9 venez-vous ?\nDans quel but ?\n\n462\n00:53:52,729
-        --> 00:53:54,063\nJe veux raconter votre histoire.\n\n463\n00:53:54,314 -->
-        00:53:57,441\nSi je ne veux pas qu'on la raconte ?\n\n464\n00:53:57,692 -->
-        00:53:59,485\nElle finira par sortir.\n\n465\n00:53:59,736 --> 00:54:02,780\nQuelqu'un
-        tombera sur une photo,\nvotre adresse.\n\n466\n00:54:03,031 --> 00:54:05,991\n-
-        Je dispara\xEEtrai \xE0 nouveau.\n- Le seul moyen serait\n\n467\n00:54:06,243
-        --> 00:54:10,246\nd'arr\xEAter d'aider les gens et j'ai l'impression\nque
-        pour vous, c'est inconcevable.\n\n468\n00:54:14,417 --> 00:54:18,420\nMon
-        p\xE8re pensait\nque si le monde d\xE9couvrait qui j'\xE9tais...\n\n469\n00:54:20,423
-        --> 00:54:21,423\nil me rejetterait.\n\n470\n00:54:22,175 --> 00:54:23,801\nPar
-        peur.\n\n471\n00:54:25,845 --> 00:54:27,888\nJ'en ai assez des pr\xE9cautions.\n\n472\n00:54:28,139
-        --> 00:54:30,224\nJe veux me rendre utile.\n\n473\n00:54:30,475 --> 00:54:33,060\n\xCAtre
-        fermier, nourrir les gens,\nce n'est pas utile ?\n\n474\n00:54:33,311 -->
-        00:54:34,144\nJ'ai pas dit \xE7a.\n\n475\n00:54:34,396 --> 00:54:36,522\nOn
-        est fermiers\ndepuis 5 g\xE9n\xE9rations.\n\n476\n00:54:36,773 --> 00:54:38,691\nDans
-        ta famille, pas la mienne.\n\n477\n00:54:38,942 --> 00:54:41,902\nPourquoi
-        je t'\xE9coute ?\nT'es pas mon p\xE8re.\n\n478\n00:54:42,153 --> 00:54:43,529\nTu
-        m'as trouv\xE9 dans un champ.\n\n479\n00:54:47,325 --> 00:54:48,993\nC'est
-        rien, Martha.\n\n480\n00:54:50,829 --> 00:54:52,913\nC'est vrai. Clark a raison.\n\n481\n00:54:53,498
-        --> 00:54:54,540\nOn est pas tes parents.\n\n482\n00:54:56,626 --> 00:54:58,335\nMais
-        on a fait de notre mieux\n\n483\n00:54:58,586 --> 00:55:01,964\net on a improvis\xE9
-        en chemin\ndonc peut-\xEAtre...\n\n484\n00:55:02,215 --> 00:55:04,591\nPeut-\xEAtre
-        que \xE7a ne suffit plus.\n\n485\n00:55:09,639 --> 00:55:11,682\n\xC9coute,
-        papa...\n\n486\n00:55:11,933 --> 00:55:13,392\nMinute.\n\n487\n00:55:33,121
-        --> 00:55:34,830\nAllez sous le pont.\n\n488\n00:55:36,624 --> 00:55:37,750\nSous
-        le pont !\n\n489\n00:55:40,086 --> 00:55:41,712\nAbritez-vous !\n\n490\n00:55:48,094
-        --> 00:55:49,261\nElle est coinc\xE9e !\n\n491\n00:55:53,808 --> 00:55:55,684\nHank
-        est dans la voiture.\n\n492\n00:55:58,438 --> 00:56:00,564\nJe vais le chercher.\n\n493\n00:56:01,107
-        --> 00:56:03,317\nEmm\xE8ne ta m\xE8re sous le pont.\n\n494\n00:56:21,711
-        --> 00:56:23,504\nHank, viens !\n\n495\n00:56:32,430 --> 00:56:33,639\n- Jonathan
-        !\n- \xC7a va !\n\n496\n00:56:54,661 --> 00:56:56,078\nReste l\xE0 !\n\n497\n00:57:26,943
-        --> 00:57:30,028\nJ'ai laiss\xE9 mon p\xE8re mourir\ncar je lui faisais confiance.\n\n498\n00:57:30,905
-        --> 00:57:34,825\nParce qu'il \xE9tait convaincu\nque je devais attendre.\n\n499\n00:57:35,577
-        --> 00:57:37,744\nQue le monde n'\xE9tait pas pr\xEAt.\n\n500\n00:57:39,497
-        --> 00:57:41,123\nQu'en pensez-vous ?\n\n501\n00:57:46,045 --> 00:57:47,671\nFais
-        gaffe, Lois.\n\n502\n00:57:48,173 --> 00:57:50,466\nPerry veut ta peau.\n\n503\n00:57:50,717
-        --> 00:57:54,470\nIl sait que t'es la source de Woodburn.\nTu vas l'entendre
-        !\n\n504\n00:58:00,268 --> 00:58:02,811\nJe t'ai interdit de le publier,\net
-        total,\n\n505\n00:58:03,062 --> 00:58:05,564\ntu laisses Woodburn\nle balancer
-        sur Internet.\n\n506\n00:58:05,815 --> 00:58:08,692\nLes directeurs veulent\nque
-        je te fasse un proc\xE8s.\n\n507\n00:58:08,943 --> 00:58:12,196\nEh bien,
-        si \xE7a peut vous rassurer,\nje laisse tomber.\n\n508\n00:58:12,447 --> 00:58:13,447\nComme
-        \xE7a ?\n\n509\n00:58:15,074 --> 00:58:16,366\nEt tes pistes ?\n\n510\n00:58:17,035
-        --> 00:58:19,661\nElles n'ont rien donn\xE9.\nC'\xE9tait du vent.\n\n511\n00:58:19,913
-        --> 00:58:21,830\nT'aurais voulu plus de battage ?\n\n512\n00:58:24,209 -->
-        00:58:25,042\n15 jours de cong\xE9\n\n513\n00:58:25,293 --> 00:58:26,919\nsans
-        solde,\npour la peine.\n\n514\n00:58:27,170 --> 00:58:28,837\nRecommence un
-        coup pareil\n\n515\n00:58:29,088 --> 00:58:30,756\n- et c'est la porte.\n-
-        Tr\xE8s bien.\n\n516\n00:58:31,007 --> 00:58:33,717\nDisons 3 semaines,\nvu
-        que tu es si conciliante.\n\n517\n00:58:33,968 --> 00:58:35,469\nArr\xEAte.\n\n518\n00:58:37,138
-        --> 00:58:38,805\nJe crois ton histoire.\n\n519\n00:58:39,307 --> 00:58:42,309\nTu
-        me feras pas croire\nque tes pistes se sont refroidies.\n\n520\n00:58:42,560
-        --> 00:58:46,063\nQuelles que soient\ntes motivations pour laisser tomber...\n\n521\n00:58:47,106
-        --> 00:58:48,941\nje pense que tu as raison.\n\n522\n00:58:49,484 --> 00:58:50,734\nPourquoi
-        ?\n\n523\n00:58:52,111 --> 00:58:55,739\nTu imagines la r\xE9action\ndes habitants
-        de cette plan\xE8te...\n\n524\n00:58:57,992 --> 00:59:01,453\ns'ils savaient\nqu'une
-        telle personne existe ?\n\n525\n00:59:19,597 --> 00:59:20,597\nVa le chercher.\n\n526\n00:59:27,438
-        --> 00:59:29,064\nRegardez-moi \xE7a !\n\n527\n00:59:46,124 --> 00:59:47,916\nUne
-        journaliste est pass\xE9e.\n\n528\n00:59:48,501 --> 00:59:50,711\nC'est une
-        amie.\nNe t'en fais pas.\n\n529\n00:59:53,715 --> 00:59:54,548\nMaman.\n\n530\n00:59:55,508
-        --> 00:59:56,508\nQuoi ?\n\n531\n00:59:57,969 --> 01:00:00,512\n- Je les ai
-        retrouv\xE9s.\n- Qui \xE7a ?\n\n532\n01:00:01,347 --> 01:00:02,848\nMes parents.\n\n533\n01:00:04,017
-        --> 01:00:05,350\nMon peuple.\n\n534\n01:00:06,227 --> 01:00:09,438\nJe sais
-        d'o\xF9 je viens.\n\n535\n01:00:13,192 --> 01:00:14,943\nC'est merveilleux.\n\n536\n01:00:16,821
-        --> 01:00:19,239\nJe suis tellement contente pour toi.\n\n537\n01:00:28,082
-        --> 01:00:30,626\n- Quoi ?\n- Rien.\n\n538\n01:00:33,338 --> 01:00:36,256\nQuand
-        tu \xE9tais b\xE9b\xE9,\nje m'allongeais pr\xE8s de ton berceau.\n\n539\n01:00:36,507
-        --> 01:00:38,884\nJe t'\xE9coutais respirer.\n\n540\n01:00:39,927 --> 01:00:41,553\nTu
-        avais du mal.\n\n541\n01:00:42,764 --> 01:00:44,139\nTu luttais.\n\n542\n01:00:44,390
-        --> 01:00:46,224\nEt j'avais tout le temps peur.\n\n543\n01:00:46,476 -->
-        01:00:48,310\nQue la v\xE9rit\xE9 \xE9clate.\n\n544\n01:00:52,023 --> 01:00:54,608\nLa
-        v\xE9rit\xE9 \xE0 ton sujet est magnifique.\n\n545\n01:00:55,068 --> 01:00:58,487\nOn
-        l'a su\nd\xE8s qu'on a pos\xE9 les yeux sur toi.\n\n546\n01:01:00,782 -->
-        01:01:04,785\nOn savait qu'un jour,\nle monde entier le comprendrait.\n\n547\n01:01:07,246
-        --> 01:01:08,872\nJ'ai...\n\n548\n01:01:09,499 --> 01:01:11,583\npeur qu'on
-        t'enl\xE8ve \xE0 moi.\n\n549\n01:01:13,795 --> 01:01:16,171\nJe n'irai nulle
-        part, maman.\n\n550\n01:01:18,007 --> 01:01:19,508\nPromis.\n\n551\n01:01:25,723
-        --> 01:01:27,891\nG\xE9n\xE9ral Swanwick.\n\n552\n01:01:28,142 --> 01:01:31,895\nQu'est-ce
-        que c'est ?\nUne com\xE8te ? Un ast\xE9ro\xEFde ?\n\n553\n01:01:33,064 -->
-        01:01:37,067\nLes com\xE8tes ne corrigent pas\nleur trajectoire, mon g\xE9n\xE9ral.\n\n554\n01:01:39,862
-        --> 01:01:43,865\nJe voulais vous pr\xE9venir avant qu'un astronome\nen herbe
-        cr\xE9e une panique mondiale.\n\n555\n01:01:45,535 --> 01:01:46,910\nLe vaisseau
-        semble\n\n556\n01:01:47,161 --> 01:01:49,913\ns'\xEAtre ins\xE9r\xE9\nsur
-        une orbite synchrone lunaire.\n\n557\n01:01:50,164 --> 01:01:52,332\nJ'ignore
-        absolument pourquoi.\n\n558\n01:01:52,583 --> 01:01:55,419\nAvez-vous essay\xE9\nd'entrer
-        en communication ?\n\n559\n01:01:55,670 --> 01:01:59,673\nIls n'ont pas r\xE9pondu
-        pour l'instant.\n\n560\n01:02:00,967 --> 01:02:04,970\nSimple sp\xE9culation,\nmais
-        je pense que le pilote\n\n561\n01:02:05,221 --> 01:02:07,723\nveut faire une
-        entr\xE9e th\xE9\xE2trale.\n\n562\n01:02:14,605 --> 01:02:16,022\nQuelqu'un
-        sait\no\xF9 on range les cartouches ?\n\n563\n01:02:17,024 --> 01:02:18,942\n-
-        Quoi ?\n- C'est aux infos.\n\n564\n01:02:19,193 --> 01:02:21,153\nVenez voir
-        \xE7a.\n\n565\n01:02:51,392 --> 01:02:52,726\nJ'arrive.\n\n566\n01:03:36,979
-        --> 01:03:38,579\nVous n'\xEAtes pas seuls.\n\n567\n01:03:40,738 --> 01:03:42,338\nVous
-        n'\xEAtes pas seuls.\n\n568\n01:03:44,866 --> 01:03:47,239\nVous n'\xEAtes
-        pas seuls.\n\n569\n01:04:20,940 --> 01:04:22,440\n\xC7a passe par le flux
-        RSS.\n\n570\n01:04:25,194 --> 01:04:27,237\nC'est aussi sur mon t\xE9l\xE9phone.\n\n571\n01:04:29,407
-        --> 01:04:31,825\nJe suis le g\xE9n\xE9ral Zod.\n\n572\n01:04:33,661 --> 01:04:36,454\nJe
-        viens d'un monde\ntr\xE8s \xE9loign\xE9 du v\xF4tre.\n\n573\n01:04:37,832
-        --> 01:04:41,835\nJ'ai travers\xE9 un oc\xE9an d'\xE9toiles\npour arriver
-        jusqu'\xE0 vous.\n\n574\n01:04:43,963 --> 01:04:47,966\nDepuis un certain
-        temps,\nvotre monde abrite un de mes citoyens.\n\n575\n01:04:48,593 --> 01:04:51,803\nJ'exige
-        que vous me remettiez\n\n576\n01:04:52,054 --> 01:04:54,180\ncet individu.\n\n577\n01:04:54,432
-        --> 01:04:58,435\nPour une raison que j'ignore,\nil a choisi de garder son
-        existence\n\n578\n01:04:58,686 --> 01:05:00,520\nsecr\xE8te \xE0 vos yeux.\n\n579\n01:05:01,606
-        --> 01:05:04,774\nIl aura fait ce qu'il faut\npour se fondre dans la masse.\n\n580\n01:05:05,359
-        --> 01:05:07,027\nIl doit vous ressembler.\n\n581\n01:05:07,778 --> 01:05:10,363\nMais
-        il n'est pas des v\xF4tres.\n\n582\n01:05:11,574 --> 01:05:13,408\n\xC0 ceux
-        d'entre vous qui sauraient\n\n583\n01:05:13,659 --> 01:05:15,660\no\xF9 il
-        se trouve actuellement,\n\n584\n01:05:15,912 --> 01:05:18,455\nle sort de
-        votre plan\xE8te\n\n585\n01:05:18,706 --> 01:05:21,374\nest entre vos mains.\n\n586\n01:05:22,460
-        --> 01:05:25,503\n\xC0 Kal-El, j'adresse ce message...\n\n587\n01:05:27,548
-        --> 01:05:30,216\nrends-toi dans les 24 h...\n\n588\n01:05:34,513 --> 01:05:37,474\nou
-        tu verras ce monde\nen subir les cons\xE9quences.\n\n589\n01:05:52,406 -->
-        01:05:54,783\nNous ignorons presque tout de lui.\n\n590\n01:05:55,034 -->
-        01:05:57,243\nS'il ne nous veut vraiment aucun mal,\n\n591\n01:05:57,495 -->
-        01:05:59,496\nil se livrera \xE0 son peuple\net assumera les cons\xE9quences.\n\n592\n01:06:00,122
-        --> 01:06:01,331\nSinon,\n\n593\n01:06:01,582 --> 01:06:03,583\nce sera \xE0
-        nous de le faire.\n\n594\n01:06:03,834 --> 01:06:06,795\nLois Lane, du Daily
-        Planet,\nsait qui c'est.\n\n595\n01:06:07,046 --> 01:06:08,672\nIl faudrait
-        l'interroger.\n\n596\n01:06:08,923 --> 01:06:11,675\nVous dites que Lois Lane...\n\n597\n01:06:11,926
-        --> 01:06:14,427\nTu regardes ?\nC'est en boucle depuis ce matin.\n\n598\n01:06:14,679
-        --> 01:06:16,972\nPour une fois, Woodburn a raison.\n\n599\n01:06:17,223 -->
-        01:06:20,517\n- Tu sais o\xF9 il est ?\n- Non. M\xEAme si je savais, je dirais
-        rien.\n\n600\n01:06:20,768 --> 01:06:23,937\nC'est le monde entier\nqui est
-        menac\xE9, l\xE0.\n\n601\n01:06:24,188 --> 01:06:25,814\nC'est pas le moment\n\n602\n01:06:26,065
-        --> 01:06:28,400\nd'invoquer l'int\xE9grit\xE9 journalistique.\n\n603\n01:06:28,651
-        --> 01:06:30,110\nL'heure est grave.\n\n604\n01:06:30,361 --> 01:06:33,321\nLe
-        FBI est l\xE0.\nIls parlent de trahison.\n\n605\n01:06:33,572 --> 01:06:35,240\nJe
-        dois y aller.\n\n606\n01:06:51,382 --> 01:06:52,716\nFBI ! Les mains en l'air
-        !\n\n607\n01:06:52,967 --> 01:06:54,759\nL\xE2chez votre sac !\n\n608\n01:07:01,642
-        --> 01:07:03,893\nConcernant ces visiteurs,\n\n609\n01:07:04,145 --> 01:07:06,604\nnous
-        sommes ignorants.\nSelon des membres du gouvernement,\n\n610\n01:07:06,856
-        --> 01:07:09,315\nils ne sont pas dangereux,\n\n611\n01:07:09,567 --> 01:07:11,735\nmalgr\xE9
-        le ton mena\xE7ant du message.\n\n612\n01:07:11,986 --> 01:07:14,487\nUne
-        question nous taraude :\n\n613\n01:07:14,739 --> 01:07:18,533\n\"Qui est ce
-        Kal-El ?\nExiste-t-il r\xE9ellement ?\n\n614\n01:07:18,784 --> 01:07:21,453\n\"Comment
-        a-t-il pu rester cach\xE9\nsi longtemps ?\"\n\n615\n01:07:26,083 --> 01:07:27,375\nSors
-        de l\xE0, Kent !\n\n616\n01:07:34,467 --> 01:07:35,550\nAllez, d\xE9fends-toi.\n\n617\n01:07:35,801
-        --> 01:07:37,385\nDebout, Kent !\n\n618\n01:07:40,681 --> 01:07:42,057\nC'est
-        tout ?\n\n619\n01:07:42,516 --> 01:07:44,017\nC'est tout ce que t'as ?\n\n620\n01:07:45,686
-        --> 01:07:47,187\nAllez, Kent.\n\n621\n01:07:48,439 --> 01:07:49,814\nAllez
-        !\n\n622\n01:08:18,427 --> 01:08:19,552\nIls t'ont bless\xE9 ?\n\n623\n01:08:20,846
-        --> 01:08:22,222\nTu sais bien que non.\n\n624\n01:08:22,598 --> 01:08:25,475\nCe
-        que je te demande,\nc'est si tu vas bien.\n\n625\n01:08:27,478 --> 01:08:29,771\nJe
-        voulais tellement le frapper !\n\n626\n01:08:30,022 --> 01:08:31,481\nJe sais.\n\n627\n01:08:31,732
-        --> 01:08:34,442\nQuelque part, j'aurais bien aim\xE9.\nMais apr\xE8s ?\n\n628\n01:08:35,152
-        --> 01:08:36,319\nTu te serais senti mieux ?\n\n629\n01:08:39,698 --> 01:08:43,701\nIl
-        faut que tu d\xE9cides\nquel genre d'homme tu veux devenir.\n\n630\n01:08:43,953
-        --> 01:08:47,664\nQue cet homme soit bon ou mauvais,\n\n631\n01:08:49,291
-        --> 01:08:51,417\nil changera le monde.\n\n632\n01:08:56,674 --> 01:08:57,715\nDites-moi
-        tout.\n\n633\n01:09:03,764 --> 01:09:05,056\nPar quoi commencer ?\n\n634\n01:09:05,683
-        --> 01:09:07,267\nPar ce que vous voulez.\n\n635\n01:09:09,436 --> 01:09:11,563\nLe
-        vaisseau apparu hier soir...\n\n636\n01:09:12,898 --> 01:09:14,691\nc'est
-        moi qu'ils cherchent.\n\n637\n01:09:19,196 --> 01:09:20,697\nSavez-vous...\n\n638\n01:09:21,490
-        --> 01:09:22,615\npourquoi ?\n\n639\n01:09:22,867 --> 01:09:25,451\nNon. Mais
-        ce g\xE9n\xE9ral Zod,\n\n640\n01:09:25,703 --> 01:09:29,706\nm\xEAme si je
-        me rends,\nrien ne garantit qu'il tiendra parole.\n\n641\n01:09:29,957 -->
-        01:09:33,960\nMais si j'ai une chance\nde sauver la Terre en me livrant...\n\n642\n01:09:35,588
-        --> 01:09:36,713\nje dois la saisir, non ?\n\n643\n01:09:38,215 --> 01:09:40,091\nQue
-        vous dit votre instinct ?\n\n644\n01:09:40,801 --> 01:09:42,510\nQue Zod n'est
-        pas fiable.\n\n645\n01:09:45,139 --> 01:09:46,723\nMais...\n\n646\n01:09:47,766
-        --> 01:09:50,351\nles Terriens le sont-ils davantage ?\n\n647\n01:09:58,360
-        --> 01:10:01,321\nIl faut parfois faire acte de foi.\n\n648\n01:10:02,740
-        --> 01:10:04,782\nLa confiance vient apr\xE8s.\n\n649\n01:10:28,933 --> 01:10:31,643\nTr\xE8s
-        bien.\nVous avez toute notre attention.\n\n650\n01:10:32,144 --> 01:10:33,144\nQue
-        voulez-vous ?\n\n651\n01:10:33,395 --> 01:10:35,188\nParler \xE0 Lois Lane.\n\n652\n01:10:35,439
-        --> 01:10:36,689\nPourquoi serait-elle ici ?\n\n653\n01:10:37,650 --> 01:10:39,692\nNe
-        faites pas le malin avec moi.\n\n654\n01:10:39,944 --> 01:10:43,947\nJe vais
-        me rendre, si vous me garantissez\nla libert\xE9 de Lois.\n\n655\n01:10:54,041
-        --> 01:10:56,000\nPourquoi vous livrer \xE0 Zod ?\n\n656\n01:10:57,211 -->
-        01:11:00,838\nJe me livre \xE0 l'humanit\xE9,\nc'est diff\xE9rent.\n\n657\n01:11:01,966
-        --> 01:11:03,883\nVous vous \xEAtes laiss\xE9 menotter ?\n\n658\n01:11:04,635
-        --> 01:11:07,053\nOn ne se livre pas\nen opposant r\xE9sistance.\n\n659\n01:11:08,555
-        --> 01:11:10,598\nEt si \xE7a peut les rassurer...\n\n660\n01:11:11,684 -->
-        01:11:13,518\n\xE7a ne mange pas de pain.\n\n661\n01:11:17,940 --> 01:11:19,107\nQue
-        repr\xE9sente le S ?\n\n662\n01:11:22,736 --> 01:11:24,320\nCe n'est pas un
-        S.\n\n663\n01:11:25,781 --> 01:11:27,365\nChez moi, \xE7a signifie espoir.\n\n664\n01:11:29,326
-        --> 01:11:32,829\nEh bien, ici, c'est un S.\n\n665\n01:11:34,873 --> 01:11:36,416\nQue
-        diriez-vous de...\n\n666\n01:11:40,754 --> 01:11:41,754\nSup...\n\n667\n01:11:42,006
-        --> 01:11:43,047\nMonsieur ?\n\n668\n01:11:43,299 --> 01:11:46,634\n- Bonjour,
-        je suis le professeur...\n- Emil Hamilton.\n\n669\n01:11:46,885 --> 01:11:49,846\nJe
-        vois votre badge\ndans votre poche de poitrine.\n\n670\n01:11:50,097 --> 01:11:52,140\nEt
-        un paquet de pastilles entam\xE9.\n\n671\n01:11:53,309 --> 01:11:55,643\nAinsi
-        que les soldats \xE0 c\xF4t\xE9\n\n672\n01:11:55,894 --> 01:11:58,187\nqui
-        pr\xE9parent l'agent tranquillisant.\n\n673\n01:11:58,439 --> 01:11:59,897\nCe
-        ne sera pas utile.\n\n674\n01:12:00,149 --> 01:12:03,192\nComprenez\nqu'on
-        prenne des pr\xE9cautions.\n\n675\n01:12:03,444 --> 01:12:05,862\nVous pourriez
-        \xEAtre porteur\nd'un agent pathog\xE8ne.\n\n676\n01:12:06,113 --> 01:12:07,572\nJe
-        suis l\xE0 depuis 33 ans.\n\n677\n01:12:07,823 --> 01:12:11,743\n- Je n'ai
-        infect\xE9 personne.\n- \xC0 votre connaissance. Nos inqui\xE9tudes\n\n678\n01:12:11,994
-        --> 01:12:15,371\nsont l\xE9gitimes.\nVous avez r\xE9v\xE9l\xE9 votre identit\xE9
-        \xE0 Mlle Lane.\n\n679\n01:12:16,373 --> 01:12:18,583\nPourquoi pas \xE0 nous
-        ?\n\n680\n01:12:19,543 --> 01:12:21,878\nMettons cartes sur table.\n\n681\n01:12:23,339
-        --> 01:12:25,048\nVous me craignez\ncar vous ne me contr\xF4lez pas.\n\n682\n01:12:25,632
-        --> 01:12:28,176\nVous n'y arrivez pas\net n'y arriverez jamais.\n\n683\n01:12:29,011
-        --> 01:12:30,970\nJe ne suis pas pour autant\nvotre ennemi.\n\n684\n01:12:31,221
-        --> 01:12:32,722\nQui l'est, alors ?\n\n685\n01:12:32,973 --> 01:12:34,390\nZod
-        ?\n\n686\n01:12:35,017 --> 01:12:36,434\nC'est ce qui m'inqui\xE8te.\n\n687\n01:12:37,019
-        --> 01:12:38,728\nQuoi qu'il en soit,\n\n688\n01:12:38,979 --> 01:12:41,773\nj'ai
-        ordre de vous livrer \xE0 lui.\n\n689\n01:12:42,983 --> 01:12:44,859\nFaites
-        votre devoir, mon g\xE9n\xE9ral.\n\n690\n01:12:49,656 --> 01:12:50,448\nMerci.\n\n691\n01:12:51,575
-        --> 01:12:52,533\nDe quoi ?\n\n692\n01:12:53,702 --> 01:12:55,286\nD'avoir
-        cru en moi.\n\n693\n01:12:58,332 --> 01:13:00,375\n\xC7a n'a pas chang\xE9
-        grand-chose.\n\n694\n01:13:01,210 --> 01:13:02,752\nPour moi, si.\n\n695\n01:13:23,357
-        --> 01:13:24,899\nIls arrivent.\n\n696\n01:13:25,692 --> 01:13:27,193\nVous
-        devriez partir.\n\n697\n01:13:30,322 --> 01:13:31,864\nPartez, Lois.\n\n698\n01:14:42,769
-        --> 01:14:44,145\nKal-El.\n\n699\n01:14:44,688 --> 01:14:46,731\nJe suis la
-        sous-commandante Faora-Ul.\n\n700\n01:14:47,399 --> 01:14:50,651\nAu nom du
-        g\xE9n\xE9ral Zod, je te salue.\n\n701\n01:14:56,700 --> 01:14:59,785\n- Vous
-        \xEAtes l'officier responsable ?\n- Oui.\n\n702\n01:15:00,037 --> 01:15:01,996\nLe
-        g\xE9n\xE9ral Zod veut\nque cette femme\n\n703\n01:15:02,247 --> 01:15:03,873\nm'accompagne.\n\n704\n01:15:04,833
-        --> 01:15:05,958\nVous avez demand\xE9 l'alien.\n\n705\n01:15:07,419 --> 01:15:10,338\nIl
-        n'a jamais \xE9t\xE9 question\nd'un des n\xF4tres.\n\n706\n01:15:10,589 -->
-        01:15:13,716\nJe dis au g\xE9n\xE9ral\nque vous refusez d'obtemp\xE9rer ?\n\n707\n01:15:13,967
-        --> 01:15:15,843\nDites-lui ce que vous voulez.\n\n708\n01:15:18,847 --> 01:15:20,264\nC'est
-        bon.\n\n709\n01:15:21,350 --> 01:15:22,558\nJ'y vais.\n\n710\n01:16:05,394
-        --> 01:16:09,230\nLa composition atmosph\xE9rique\nest incompatible avec les
-        humains.\n\n711\n01:16:09,481 --> 01:16:10,856\nVous devrez d\xE9sormais\n\n712\n01:16:11,108
-        --> 01:16:12,775\nporter un respirateur.\n\n713\n01:16:37,926 --> 01:16:38,843\nKal-El.\n\n714\n01:16:40,804
-        --> 01:16:42,430\nSi tu savais\n\n715\n01:16:42,681 --> 01:16:44,724\ndepuis
-        combien de temps\nnous te cherchons.\n\n716\n01:16:45,183 --> 01:16:46,183\nZod,
-        je pr\xE9sume.\n\n717\n01:16:46,435 --> 01:16:47,560\nG\xE9n\xE9ral Zod !\n\n718\n01:16:47,811
-        --> 01:16:49,604\n- Notre commandant.\n- Ce n'est rien.\n\n719\n01:16:49,855
-        --> 01:16:52,523\nPardonnons-lui son manque de d\xE9corum.\n\n720\n01:16:52,774
-        --> 01:16:54,692\nIl ne conna\xEEt pas nos usages.\n\n721\n01:16:54,943 -->
-        01:16:55,985\nNous devrions\n\n722\n01:16:56,236 --> 01:16:59,280\nnous r\xE9jouir,
-        pas nous battre.\n\n723\n01:17:04,119 --> 01:17:05,161\nJe...\n\n724\n01:17:05,412
-        --> 01:17:06,621\nme sens bizarre.\n\n725\n01:17:09,374 --> 01:17:10,666\nFaible.\n\n726\n01:17:12,878
-        --> 01:17:14,003\nQue lui arrive-t-il ?\n\n727\n01:17:14,254 --> 01:17:16,797\nIl
-        rejette l'atmosph\xE8re\nde notre vaisseau.\n\n728\n01:17:17,883 --> 01:17:20,551\nTu
-        as r\xE9ussi \xE0 t'adapter\n\xE0 l'environnement terrien\n\n729\n01:17:20,719
-        --> 01:17:21,636\nmais pas au n\xF4tre.\n\n730\n01:17:21,803 --> 01:17:22,845\nAidez-le.\n\n731\n01:17:23,096
-        --> 01:17:24,639\nImpossible. Ce qu'il subit\n\n732\n01:17:24,890 --> 01:17:27,433\ndoit
-        suivre son cours.\n\n733\n01:17:28,477 --> 01:17:29,769\nAidez-le.\n\n734\n01:17:31,563
-        --> 01:17:32,730\nAidez-le !\n\n735\n01:17:44,368 --> 01:17:45,910\nBonjour,
-        Kal.\n\n736\n01:17:47,579 --> 01:17:48,621\nOu pr\xE9f\xE8res-tu Clark ?\n\n737\n01:17:50,374
-        --> 01:17:51,749\nC'est le pr\xE9nom qu'ils t'ont donn\xE9,\n\n738\n01:17:52,000
-        --> 01:17:53,292\nn'est-ce pas ?\n\n739\n01:17:54,586 --> 01:17:56,295\nJ'\xE9tais
-        chef\nde l'arm\xE9e de Krypton.\n\n740\n01:17:56,546 --> 01:17:58,964\nTon
-        p\xE8re,\nnotre plus grand scientifique.\n\n741\n01:17:59,216 --> 01:18:00,633\nNous
-        \xE9tions d'accord\nsur une chose,\n\n742\n01:18:00,884 --> 01:18:03,636\nKrypton
-        se mourait.\nPour avoir voulu\n\n743\n01:18:03,887 --> 01:18:06,430\nprot\xE9ger
-        notre civilisation\n\n744\n01:18:06,682 --> 01:18:08,766\net sauver notre
-        plan\xE8te,\n\n745\n01:18:09,017 --> 01:18:13,020\nmes officiers et moi-m\xEAme\navons
-        \xE9t\xE9 condamn\xE9s \xE0 la Zone Phantom.\n\n746\n01:18:15,982 --> 01:18:19,235\nPuis,
-        la destruction de notre monde\n\n747\n01:18:19,486 --> 01:18:20,986\nnous
-        a lib\xE9r\xE9s.\n\n748\n01:18:26,159 --> 01:18:29,662\nNous avons d\xE9riv\xE9,
-        vou\xE9s \xE0 flotter\n\n749\n01:18:29,913 --> 01:18:31,831\nparmi les ruines
-        de notre plan\xE8te\n\n750\n01:18:32,082 --> 01:18:33,958\net \xE0 mourir
-        de faim.\n\n751\n01:18:34,835 --> 01:18:36,460\nEt vous avez trouv\xE9 la
-        Terre ?\n\n752\n01:18:37,212 --> 01:18:41,215\nNous avons transform\xE9 le
-        r\xE9tromoteur\ndu Phantom en hyperpropulseur.\n\n753\n01:18:41,717 --> 01:18:44,885\nTon
-        p\xE8re a fait pareil\nsur l'engin qui t'a amen\xE9 ici.\n\n754\n01:18:46,930
-        --> 01:18:50,015\nEt alors,\nl'instrument de notre damnation...\n\n755\n01:18:52,060
-        --> 01:18:53,853\nest devenu notre salut.\n\n756\n01:18:58,817 --> 01:19:01,318\nNous
-        avons explor\xE9\nles avant-postes coloniaux,\n\n757\n01:19:01,570 --> 01:19:03,779\n\xE0
-        la recherche de signes de vie.\n\n758\n01:19:06,241 --> 01:19:09,034\nMais
-        nous n'avons trouv\xE9\nque la mort.\n\n759\n01:19:10,036 --> 01:19:12,621\nCoup\xE9s
-        de Krypton,\nils avaient d\xE9p\xE9ri\n\n760\n01:19:12,873 --> 01:19:15,082\net
-        \xE9taient morts depuis longtemps.\n\n761\n01:19:15,584 --> 01:19:17,543\nNous
-        avons r\xE9cup\xE9r\xE9\nce que nous avons pu.\n\n762\n01:19:17,794 --> 01:19:19,503\nArmures,
-        armes,\n\n763\n01:19:19,755 --> 01:19:21,672\nm\xEAme une machine \xE0 gravit\xE9.\n\n764\n01:19:23,425
-        --> 01:19:25,301\nPendant 33 ann\xE9es,\nnous nous sommes pr\xE9par\xE9s.\n\n765\n01:19:26,803
-        --> 01:19:29,555\nPuis nous avons d\xE9tect\xE9\nune balise de d\xE9tresse\n\n766\n01:19:29,806
-        --> 01:19:31,599\nque tu as d\xE9clench\xE9e\n\n767\n01:19:31,850 --> 01:19:34,059\nen
-        p\xE9n\xE9trant\ndans le vaisseau de reconnaissance.\n\n768\n01:19:35,479
-        --> 01:19:38,022\nC'est toi qui nous as men\xE9s ici, Kal.\n\n769\n01:19:39,149
-        --> 01:19:40,483\nEt maintenant,\ntu as le pouvoir\n\n770\n01:19:40,734 -->
-        01:19:44,361\nde sauver ce qui reste de ta race.\n\n771\n01:19:49,117 -->
-        01:19:50,367\nSur Krypton,\n\n772\n01:19:50,619 --> 01:19:53,245\nla matrice
-        g\xE9n\xE9tique\nde chaque \xEAtre \xE0 na\xEEtre\n\n773\n01:19:53,497 -->
-        01:19:56,040\nest encod\xE9e\ndans le registre des citoyens.\n\n774\n01:19:56,708
-        --> 01:19:58,834\nTon p\xE8re a vol\xE9\nle codex du registre\n\n775\n01:19:59,085
-        --> 01:20:01,921\net l'a cach\xE9 dans la capsule\nqui t'a amen\xE9 ici.\n\n776\n01:20:02,631
-        --> 01:20:03,464\nDans quel but ?\n\n777\n01:20:04,549 --> 01:20:07,259\nPour
-        que Krypton puisse revivre.\n\n778\n01:20:08,136 --> 01:20:09,678\nSur Terre.\n\n779\n01:20:29,533
-        --> 01:20:31,617\nO\xF9 est le codex ?\n\n780\n01:20:33,286 --> 01:20:35,120\nSi
-        Krypton revit...\n\n781\n01:20:36,289 --> 01:20:37,665\nque devient la Terre
-        ?\n\n782\n01:20:38,708 --> 01:20:42,211\nLes fondations doivent \xEAtre construites\nsur
-        quelque chose.\n\n783\n01:20:42,462 --> 01:20:45,256\nM\xEAme ton p\xE8re
-        reconnaissait ce fait.\n\n784\n01:20:55,183 --> 01:20:56,392\nJe refuse de
-        participer \xE0 \xE7a.\n\n785\n01:20:57,227 --> 01:20:58,936\nAlors tu participeras
-        \xE0 quoi ?\n\n786\n01:21:13,577 --> 01:21:14,702\nTon p\xE8re\n\n787\n01:21:14,953
-        --> 01:21:16,954\na \xE9t\xE9 digne jusqu'au bout.\n\n788\n01:21:19,833 -->
-        01:21:21,792\nVous l'avez tu\xE9 ?\n\n789\n01:21:22,168 --> 01:21:23,502\nEn
-        effet.\n\n790\n01:21:24,129 --> 01:21:27,506\nEt pas un jour ne passe\nsans
-        que cela me hante.\n\n791\n01:21:28,884 --> 01:21:31,218\nMais s'il le fallait,\nje
-        recommencerais.\n\n792\n01:21:31,469 --> 01:21:34,930\nJ'ai un devoir envers
-        mon peuple.\n\n793\n01:21:35,181 --> 01:21:39,184\nEt je ne laisserai personne\nm'emp\xEAcher
-        de l'accomplir.\n\n794\n01:21:55,660 --> 01:21:57,286\nQuelle est la situation,
-        commandant ?\n\n795\n01:21:57,913 --> 01:22:00,289\nDeux engins lanc\xE9s\nd'un
-        vaisseau alien.\n\n796\n01:22:00,540 --> 01:22:02,666\nEnvoyez l'image.\n\n797\n01:22:03,084
-        --> 01:22:04,168\nLes voil\xE0.\n\n798\n01:22:04,419 --> 01:22:05,210\nReciblez
-        Ikon-4\n\n799\n01:22:05,462 --> 01:22:07,880\net zoomez sur ces engins.\n\n800\n01:22:08,214
-        --> 01:22:09,131\nIci le commandement.\n\n801\n01:22:09,382 --> 01:22:10,549\nMot
-        de passe, trident.\n\n802\n01:22:10,800 --> 01:22:12,885\nEngins aliens en
-        approche d'attaque.\n\n803\n01:22:13,136 --> 01:22:14,762\nIkon-4 activ\xE9.\n\n804\n01:22:15,013
-        --> 01:22:15,804\nVitesse air ?\n\n805\n01:22:16,056 --> 01:22:17,473\n380
-        n\x9Cuds. Ils survolent le Kansas\n\n806\n01:22:17,724 --> 01:22:19,725\nsans
-        r\xE9pondre aux signaux.\n\n807\n01:22:19,976 --> 01:22:22,186\nTu te fatigues
-        pour rien.\n\n808\n01:22:23,104 --> 01:22:25,439\nTa force tir\xE9e du soleil
-        terrien\n\n809\n01:22:25,690 --> 01:22:27,775\nest neutralis\xE9e \xE0 bord.\n\n810\n01:22:28,443
-        --> 01:22:29,568\nIci,\n\n811\n01:22:29,819 --> 01:22:31,403\ndans cet environnement...\n\n812\n01:22:32,197
-        --> 01:22:33,656\ntu es aussi faible qu'un humain.\n\n813\n01:23:32,215 -->
-        01:23:34,049\nD'o\xF9 sortez-vous ?\n\n814\n01:23:34,592 --> 01:23:36,010\nLa
-        cl\xE9 de commande\n\n815\n01:23:36,261 --> 01:23:38,679\nm'a t\xE9l\xE9charg\xE9\ndans
-        le processeur central.\n\n816\n01:23:39,931 --> 01:23:40,889\nQui \xEAtes-vous
-        ?\n\n817\n01:23:41,850 --> 01:23:43,142\nLe p\xE8re de Kal.\n\n818\n01:23:44,811
-        --> 01:23:45,561\nPouvez-vous nous aider ?\n\n819\n01:23:47,522 --> 01:23:49,356\nJ'ai
-        con\xE7u ce vaisseau.\n\n820\n01:23:49,607 --> 01:23:51,775\nJe peux rendre
-        son atmosph\xE8re\n\n821\n01:23:52,027 --> 01:23:53,777\ncompatible aux humains.\n\n822\n01:23:54,029
-        --> 01:23:54,862\nOn peut les neutraliser\n\n823\n01:23:55,113 --> 01:23:57,573\nen
-        les renvoyant dans la Zone Phantom.\n\n824\n01:23:58,533 --> 01:23:59,158\nComment
-        ?\n\n825\n01:23:59,409 --> 01:24:00,951\nJe vous apprendrai.\n\n826\n01:24:01,202
-        --> 01:24:02,995\nPuis, vous apprendrez \xE0 Kal.\n\n827\n01:24:03,246 -->
-        01:24:04,955\nM'aiderez-vous ?\n\n828\n01:24:18,803 --> 01:24:20,095\nL'\xE9quipage
-        est alert\xE9.\n\n829\n01:24:20,346 --> 01:24:21,388\nD\xE9pla\xE7ons-nous.\n\n830\n01:24:21,639
-        --> 01:24:23,307\nR\xE9cup\xE9rez la cl\xE9.\n\n831\n01:24:30,940 --> 01:24:33,984\n-
-        C'est vous ?\n- Oui. R\xE9cup\xE9rez l'arme.\n\n832\n01:24:43,369 --> 01:24:44,745\nQue
-        se passe-t-il ?\n\n833\n01:25:05,725 --> 01:25:06,391\n\xC0 droite.\n\n834\n01:25:06,643
-        --> 01:25:07,267\nTirez.\n\n835\n01:25:08,853 --> 01:25:09,561\nDerri\xE8re
-        vous.\n\n836\n01:25:23,076 --> 01:25:25,119\nAttachez-vous dans la nacelle.\n\n837\n01:25:26,162
-        --> 01:25:28,413\nBon voyage, Mlle Lane.\nNous ne serons pas amen\xE9s\n\n838\n01:25:31,835
-        --> 01:25:34,920\nLes Phantom propulseurs\nsont essentiels pour les arr\xEAter.\n\n839\n01:25:35,797
-        --> 01:25:37,047\nPenchez la t\xEAte \xE0 gauche.\n\n840\n01:26:04,617 -->
-        01:26:06,535\nZod a dit vrai pour le codex ?\n\n841\n01:26:07,662 --> 01:26:09,037\nFrappe
-        cette paroi.\n\n842\n01:26:12,709 --> 01:26:13,876\nNous voulions que tu saches\n\n843\n01:26:14,127
-        --> 01:26:16,253\nce qu'\xEAtre humain signifiait,\n\n844\n01:26:16,880 -->
-        01:26:20,507\npour qu'un jour, le moment venu,\ntu puisses \xEAtre le lien\n\n845\n01:26:20,758
-        --> 01:26:22,509\nentre deux peuples.\n\n846\n01:26:25,263 --> 01:26:26,013\nRegarde.\n\n847\n01:26:29,184
-        --> 01:26:30,434\nLois.\n\n848\n01:26:31,019 --> 01:26:32,060\nTu peux la
-        sauver.\n\n849\n01:26:35,190 --> 01:26:37,065\nTu peux tous les sauver.\n\n850\n01:27:55,979
-        --> 01:27:57,521\nVous serez en s\xE9curit\xE9 ici.\n\n851\n01:27:59,857 -->
-        01:28:01,275\nTout va bien ?\n\n852\n01:28:05,655 --> 01:28:07,114\nJe suis
-        d\xE9sol\xE9e.\n\n853\n01:28:07,865 --> 01:28:10,826\nJe ne voulais pas vous
-        trahir\nmais ils ont sond\xE9\n\n854\n01:28:13,496 --> 01:28:15,247\nIls m'ont
-        fait la m\xEAme chose.\n\n855\n01:28:28,344 --> 01:28:29,678\nClark !\n\n856\n01:28:38,688
-        --> 01:28:40,439\nL'engin qui l'a amen\xE9...\n\n857\n01:28:40,982 --> 01:28:42,149\no\xF9
-        est-il ?\n\n858\n01:28:44,068 --> 01:28:45,235\nVa te faire voir.\n\n859\n01:28:56,539
-        --> 01:28:57,497\nL\xE0-bas.\n\n860\n01:29:20,521 --> 01:29:22,647\nLe codex
-        n'y est pas.\n\n861\n01:29:29,405 --> 01:29:30,447\nO\xF9 l'a-t-il cach\xE9
-        ?\n\n862\n01:29:30,698 --> 01:29:31,323\nJe ne sais pas.\n\n863\n01:29:31,574
-        --> 01:29:32,657\nO\xF9 est le codex ?\n\n864\n01:29:48,674 --> 01:29:50,634\nJe
-        vous interdis\nde menacer ma m\xE8re !\n\n865\n01:30:32,427 --> 01:30:33,885\nQue
-        m'as-tu fait ?\n\n866\n01:30:34,137 --> 01:30:36,555\nMes parents m'ont appris\n\n867\n01:30:39,976
-        --> 01:30:41,560\n\xC0 me concentrer...\n\n868\n01:30:42,145 --> 01:30:43,854\nsur
-        ce que je voulais voir.\n\n869\n01:30:44,105 --> 01:30:45,147\nSans votre
-        casque,\n\n870\n01:30:45,398 --> 01:30:46,982\nvous recevez tout.\n\n871\n01:30:48,234
-        --> 01:30:49,651\nEt c'est douloureux,\n\n872\n01:30:50,236 --> 01:30:51,611\nn'est-ce
-        pas ?\n\n873\n01:31:36,449 --> 01:31:37,741\nRestez pas \xE0 la fen\xEAtre.\n\n874\n01:31:40,703
-        --> 01:31:42,496\nRentrez.\nC'est dangereux.\n\n875\n01:31:47,835 --> 01:31:50,712\nIci
-        Guardian,\ncommandant de la mission.\n\n876\n01:31:50,963 --> 01:31:53,006\nJ'ai
-        d\xE9j\xE0 rencontr\xE9 et observ\xE9\n\n877\n01:31:53,257 --> 01:31:55,383\nceux
-        que nous allons attaquer.\n\n878\n01:31:55,635 --> 01:31:58,345\nIls sont
-        tr\xE8s dangereux.\nNous sommes autoris\xE9s\n\n879\n01:31:58,596 --> 01:32:00,096\n\xE0
-        employer la force l\xE9tale.\n\n880\n01:32:02,058 --> 01:32:04,017\nBien re\xE7u.\nArrivons
-        sur cible.\n\n881\n01:32:09,690 --> 01:32:10,899\nAutorisation tir libre.\n\n882\n01:32:11,150
-        --> 01:32:12,776\nCompris, 11. Tir libre.\n\n883\n01:32:15,571 --> 01:32:16,321\nThunder
-        11...\n\n884\n01:32:16,572 --> 01:32:17,614\n3 cibles en vue.\n\n885\n01:32:35,216
-        --> 01:32:36,007\nThunder 11,\n\n886\n01:32:36,259 --> 01:32:38,677\njoli
-        tir.\nDemande nouvel assaut imm\xE9diat.\n\n887\n01:32:38,928 --> 01:32:41,054\nRe\xE7u,
-        Guardian.\nDeuxi\xE8me passe de tir,\n\n888\n01:32:41,305 --> 01:32:43,390\ncap
-        \xE0 212 degr\xE9s.\n\n889\n01:32:50,398 --> 01:32:51,356\nThunder 11,\n\n890\n01:32:51,607
-        --> 01:32:52,983\n\xE9jectez-vous !\n\n891\n01:32:53,317 --> 01:32:54,943\nThunder
-        11, \xE9jectez-vous !\n\n892\n01:33:05,079 --> 01:33:06,663\nEnnemi droit
-        devant !\n\n893\n01:33:27,101 --> 01:33:27,976\nTu es faible,\n\n894\n01:33:28,227
-        --> 01:33:29,352\nfils d'El.\n\n895\n01:33:29,604 --> 01:33:30,729\nPeu s\xFBr
-        de toi.\n\n896\n01:33:35,985 --> 01:33:38,945\nLe fait que tu poss\xE8des\nune
-        conscience morale,\n\n897\n01:33:39,196 --> 01:33:40,947\net pas nous,\n\n898\n01:33:41,198
-        --> 01:33:43,742\nnous donne l'avantage de l'\xE9volution.\n\n899\n01:33:47,246
-        --> 01:33:49,748\nSi l'Histoire\nnous a appris quelque chose...\n\n900\n01:33:59,634
-        --> 01:34:03,219\nc'est que l'\xE9volution\nl'emporte toujours.\n\n901\n01:34:24,533
-        --> 01:34:26,034\nTour de contr\xF4le,\nen approche\n\n902\n01:34:26,285 -->
-        01:34:28,119\nde Jayhawk.\n\n903\n01:35:09,787 --> 01:35:11,079\n\xC0 tous
-        les rangers,\n\n904\n01:35:11,330 --> 01:35:12,497\nattaquez les cibles.\n\n905\n01:35:12,998
-        --> 01:35:14,082\nIci B01.\n\n906\n01:35:14,333 --> 01:35:15,625\nEt le type
-        en bleu ?\n\n907\n01:35:15,876 --> 01:35:16,918\nJ'ai dit d'attaquer\n\n908\n01:35:17,169
-        --> 01:35:18,336\ntoutes les cibles.\n\n909\n01:35:40,735 --> 01:35:41,568\n\xC7a
-        va ?\n\n910\n01:35:47,324 --> 01:35:49,409\nAutorotation !\nOn va s'\xE9craser
-        !\n\n911\n01:35:50,161 --> 01:35:53,246\nPosition de s\xE9curit\xE9 !\n\n912\n01:35:53,497
-        --> 01:35:54,456\nOn s'\xE9crase !\n\n913\n01:35:59,545 --> 01:36:03,548\nAppareil
-        \xE0 terre. Guardian abattu.\nJe r\xE9p\xE8te, Guardian abattu.\n\n914\n01:36:27,239
-        --> 01:36:28,573\nThunder 12 \xE0 Guardian.\n\n915\n01:36:28,824 --> 01:36:30,158\nVous
-        me recevez ?\n\n916\n01:36:30,409 --> 01:36:31,326\nIci Guardian.\n\n917\n01:36:31,577
-        --> 01:36:33,953\nEnvoyez les forces\nau nord de ma position.\n\n918\n01:36:34,205
-        --> 01:36:36,372\n- Amis \xE0 proximit\xE9.\n- Bien re\xE7u.\n\n919\n01:36:36,624
-        --> 01:36:37,874\nBonne chance.\n\n920\n01:37:17,748 --> 01:37:20,583\nMourir
-        dignement\nest une r\xE9compense en soi.\n\n921\n01:37:34,181 --> 01:37:35,557\nTu
-        ne gagneras pas.\n\n922\n01:37:36,976 --> 01:37:38,518\nPour chaque humain
-        que tu sauveras,\n\n923\n01:37:38,769 --> 01:37:40,937\nnous en tuerons un
-        million.\n\n924\n01:38:32,740 --> 01:38:35,909\nL'alerte est-elle termin\xE9e
-        ?\n\n925\n01:38:36,160 --> 01:38:38,411\n\xC9quipe Alpha, au rapport.\n\n926\n01:38:38,662
-        --> 01:38:40,246\nVous me recevez ?\n\n927\n01:39:29,755 --> 01:39:31,965\nCet
-        homme n'est pas notre ennemi.\n\n928\n01:39:34,426 --> 01:39:35,969\nMerci,
-        mon colonel.\n\n929\n01:39:53,821 --> 01:39:54,654\nMaman ?\n\n930\n01:39:55,948
-        --> 01:39:57,615\nTout va bien.\n\n931\n01:40:09,670 --> 01:40:11,629\nJoli
-        costume, fiston.\n\n932\n01:40:12,715 --> 01:40:14,007\nJe suis vraiment d\xE9sol\xE9.\n\n933\n01:40:15,050
-        --> 01:40:17,343\nCe ne sont que des objets.\n\n934\n01:40:18,512 --> 01:40:20,930\nOn
-        peut toujours les remplacer.\n\n935\n01:40:23,392 --> 01:40:24,642\nToi, tu
-        es irrempla\xE7able.\n\n936\n01:40:25,978 --> 01:40:28,396\nD'apr\xE8s Zod,
-        ce codex pourrait\n\n937\n01:40:28,647 --> 01:40:30,940\nramener mon peuple.\n\n938\n01:40:31,275
-        --> 01:40:32,942\nN'est-ce pas une bonne chose ?\n\n939\n01:40:37,156 -->
-        01:40:39,657\nIls ne veulent pas partager ce monde.\n\n940\n01:40:40,284 -->
-        01:40:41,492\nClark.\n\n941\n01:40:44,997 --> 01:40:46,873\nJe sais comment
-        les neutraliser.\n\n942\n01:40:48,959 --> 01:40:50,376\nQue s'est-il pass\xE9
-        en bas ?\n\n943\n01:40:50,627 --> 01:40:53,463\nIl a mis \xE0 jour\nune faiblesse
-        passag\xE8re.\n\n944\n01:40:54,339 --> 01:40:56,174\n\xC7a n'a gu\xE8re d'importance.\n\n945\n01:40:57,551
-        --> 01:41:00,470\nCar j'ai localis\xE9 le codex.\n\n946\n01:41:01,263 -->
-        01:41:03,514\nIl n'a jamais \xE9t\xE9 dans la capsule.\n\n947\n01:41:04,141
-        --> 01:41:05,808\nJor-El a pris le codex,\n\n948\n01:41:06,060 --> 01:41:08,519\nl'ADN
-        d'un milliard d'individus.\nPuis il l'a associ\xE9\n\n949\n01:41:08,771 -->
-        01:41:10,563\naux cellules\n\n950\n01:41:10,814 --> 01:41:11,731\nde son fils.\n\n951\n01:41:11,982
-        --> 01:41:13,566\nTous les h\xE9ritiers de Krypton\n\n952\n01:41:13,817 -->
-        01:41:17,236\nvivent cach\xE9s\ndans le corps d'un r\xE9fugi\xE9.\n\n953\n01:41:21,325
-        --> 01:41:23,284\nKal-El doit-il \xEAtre en vie\n\n954\n01:41:23,535 --> 01:41:26,704\npour
-        que l'on extraie\nle codex de ses cellules ?\n\n955\n01:41:28,082 --> 01:41:29,248\nNon.\n\n956\n01:41:35,172
-        --> 01:41:37,423\nSortez la machine \xE0 gravit\xE9.\n\n957\n01:42:09,665
-        --> 01:42:10,581\nC'\xE9tait quoi ?\n\n958\n01:42:10,749 --> 01:42:11,916\nLe
-        vaisseau s'est scind\xE9.\n\n959\n01:42:12,167 --> 01:42:15,253\nUne partie
-        gagne l'est,\nl'autre, l'h\xE9misph\xE8re sud.\n\n960\n01:42:15,504 --> 01:42:17,922\n-
-        L'ennemi arrive vite ?\n- Il atteint\n\n961\n01:42:18,173 --> 01:42:19,590\nMach
-        24 et il acc\xE9l\xE8re.\n\n962\n01:42:19,842 --> 01:42:22,510\nIl va s'\xE9craser\ndans
-        le sud de l'oc\xE9an Indien.\n\n963\n01:42:41,238 --> 01:42:42,864\nLe reste
-        du vaisseau arrive.\n\n964\n01:42:43,866 --> 01:42:44,991\nMettez le visuel.\n\n965\n01:43:28,994
-        --> 01:43:31,787\nActivez le Phantom propulseur.\n\n966\n01:43:53,393 -->
-        01:43:55,228\nNous voil\xE0 esclaves\nde la machine \xE0 gravit\xE9.\n\n967\n01:43:56,980
-        --> 01:43:58,356\nD\xE9marrez.\n\n968\n01:44:32,432 --> 01:44:35,851\n- Avec
-        quoi nous attaquent-ils ?\n- On dirait une arme \xE0 pesanteur,\n\n969\n01:44:36,103
-        --> 01:44:38,646\nmarchant de pair avec leur vaisseau.\n\n970\n01:44:40,065
-        --> 01:44:43,150\nIls arrivent \xE0 augmenter\nla masse de la Terre\n\n971\n01:44:43,402
-        --> 01:44:45,528\nen emplissant l'atmosph\xE8re\nde particules.\n\n972\n01:44:50,200
-        --> 01:44:51,200\nIls terraforment.\n\n973\n01:44:51,952 --> 01:44:52,743\nC'est-\xE0-dire
-        ?\n\n974\n01:44:53,578 --> 01:44:54,704\nL'ing\xE9nierie plan\xE9taire\n\n975\n01:44:54,955
-        --> 01:44:58,165\nmodifie\nl'atmosph\xE8re et la topographie.\n\n976\n01:44:58,417
-        --> 01:44:59,667\nTransformant la Terre en Krypton.\n\n977\n01:45:00,377 -->
-        01:45:03,504\n- Qu'allons-nous devenir ?\n- Au vu de ces donn\xE9es,\n\n978\n01:45:03,755
-        --> 01:45:06,757\n- nous n'existerons plus.\n- G\xE9n\xE9ral Swanwick.\n\n979\n01:45:07,175
-        --> 01:45:08,551\nOn nous informe\n\n980\n01:45:08,802 --> 01:45:11,053\nque
-        le colonel Hardy\narrive avec Superman.\n\n981\n01:45:11,763 --> 01:45:12,847\nSuperman
-        ?\n\n982\n01:45:13,390 --> 01:45:14,557\nL'alien, monsieur.\n\n983\n01:45:14,808
-        --> 01:45:17,184\nIls l'ont baptis\xE9 comme \xE7a.\n\n984\n01:45:22,691 -->
-        01:45:23,899\nNous avons un plan.\n\n985\n01:45:24,151 --> 01:45:25,609\nC'est
-        ce que je crois ?\n\n986\n01:45:26,778 --> 01:45:28,571\nLe vaisseau qui l'a
-        amen\xE9.\n\n987\n01:45:30,240 --> 01:45:32,867\nIl est muni\nd'un Phantom
-        propulseur.\n\n988\n01:45:33,118 --> 01:45:34,577\nIl courbe l'espace.\n\n989\n01:45:34,828
-        --> 01:45:38,789\nComme celui de Zod.\nSi les propulseurs se heurtent...\n\n990\n01:45:39,041
-        --> 01:45:40,875\n\xC7a cr\xE9era une singularit\xE9.\n\n991\n01:45:41,126
-        --> 01:45:42,168\nUn trou noir.\n\n992\n01:45:42,711 --> 01:45:44,211\nSi
-        on ouvre ce portail,\n\n993\n01:45:44,463 --> 01:45:46,088\n\xE7a devrait
-        les aspirer.\n\n994\n01:45:46,340 --> 01:45:48,841\nOn doit les bombarder
-        avec \xE7a ?\n\n995\n01:45:49,092 --> 01:45:51,052\nCet engin atteint au maximum\n\n996\n01:45:51,303
-        --> 01:45:54,680\n8 tonnes.\nOn peut le larguer d'un C-17.\n\n997\n01:45:54,931
-        --> 01:45:56,057\nC'est faisable.\n\n998\n01:45:56,308 --> 01:45:58,434\nJe
-        dois arr\xEAter la machine\ndans l'oc\xE9an\n\n999\n01:45:58,685 --> 01:46:00,394\nou
-        le champ de gravit\xE9\ncontinuera\n\n1000\n01:46:00,645 --> 01:46:01,979\nde
-        s'\xE9tendre.\n\n1001\n01:46:07,778 --> 01:46:10,529\nSi cette chose fait
-        de la Terre\nune nouvelle Krypton,\n\n1002\n01:46:10,906 --> 01:46:12,448\nvous
-        ne risquez pas d'\xEAtre affaibli ?\n\n1003\n01:46:14,242 --> 01:46:15,534\nPeut-\xEAtre.\n\n1004\n01:46:16,411
-        --> 01:46:18,871\nMais \xE7a ne doit pas\nm'emp\xEAcher d'essayer.\n\n1005\n01:46:19,831
-        --> 01:46:22,041\nVous devriez reculer un peu.\n\n1006\n01:46:24,127 --> 01:46:25,252\nEncore
-        un peu.\n\n1007\n01:46:57,702 --> 01:46:58,327\nFaora.\n\n1008\n01:46:59,329
-        --> 01:47:00,413\nPrenez le commandement.\n\n1009\n01:47:00,664 --> 01:47:03,791\nJe
-        dois prot\xE9ger\nla chambre de gen\xE8se\n\n1010\n01:47:04,209 --> 01:47:06,961\net
-        pr\xE9senter mes hommages\n\xE0 un vieil ami.\n\n1011\n01:47:14,719 --> 01:47:16,846\nGuardian
-        en route vers Metropolis.\n\n1012\n01:47:17,639 --> 01:47:18,848\nAvec le
-        colis.\n\n1013\n01:48:14,446 --> 01:48:18,115\nCl\xE9 de commande accept\xE9e.\nLa
-        chambre de gen\xE8se est activ\xE9e.\n\n1014\n01:48:18,533 --> 01:48:19,450\nArr\xEAte
-        \xE7a, Zod.\n\n1015\n01:48:19,701 --> 01:48:21,827\nTant qu'il est encore
-        temps.\n\n1016\n01:48:23,079 --> 01:48:26,373\nToujours \xE0 me sermonner,
-        hein ?\nM\xEAme mort.\n\n1017\n01:48:26,750 --> 01:48:28,751\nLe codex ne
-        servira pas \xE0 \xE7a.\n\n1018\n01:48:29,002 --> 01:48:30,711\nTu ne peux
-        pas m'en emp\xEAcher.\n\n1019\n01:48:30,962 --> 01:48:34,006\nCette cl\xE9
-        de commande\nr\xE9voque ton autorit\xE9.\n\n1020\n01:48:34,257 --> 01:48:37,134\nCe
-        vaisseau est d\xE9sormais\nsous mon contr\xF4le.\n\n1021\n01:49:08,667 -->
-        01:49:10,251\nNorthcom Lightening-1\n\n1022\n01:49:10,502 --> 01:49:12,920\ndemande
-        autorisation\nde l\xE2cher les chiens.\n\n1023\n01:49:13,171 --> 01:49:16,632\nAccord\xE9e.\nEnvoyez
-        une estimation des d\xE9g\xE2ts.\n\n1024\n01:49:30,188 --> 01:49:32,565\nL'avionique
-        ne r\xE9pond plus.\nLe champ de gravit\xE9\n\n1025\n01:49:32,816 --> 01:49:35,150\nattire
-        nos missiles.\nFaut s'approcher.\n\n1026\n01:49:40,240 --> 01:49:41,282\nIl
-        faut\n\n1027\n01:49:41,533 --> 01:49:44,410\n\xE9vacuer l'immeuble\nimm\xE9diatement
-        !\n\n1028\n01:50:07,559 --> 01:50:09,435\nJ'ai perdu mon ailier !\n\n1029\n01:50:24,534
-        --> 01:50:26,493\nVenez tous ! Par ici !\n\n1030\n01:50:36,671 --> 01:50:37,713\nJenny
-        !\n\n1031\n01:50:42,761 --> 01:50:43,761\nPerry !\n\n1032\n01:50:56,024 -->
-        01:50:57,524\nNos peuples peuvent coexister.\n\n1033\n01:50:58,151 --> 01:51:02,154\nEt
-        endurer des ann\xE9es de souffrance\npour s'adapter, comme ton fils ?\n\n1034\n01:51:02,989
-        --> 01:51:04,657\nTu envisages un g\xE9nocide.\n\n1035\n01:51:04,908 --> 01:51:07,493\nEt
-        j'en d\xE9fends le bien-fond\xE9\navec un fant\xF4me.\n\n1036\n01:51:08,870
-        --> 01:51:10,663\nNous sommes tous deux des fant\xF4mes.\n\n1037\n01:51:10,914
-        --> 01:51:14,416\nTu ne comprends pas ?\nKrypton n'existe plus.\n\n1038\n01:51:14,668
-        --> 01:51:17,252\nUnit\xE9 centrale,\nl'intrus est en quarantaine ?\n\n1039\n01:51:17,504
-        --> 01:51:18,379\n- Tu \xE9choueras.\n- Affirmatif.\n\n1040\n01:51:18,630
-        --> 01:51:20,047\nD\xE9truis-le.\n\n1041\n01:51:20,298 --> 01:51:22,091\n-
-        Assez de ce d\xE9bat.\n- Me r\xE9duire au silence\n\n1042\n01:51:22,342 -->
-        01:51:23,759\nne changera rien.\n\n1043\n01:51:26,012 --> 01:51:27,304\nMon
-        fils est bien...\n\n1044\n01:51:28,139 --> 01:51:29,473\nplus valeureux\nque
-        tu ne l'as jamais \xE9t\xE9.\n\n1045\n01:51:32,477 --> 01:51:34,144\nIl ach\xE8vera
-        notre \x9Cuvre.\n\n1046\n01:51:35,105 --> 01:51:36,313\nJe te le garantis.\n\n1047\n01:51:41,528
-        --> 01:51:42,903\nDis-moi...\n\n1048\n01:51:43,154 --> 01:51:46,740\ntoi qui
-        as les souvenirs de Jor-El,\nsa conscience...\n\n1049\n01:51:47,450 --> 01:51:48,450\npeux-tu
-        ressentir\n\n1050\n01:51:48,702 --> 01:51:49,827\nsa douleur ?\n\n1051\n01:51:51,871
-        --> 01:51:55,457\nJ'extirperai le codex\ndu cadavre de ton fils.\n\n1052\n01:51:55,917
-        --> 01:51:58,210\nEt je reconstruirai Krypton\n\n1053\n01:51:58,461 --> 01:52:00,963\nsur
-        ses ossements.\n\n1054\n01:52:59,606 --> 01:53:02,357\n- Jenny, o\xF9 es-tu
-        ?\n- Ici !\n\n1055\n01:53:03,902 --> 01:53:05,402\nTiens bon.\n\n1056\n01:53:05,653
-        --> 01:53:06,612\nJe suis coinc\xE9e.\n\n1057\n01:53:06,863 --> 01:53:08,530\nImpossible
-        de bouger.\n\n1058\n01:53:08,782 --> 01:53:11,325\nOn va te sortir de l\xE0.\nTiens
-        bon.\n\n1059\n01:53:12,410 --> 01:53:14,119\n- Piti\xE9, ne me laissez pas.\n-
-        Je reste l\xE0.\n\n1060\n01:53:15,789 --> 01:53:19,124\nLombard !\nViens m'aider,
-        fissa !\n\n1061\n01:53:21,127 --> 01:53:23,086\nFaut d\xE9placer \xE7a.\n\n1062\n01:53:23,338
-        --> 01:53:25,380\nFaites levier, je tire.\n\n1063\n01:53:32,430 --> 01:53:34,056\n\xC7a
-        se rapproche ! Poussez !\n\n1064\n01:53:36,100 --> 01:53:38,310\nIci Guardian.\nAutorisation
-        largage ?\n\n1065\n01:53:38,853 --> 01:53:39,853\nN\xE9gatif.\n\n1066\n01:54:59,017
-        --> 01:55:00,350\nIl a r\xE9ussi.\n\n1067\n01:55:02,562 --> 01:55:03,812\nIci
-        Guardian.\n\n1068\n01:55:04,063 --> 01:55:06,315\nOn passe au code rouge.\nPar\xE9s
-        \xE0 larguer.\n\n1069\n01:55:06,566 --> 01:55:07,482\nBonne chance.\n\n1070\n01:55:07,734
-        --> 01:55:10,152\nArmez le colis.\nVous \xEAtes autoris\xE9s \xE0 tirer.\n\n1071\n01:55:10,403
-        --> 01:55:12,487\nOn est pr\xEAt\npour la derni\xE8re phase.\n\n1072\n01:55:13,281
-        --> 01:55:15,282\nC'est \xE0 Hamilton et \xE0 vous de jouer.\n\n1073\n01:55:55,448
-        --> 01:55:56,198\nC'est pas vrai !\n\n1074\n01:55:56,449 --> 01:55:57,866\nCoordonnateur,
-        colis arm\xE9,\n\n1075\n01:55:58,117 --> 01:55:59,117\npar\xE9 au largage
-        ?\n\n1076\n01:55:59,369 --> 01:56:00,619\nN\xE9gatif, Guardian.\n\n1077\n01:56:00,870
-        --> 01:56:02,412\nC'est pas cens\xE9 faire \xE7a.\n\n1078\n01:56:02,664 -->
-        01:56:04,414\nC'est cens\xE9 faire quoi ?\n\n1079\n01:56:04,666 --> 01:56:07,709\n-
-        S'enfoncer compl\xE8tement.\n- Laissez-moi regarder.\n\n1080\n01:56:07,961
-        --> 01:56:11,755\nCopilote aux commandes.\n\n1081\n01:56:18,513 --> 01:56:21,181\nOn
-        est par\xE9s au largage.\nOn attend quoi ?\n\n1082\n01:56:21,432 --> 01:56:22,432\nY
-        a un petit souci.\n\n1083\n01:56:38,199 --> 01:56:39,700\nVisez cet avion.\n\n1084\n01:56:43,579
-        --> 01:56:44,997\nCible verrouill\xE9e.\n\n1085\n01:56:54,799 --> 01:56:55,674\nArr\xEAte
-        !\n\n1086\n01:56:55,925 --> 01:56:58,010\nSi tu d\xE9truis ce vaisseau,\n\n1087\n01:56:58,261
-        --> 01:57:00,929\ntu d\xE9truis Krypton !\n\n1088\n01:57:03,725 --> 01:57:05,892\nKrypton
-        a eu sa chance !\n\n1089\n01:57:59,864 --> 01:58:01,740\nMlle Lane, c'est
-        dangereux\n\n1090\n01:58:01,991 --> 01:58:02,866\nde rester l\xE0 !\n\n1091\n01:58:33,606
-        --> 01:58:35,357\nD\xE9gage !\n\n1092\n01:58:56,212 --> 01:58:57,212\nMourir
-        dignement\n\n1093\n01:58:57,463 --> 01:58:59,047\nest une r\xE9compense en
-        soi.\n\n1094\n02:00:01,485 --> 02:00:02,944\nIls sont partis ?\n\n1095\n02:00:04,113
-        --> 02:00:05,488\nJe crois, oui.\n\n1096\n02:00:07,408 --> 02:00:08,742\nIl
-        nous a sauv\xE9s.\n\n1097\n02:00:34,227 --> 02:00:37,437\nOn dit qu'apr\xE8s
-        le premier baiser,\nc'est le d\xE9but de la fin.\n\n1098\n02:00:40,900 -->
-        02:00:43,944\n\xC7a ne vaut\nque si vous embrassez un humain.\n\n1099\n02:01:13,307
-        --> 02:01:14,766\nRegarde.\n\n1100\n02:01:17,061 --> 02:01:18,979\nNous aurions
-        pu recr\xE9er Krypton\n\n1101\n02:01:19,230 --> 02:01:20,981\ndans cette mis\xE8re.\n\n1102\n02:01:21,232
-        --> 02:01:24,359\nMais tu nous as pr\xE9f\xE9r\xE9 les humains.\n\n1103\n02:01:25,778
-        --> 02:01:27,320\nJe n'existe\n\n1104\n02:01:27,571 --> 02:01:29,990\nque
-        pour prot\xE9ger Krypton.\n\n1105\n02:01:31,742 --> 02:01:35,745\nC'est dans
-        ce seul et unique dessein\nque je suis n\xE9.\n\n1106\n02:01:36,998 --> 02:01:39,124\nTous
-        les actes que j'accomplis,\n\n1107\n02:01:39,375 --> 02:01:41,376\npeu importe
-        leur violence,\n\n1108\n02:01:41,627 --> 02:01:43,336\nou leur cruaut\xE9,\n\n1109\n02:01:44,547
-        --> 02:01:46,923\nsont dirig\xE9s dans l'int\xE9r\xEAt\n\n1110\n02:01:47,174
-        --> 02:01:49,092\nde mon peuple.\n\n1111\n02:01:53,431 --> 02:01:54,848\nEt
-        maintenant,\n\n1112\n02:01:55,099 --> 02:01:57,392\nje n'ai plus de peuple.\n\n1113\n02:02:00,813
-        --> 02:02:02,397\nMon \xE2me...\n\n1114\n02:02:04,483 --> 02:02:08,028\nVoil\xE0
-        ce que\n\n1115\n02:02:08,279 --> 02:02:09,904\ntu m'as pris.\n\n1116\n02:02:16,787
-        --> 02:02:19,289\nJe vais les faire souffrir.\n\n1117\n02:02:19,540 --> 02:02:22,959\nCes
-        humains que tu as adopt\xE9s,\nje vais tous te les prendre,\n\n1118\n02:02:28,799
-        --> 02:02:30,008\nJe vous en emp\xEAcherai.\n\n1119\n02:04:11,610 --> 02:04:12,318\nIl
-        n'y a\n\n1120\n02:04:12,570 --> 02:04:13,903\nqu'une issue possible.\n\n1121\n02:04:14,155
-        --> 02:04:15,989\nTa mort,\n\n1122\n02:04:16,240 --> 02:04:17,031\nou la mienne.\n\n1123\n02:04:48,689
-        --> 02:04:50,815\nJ'ai \xE9t\xE9 \xE9lev\xE9 pour \xEAtre un guerrier.\n\n1124\n02:04:51,692
-        --> 02:04:53,318\nToute une vie d'entra\xEEnement\n\n1125\n02:04:53,569 -->
-        02:04:55,403\npour ma\xEEtriser mes sens.\n\n1126\n02:04:55,905 --> 02:04:59,491\nEt
-        toi, tu t'es entra\xEEn\xE9 o\xF9 ?\nDans une ferme ?\n\n1127\n02:07:08,412
-        --> 02:07:09,871\nSi tu aimes\n\n1128\n02:07:10,122 --> 02:07:12,457\nces
-        gens \xE0 ce point,\n\n1129\n02:07:13,208 --> 02:07:15,460\ntu vas les pleurer.\n\n1130\n02:07:19,923
-        --> 02:07:21,007\nNe faites pas \xE7a !\n\n1131\n02:07:24,219 --> 02:07:25,011\nArr\xEAtez
-        !\n\n1132\n02:07:34,730 --> 02:07:35,855\nJamais.\n\n1133\n02:09:10,534 -->
-        02:09:11,909\nVous \xEAtes d\xE9bile ou quoi ?\n\n1134\n02:09:12,161 --> 02:09:13,870\nUn
-        de vos drones de surveillance.\n\n1135\n02:09:14,121 --> 02:09:17,832\n- Du
-        matos \xE0 12 millions de dollars.\n- Plus maintenant.\n\n1136\n02:09:18,625
-        --> 02:09:21,169\nVous voulez savoir\no\xF9 j'enfile ma cape.\n\n1137\n02:09:21,754
-        --> 02:09:23,212\n- Peine perdue.\n- Passons \xE0 la question\n\n1138\n02:09:23,464
-        --> 02:09:24,756\nqui br\xFBle les l\xE8vres.\n\n1139\n02:09:25,215 --> 02:09:28,217\nComment
-        s'assurer de votre loyaut\xE9\nenvers l'Am\xE9rique ?\n\n1140\n02:09:28,927
-        --> 02:09:30,762\nJ'ai grandi dans le Kansas.\n\n1141\n02:09:31,221 --> 02:09:33,389\nOn
-        peut pas faire plus am\xE9ricain.\n\n1142\n02:09:33,682 --> 02:09:34,557\n\xC9coutez,\n\n1143\n02:09:34,808
-        --> 02:09:36,267\nje veux vous aider.\n\n1144\n02:09:36,518 --> 02:09:38,728\nMais
-        \xE0 mes conditions.\n\n1145\n02:09:38,979 --> 02:09:40,813\nIl faut convaincre
-        Washington.\n\n1146\n02:09:41,064 --> 02:09:45,067\nM\xEAme si j'\xE9tais
-        dispos\xE9 \xE0 essayer,\npourquoi accepteraient-ils ?\n\n1147\n02:09:46,153
-        --> 02:09:47,737\nJe ne sais pas, mon g\xE9n\xE9ral.\n\n1148\n02:09:49,156
-        --> 02:09:50,865\nJe m'en remets \xE0 vous.\n\n1149\n02:10:00,417 --> 02:10:01,793\nPourquoi
-        souriez-vous ?\n\n1150\n02:10:02,628 --> 02:10:03,961\nPour rien, mon g\xE9n\xE9ral.\n\n1151\n02:10:07,132
-        --> 02:10:09,091\nJe le trouve craquant.\n\n1152\n02:10:11,261 --> 02:10:13,387\nEn
-        voiture, capitaine.\n\n1153\n02:10:23,357 --> 02:10:26,567\nIl a toujours
-        pens\xE9\nque de grands desseins t'attendaient.\n\n1154\n02:10:26,819 -->
-        02:10:28,319\nEt que le jour venu,\n\n1155\n02:10:28,570 --> 02:10:31,364\ntu
-        aurais les \xE9paules assez larges.\n\n1156\n02:10:31,615 --> 02:10:35,451\nS'il
-        avait su qu'il avait raison.\n\n1157\n02:10:35,911 --> 02:10:37,870\nIl le
-        savait, Clark, tu peux me croire.\n\n1158\n02:11:25,377 --> 02:11:28,212\nTu
-        vas faire quoi,\n\xE0 part sauver le monde ?\n\n1159\n02:11:28,463 --> 02:11:31,632\n-
-        Tu as une id\xE9e ?\n- J'en ai une, oui.\n\n1160\n02:11:33,802 --> 02:11:37,805\nJe
-        vais trouver un boulot\no\xF9 je peux me tenir inform\xE9.\n\n1161\n02:11:43,020
-        --> 02:11:45,104\nO\xF9 personne ne s'\xE9tonnera\n\n1162\n02:11:45,355 -->
-        02:11:49,150\nque j'aille au-devant du danger\net ne posera de questions.\n\n1163\n02:12:03,248
-        --> 02:12:06,292\nAllez, Lois.\nSois un peu charitable.\n\n1164\n02:12:07,544
-        --> 02:12:09,211\nPlaces en or pour le match.\n\n1165\n02:12:09,671 --> 02:12:11,213\n-
-        T'en dis quoi ?\n- J'en dis que\n\n1166\n02:12:11,465 --> 02:12:14,008\ntu
-        devrais retourner\nvoir les stagiaires.\n\n1167\n02:12:14,259 --> 02:12:17,637\nCe
-        sera plus payant. D\xE9sol\xE9e.\n\n1168\n02:12:19,431 --> 02:12:20,097\nPlaces
-        en or ?\n\n1169\n02:12:20,349 --> 02:12:22,058\nRefusez.\n\n1170\n02:12:22,309
-        --> 02:12:25,102\nLombard, Lane.\nLe nouveau pigiste.\n\n1171\n02:12:25,354
-        --> 02:12:28,564\nMettez-le au parfum.\nJe vous pr\xE9sente Clark Kent.\n\n1172\n02:12:28,815
-        --> 02:12:30,107\nBonne chance, petit.\n\n1173\n02:12:31,652 --> 02:12:32,902\nMoi,
-        c'est Steve.\n\n1174\n02:12:33,153 --> 02:12:34,403\nEnchant\xE9.\n\n1175\n02:12:36,406
-        --> 02:12:37,740\nLois Lane.\n\n1176\n02:12:38,575 --> 02:12:40,117\nBienvenue
-        sur notre Planet.\n\n1177\n02:12:43,872 --> 02:12:45,831\nRavi d'en faire
-        partie, Lois.\n\n1178\n02:22:57,777 --> 02:22:59,778\n[French]\n"
+      string: !!binary |
+        U/gtQRXJSmcPgKrA2N0Q67ie73utT/vPD8eC2rlOVB0AEYHl/pnhYVPs31JTEiVSmmVFZaKqwM5E
+        XgKJ+0haz/uLYc/CWVu3Z928l/7zmtln/r9Ab2vkIF2D1EmqTMz0g/ic9xDcCzB4ICoAyAqAKgVk
+        lQKgSgEp9WN1Bw+aDdB4YXlleW16rZ7xIk04LFUHpZYXqdvrlk0Q9zgaO3Jo695XrL2xP/sCcTAI
+        Id82WSp1rT33DMFYRtKUmPPtSXYLhfLfZydxFB+aQ2q1qqL2+u2PaZLLBYllS2o1M6vK7D6eKUu+
+        FFsiCRBsFVPJce/+VGvE8dCgSADfx4DWZ23PxqBmr+7u/i31xt9wxug8/JjVtK2Xlmv+cnfdRleX
+        1NULeJNV3T6noeas/tI+X/atqn7Kj49bnVu+B7DOxwStCT8woAjDq6zqKfddfRynUbNa63+wmrPq
+        eU2l5n4P32e1nNI1la7mst8D0JqfDBi0fA9rkbSH158uy1b23NSyyv+pqKbTcdtT2dU8VB9lKnO+
+        h+NfJJVUmqbjthy3dtwAGNxdE4n+f4ygdRHu1JLVb77+P3Z0NZ/Kelm2XrZ6D3fqx62rdtx6btfc
+        1Xw6bjW3p5IBxPeYoFjd8BiigxX+D8x1V3tqJfd7+Hmc0mhlq/2ubqOr+fj/1WMqLasXAM7jjYCG
+        g/sfSAbFefglT9topak0Pqnjtm9lyR3h94D/j1TLaau7ekxlV3XrKtXp+Pvecr8H8OCqGzbt/xMJ
+        uujgu0V9VknNpzT2lrtatzrnrv6lk/9VHpbc7+HVtq65Hn/baleX1NSSu0rXVPe7y9b3O43CdcGY
+        cx+hiE4CvK7X0tPTl19DP26t5NH/cgz/VjCfjts1TSM3tW9jz2pJ6rKkevy+hyeKexQx6k38ABOS
+        DfB+G7ta8vK/vypTUbnvaj5uH46vat3afg9g9I49lRmN4//J7NHrAK+2+ljyl7t1K2rJatrm/Any
+        rj6cUu+j5ZaKWpL6O9b+kKzmrOq2t6xamvI9gCm6PQ7oXG08wBG9GPhuUS333fre5ZT7ZSvtHsDU
+        1FNFo9b0eWJRNMP3p1TUnutQU97Vj89Sue4tqzV3taZS+z2AKaLb6Kw9MhX9r0NnHVEcwauXf0rt
+        uSwqqeO2Hzf198KV4SHiXaNRB+hhOhuDIUZ4OVTdVjXX9A9ZlqzS2LdW9uOmXgAYcTFm0Xp5gJC1
+        hjdJrSXXGq3UGTwZ0Ih7rzXIouG3bXSVkL+lnlv+oj6Mp+PWIe/qP1mgULk+T+u4fRy5bkHiV/FU
+        S8hCv8FWMEYHd+rnkdVjKv1uH6j+vW1WL9T7oXJXj9tQ38Cd+j6rekpFfRxZ7W27AJjgecyhZf+C
+        w2gY/lq2l+dxD2Di5WMejZP/kIBWe3iVu1qO21PpS9rzaB3A6luMBWQJ/yMiChvIu1ryaF3Nx+0h
+        7V31VLt6LBXAGvsnI/po/x+TxmgCbHVX01bnUXY4vqolqTZKzdh+dg9graefQYw2+gOC0TG8K2oP
+        0w9pU+5qb2VbL8+57ghgs26PHFqzl//2FDCwhTu1D9WO21PNLXXVR1PzUNcy55D/sJfL1rpq+cNW
+        ar9bt4IANhf3KKKOW3mILRofIZU5V+m7j6+qp3HNrRS3f8kTXN17fFVfjlvb7gFslj6VLTLp+5mQ
+        vYV3x+2SGjrPAWym7jOht6t52CF7gTl3tZSnetzyHn3C03Grx62lvVxzh4+jKJj/AVvd1Zrrcetq
+        Ob7eA9hs3WOH3pbA53HE6AP8PIqaj9tU5twSlJx/O2DQ2bVtdc/kOYBN1T0xKDYfDohFEgfvt3Lt
+        KI4xRm3aDp3R8GOVgA7cd/wtoXq93ANQqu6Lw+BMPzsiWQPfZ1WzuubxSV1Sh48jP/8Pm/M117LV
+        rnKteS39HoBy9wmJKP5T+awtmhjh/VCpq5brVqfj1vC+6dJKncoltItRS+8Ntr4HoEyGm2ss2q8Q
+        qvyw90Ptp9xVy/s2Wj1uAER224Q+Hof4rAWjMTBtOPtHL7mrveSc+N2YQ47uvRHJE3x/et7q1i4a
+        p+dtXXNEin0oPrDs6kOaQ5HKEm5EDPT6HmPQRwtvU+9qRd8bk3JqRywE9sK4ByDn5mcYQR3CqkO2
+        Bl6vK8O7uOR7APIWT7UWJcqDljDaCD9stZc8Grbhj6hrUg8lV/UCgIL5GKMJWqR+Pnr8qym1Pd/t
+        W7kHoGgy5pA4Lh1Gsl3tPXPZ7+/vAVg/yR4TBru2A8wYnIOXl0vTefVNaukegI3NmEOr7X9YQPIa
+        vt8aqjm3Vo7fW1b7VtQ3AJwmj4tF+5AwWjHwJrWE6tKgYDWrJasl1YminN4DcMbcFEa58/vFoXER
+        vs9qzwrQPqzSUJdldHUte74H4A77E+lFT8gfkrOxaJjhz6df0l/TWhO5fFcMujI9LGdhJGPgTv22
+        9bGYp/zbqBdwp95to6slqYeW6vSc1ZTr3tLu5+zcjjGKs01BFzz8kJztrOatdDUONNpxu+ZKUnL2
+        LsYEI4VPDGjJwJ+2NuWmlqSm57Q+tDbzWU+5Hr/3DLnvalQ1tbLmPU+Dy52AHFB+xZ21Re0ihy/r
+        KQURdPzjW9tTnTKqv+Qlf7qHN2SvtW9jes7tYE09lnoPwDB305+1H1HEF9u3Bgffb+3u9YKQSE1v
+        OfGZ+TwUlr9nUf/eNiOAaK9jRqOhbzcWtSFouc75y5bU9wDSn28LZ61R242swlkbPgbO2pq38QnV
+        9p/dA4g1HFqbZi+FsyX0YqnR/8pr/qL2to3rcWPKuZCXbUaigf824WwdOtJwp34a5R7u1D9v6Vr2
+        VHcqV42m5nHNDBb3qQ9p1IwAwk6fjBgCv4MMsgvwq6HLg+Idi8B1w8DvDhCKsfDdonqTWLZWWhoN
+        D3TV0lzSXjawzcX5GXPo2DwcMEQLr/K+Z3XZLmMx/ATV8/qwZFXqnpelPOVafLl4X09GDEa3WGOI
+        vJ4DLalR1SW1shdR2GWDAeglDBznhuDXiszn9wASLbYZhfodCmcWJPHw3YLli33ktjWs3GmrMUGn
+        w5lHbWXgkn0stMl0kz3GvPi/wBGN0fB2G03l8QlVeZpX5pLHPYBLqj0xyJwSh4RQPMHrXfVx54Fr
+        Kr3nNNRy/FfTcz6N3J4wCu3kQgSFolet22i4nLpc2RWHkYBLgIm7goN3eSz3AK7xSayNPyX8JC4C
+        GXglHpykcTdP45xzyEDP7wGcc7JtUQOIxmZ/R4Dvs7rk2tOcgDG4raZ0SQ8LAuXOO9km9NPkJ8Sz
+        FmSn4YdU6p5rqhqGK8u3cjm+ehiFbcE49L8az9qjsxFEkyx3/n1fWutxy/cALlrfCBjo3heMRuf5
+        6e/sSfU8lqym5zTbTL023jUGqQwlTldTF979riXbETEeUKtLHpdGkHvja4yRbXhZ0JGHn0YB2RfV
+        CwBv4YphCCbf4jGwh1elfsydH/RJzae07+njyJBaK9dc91H30n4P4MnjjYA6Rn7NamQieEOjq8dc
+        O8tBQ/nMsqc5L0uGvtVdpZqWz/24yRpHDD6uuSBO0Toz+D6x71T7cVuO2/Sc2pN6ZGE69em4ay1S
+        2kpE3MpreDndQUOxiXfTCnLmrtiAJAHehCK50w7ubfkptTm3ewCfcWNk0PvDxGiDgR+30VVlHJ91
+        za1ttasPaU2lqzW16dnRKHQdWT0UzxTQmQA/lh/NU657rvNnTB/LdLnk5YfNwF1m1JBaxTNL6YAF
+        3LccX+8eUkeAkHi7LOih84F4Zo/OerikthZ6bLUo8Lk0JNoeR9R6aw6LRtECZVHXcsUNCQh1m9Fn
+        DiiqwycbfeaIQRy8nEseqNatqseyyEwJme2IQTP2PmD0WQg9CbwfKlOGKneoyl3r79fcVdbFWB9w
+        9lO+xZzJIreYTzHmTIKWBH4rPX9RfTQ6XC+5K892GpGkjM0giK8d0SgF6owZxlpM8G1ayes5AgRn
+        8LhBHxeMgYIS+XBXb59T3bdVXdp2GUtXAFAE/4Mu7fj73u/hTr1t23Tc5vxFHV/VckrLMtb0lO8B
+        gl/UmKAj8zaHjgz8sFWS88I9QAhwTS+EsN5rz1qjdRp+reoeQORL255HAxGpaPkis+6rOdVeuNU9
+        QMi824w9a4MWMRfGnrWFneGvlWfnUduMEQbtPuzQBAtv27Yft6f8RU0U4HOWtOfHra0Z1bSta6pz
+        8haZPRPQmSc7YDUKafg+qz5hJqt3pK6u23LcQGIa7RPsWIMOt8SI0h91McIvuc79bskAkS4fsxhF
+        V4xRpBz5MCPIAppGTCyvJcsY5/cAke84Jig+nAY0tju6UcmTXIci9olzuGyjqfUvIEAUMB6Qf/4D
+        pNFrD5fU+wXGG3rY1Biq47YM7Vhj0r7DnsmiFeNtQcgmKNqYRiA9n78AiN5qjNC5uBSMzmKeS1dV
+        4KWhRlW5Pm5bFHbJYYSEb7FnCkgU4VcoSGNu7VFAiWv7ABuUSPAmqUvL6wz4UE2l91SnrGraR2sq
+        H5zzZZSu5txVL8fvU0XnRifhDluUviBGNn7BOguvd6pVLOWBA+ZG59tNZvSLf5k9WkvwpoxF7nFr
+        RK6n+sbbZ30vJCE3Ouf2OKDRFbPCEUUi/PlA49VesvoGwOi82xOD7MP9kFg0LPDtcdvbKF0DoBnz
+        TIh8epqdGDWqcMaNwbx6JNsOPbYJLXBdIhz/atrGrpcjEKlzvxWQm4YYEepcU4A382rR8uU8pVn3
+        DMspDZpXyJLPjPZgf82G6PAuRs8RXtY6lqlrA0MyowFNmF17vFWMXrAIQeA3XoSOIvf7l0aj7YCm
+        8oQF+UZ0sB3/71GVPSY7y/W6fZa9eaawZ/gsNK23DZ9FkER/10+NeLlkAHNIwEsCJ/aLkRHaLjj4
+        S1qWxmOBdxg+i0eSZ3lAIpoQ4LEsXc0ngU6N+H+bkbO2SFPvK0bOmtFJ5jZz39Xz1ni1XvnhbGt7
+        AvIIwBk52PPD/oCcjUMfIrx8SPsOvvHAgPtHsmMFjZJ1v5GzdSjaw6vywG9OR1mWW0ZujwJau2xH
+        UZXQX8bq9nXrKrW1Qqny87pBpHUeYIvaEvy29el4esld82TKrZJGNWq+M1IifeM9YCCaO/jnnfFE
+        /XvbvBdptHucMNivORQfARQShxlZmqPtLUMmwQef09iz2lt6Lh2h1cj+dBMELdoZpxcUbEDZ4VEN
+        TmbNKNHOCKnUfkBx+Lp1VWof7em4dc8EInHttmve/ddgdN7A8VWR1mr6PC25w5xVy9NW57KXrdZu
+        sKr6tqa9fBzIxrMBZ1z7HXhaatNjdA6+fWTXKtCihTa2uh+3fiLE04HbjDsbg1Y0dsadESX2lKfd
+        8uPo+cvA4kYfkwFWj+wt7mwIvaTtjJtIMg5qCCLU6GkpreBBfByW/qZitR6PW8tfpHgbyroBmPOA
+        fePOxsHtIXc2Aa3zkEYytVTdSlMbfeh03PbcatmP28Fd4mI0tLpML7uzNUhRarpLpWsqu2qpdHx7
+        ZHFp4ObydePOVpCM+yHQc7mejr/vubPoi4dU5wyHVQ/Hbaq4D8L7bXT1YfSP48TXF62Wcl8NH+CM
+        o60GJJ9SeWR9JCRX4o+cwDuMO9uIxjzpMzIoHna6cMm15y/BZw9RgHssQd1DIxjUUAXOuJqhEx5d
+        gwhjtLx/lVXLEFaRW0ofKYXvPjFaXsfDHoU8fJ9VO27TuBw3HnYGU15POpoduZ4XujyelMJ3jyJG
+        2WbHhlj7CkuxYTvGFr38KpgxkLuBFFHp3FDM7rHHaF+Yv5NoZDceOZk0gBiwLHB817tMOBNjsKaD
+        AHc3v7aSjJqX1NX0nPtEvEzZU34OqZt3TNAZrgKKB70W9fRZJcUHzoLycTzBq7JR0uQKxMBmocQQ
+        MLG/KI4c3SQKxCBl3fjpz1iQ8J10AWvVUAXOhEwXhJIECNF7rSN41Y5bVqMy+ytrLsuSRyNVDi5Z
+        1eP/2FtG9ZdmRg2X4Kzu67wU4ayOwE9iDX9Kpaun9PiYUaWHNvbfSSncZvWZGE1B6ayGHy9ECz+N
+        KxP08Oc8PsE21D7UY6mlJZxJHpKblHqQRIOzujv3eJZPsPrMBo0I/HT8vyr3/S6MG6eydLVrNz5p
+        Pm5P274fN4SHJdXp7iFP7xW5B04ScF/0/aw+s8XgBP6Uxq5aXre64/DsBtXwDu+0+syExow+yOgk
+        wrvjNo3W7NZLVheAUg0HwSuD2P7/TqsPR2Php6qSavn4Ww2PEucDas5qPm57y71ngJO9/mxFXY7b
+        3rYlW2DbI/dUDmgc/UPiiCyyusjvCaNxD7khgt4YIKl4SDsm1Z7KtSwdVRfolU/m0ndcTQ0PwdHd
+        uAonoVUevEk3sX5NKn+6LFs/ZUkzcIDfN2fWZOCWhz+WXLepvIfXEELreVvX3A/NstRdACPtMZNj
+        4AwBi0cya3phIeT+5Yel5C/36rsFECjXrf2W/jFkagQw3MNt1pw1o85MB605a4c6ekgXLANwVXPN
+        XX0YK8Nc3wMYDsJZg2d6wMi3WHPWAaMX+Dh0FCQcbrPmbDxSUfWKNWerMbh3HiAKQj4tEpjDp+3T
+        56fj95rv4afKr2ZzO5PWl60+7Xm99E+JeJcM2vgX81YvjIPvJgQbkNvH7qbj/9izcmL0Pfxas+JB
+        dUm9p6es8q6YglLtpXcjVeGsgda8hs9ZQzNMfQQBV/IX9Q38uyo1jNVTal3KcNdyej5uS7lsbV9u
+        5LYl4nEuFkrJgjuA9I7S1T2SSE+IRUiuGWOGLS1ycG/32WeVluW/Udiy6Lmoz7L2rBlZC7xclvxF
+        faPen5QpdVcfB/evhqlQ20963ZHYFvIh8R7u7+/VktVfUu25obiWyt1d3HNrZd9Uamr4C2ct6Oa1
+        Z7/b2qaHV0tqf9X5pObqLYceF6mtPYviqvl+qPV03HpJVo7qgvAGnbVNpXdZOmvGwBreCXgQTx9I
+        atqWrZZ+3AAMY3GbpbMW1Oigs1TDbhHB/eHTIt4xEUmF5CxhRInl6HwWXA178Q5LZzaow6gWW3Q2
+        3PwMVe+yKPdQw1nwyiB06s4SqjA1BB9Td9beW6ofRwHQ1LAVYjv2wJYyYhvzMrDRhuEMvnzc1J7U
+        esaSqRDbQw+IRy+EkLiqyvoAfbHQKD5VCCWG5yIocn/vW7eqpufj1sr9C16taU0FAJmKd1o6i8fo
+        p1lG1CY+8ZNtXNsfpCR4Tc/6N0AYMARdqd/xL/+0S+qqbm1Nyz3cqR/INzU0BUf50HxmuRl+gOHt
+        kkerZXrOoy00pUFjFsU5EfLNvcsKx3mue4NS1B1y9R3qwzayStc8yR+TIa9UQ0ZwmsCy+2JlIpn1
+        +52lcv1IthxK57tm+aw9kgNoZ9M//acrHrmtgCJa+qLls9HoxFGFH9tPqcy5QS9qH6rudHKJd/IQ
+        HDqIepW3GELLllHHkf0j23ZRTy3VGZ9wGqbZJuQTDuqTypgIaq4mqpYueadDGMakHm6zfLYGhakR
+        q0NpeqPh1Va1ClCPfBD6aGpN6rqVT/cAhogQKzQZWpnhLo/WMHy3pqciMp6r6QSRrh3/05IRwPAR
+        HBFSpl7ns41oJQBsvTxt03G71TQE1R5pDHrUKlnUkeH9gG6zrexuGmLqJgmGnxfkMLAuxIzBR4z4
+        ekCzIyus0QQHP+Ls/0dS7aonNZeWp71s9d2bgwmRNBDSO4nFll60geHncSozy6Ku2fXC9Jy/qDUj
+        kI3IrNNLei+DOMz6QIzwvm1jHtPKU3/9mKCwfebR6uff2E+pq6swZbmmfXr+sFEY88hOS8SED9yp
+        P5XpOd8tQ1576JLKp3u4U+9PeSPqmmpadRR3SKNtVn9qXQigPiRorb5Vla6bTk5BbXfpSb/5g9No
+        k2aNAIYzeId1ZxI0flM+gQQDE/S0ZLXmNucRnyQIbrPhbBwGMtjZQJE6q19nIHWQgaf7cUu2wNlA
+        hvpH333hbDXaoOG7ZRRDtM7qYdzQEcPFgWjGxCpESrJyaNZJXUfF5bI6uZ1KAL3eK1ztafQoQiwS
+        2pfzveFsA9oQ4E696lLep5Ka2lDXrbT7OXR/fw936teaVQrSD6m5XEvNqL7fatqfjw3yB99sw9lG
+        pCU3yKDXsco+b9u1zBpe/iq2ew25M5CABSQaHanzp/SE7FSjqovUQQ19wItDny2h4jigdYSXD31b
+        xoF58JL6PbxJNanltGFVGr03g2QWONDHrdZtOLNF60w1/xnqkveyqz9tbX5O6z2AJQ546UDM3UI8
+        GhhPBKrcDXqieNyKEDg1szxOGP2ZYAgxDYFoORs1q50BKraeF8FcqDF7enUZdBF/UHv6I9dtLMgW
+        GDiiMUIhOndog+Quh8BIX96qylUlVX15SQ1wUcsrcOg1ITfXwmOwQcpYXFsqRdVyC2KVEIFVFoj9
+        +SzGAD99lvmQQr0fwjSIBdUSDe+w8WwMcrxZZ1j17F5lYVCZ2q7RX9u3AvNW9k5wvamep3b8vu9c
+        5PeNIPnlHIpoxcH3pzSaRSX2aZiSev4mdzIPMpistBuMwp5l1LKtUEo2DbzNY7+TpWD3ovhU65Gi
+        /gAZpEjw5pTrhzwKodNldKWGy3clsv0ibENNeXxS0thWrvs22m9qWQqxioOQsuh3xDMJejLw80h1
+        VprqLJJRS1WIlRyEDhT5NcUza3SRB0KtfGgb11Zagj13xc2BqezHraM6/qYLXNSn3FI3iA+xMbvH
+        GiOvzDERtN/x49bV1LbPqU65o9NiddrqlC972eTvNoJ3mdB34RL12ctoYc59Z3KSIFIM1HgeayoV
+        P+VqRjzm0DOdRRRycmS5pv55O25nHlI7Su6WmrN6m6MqNQH+OEf094nBGD28XpacE1r58bGlzwxM
+        bk1wP1UIjeWGEEbxSi/bz+XWRO+eCAbaw4YEdF4LaqqnXLv8fOeSR9sSVxbJiTF/TeqpOAdrInhP
+        Aka7rU6iQgF3kCTQj4tBFN9G+qwNxpo6Iw1eWNSv/Lbkti1bTwkJoVG/ALAWiD3SZy0o4PcgfdYO
+        Q/Dwy3G7bHXuVKNa34Mjzct7JG1GOhGKxhTcKTFB0EiuHF/v5jynepv0OzjSzi9PgeZIZz5heCvp
+        /bMm48SBUbO6ll72rA4FZkzKBP6JlCbtB6yN10mfSSOLldZcvuTWt1ozgRFwq3U7KIFtHvTzMukz
+        O3Qk1qz0umloQJJ9LyIZcBRlO9JilA+Lg1+rmp7LWvqeAaydgVf4xWpGmi92GuRal0ct19y6FJYt
+        cwlgaQsOCEh5IwTG3RG9h/WU1FxOptiVd/KYyg4Hlmva8T+c5OQolPC3Li2oCOgy3kpR9ZQ/lV49
+        zS6pl+suK0vae9JQl+PWyjYTVmqpjNvInLVGVxYLwWprwXh4OfZGdGVzca+ketS2Rf0AgJ7tkYkw
+        JW6+QjwnSwDLWggBa762Ugk9W8QAr3fleVG3KmTGuMgOjCbJV8mcjcEoVr6U9LPmPZet9ozqsXSj
+        Dv0KjgyF5vnEVsicDaMEi5Ud21DHV/jDO8gRbhZoA5Mu0rEPuqVe/AHAcheODNHrifUdGXcWf02u
+        xo5jtZzSF8kLXjpgs4OvWI02MrzWvBiXqc77ELmB1YDIQTJnSyghwqssyEWp8wG1bKPN6jG1OafB
+        tiZVEI7uBrOO/BhhYL30aCW+hOiMTVd81TTwDnLay8dXNbWthOojEvN+d+x9OtJ6kPrjOG0njhUG
+        gBHeGjUTI7ml6Nwhg0LJrJM5E6OOkcq7c8pdPWxjydfcTJEHOqpR1YdtNF+UjVjk8o1bdeTVAzAE
+        rHR1za2lLoeSfHzJA6/t5lKrV/fwKk9b3S3H16lHpuvfxu9nzhSRhKEsas/qMY25pTJoOaqanpv0
+        3HJc71BEh9GukjkzodNR+FE9b+VTPXbglHofa27q8UCg9fMkX1MFyZGfT7vaRlZKOfB3WJCI5AfI
+        nDmgJg3vivpQHDT2Ukcqlq9yLs11k3zAudK9GTt/AWA56G9yQB8zF0SjE/8m+rLD3HK874mgsSs5
+        E4/GnvOtjyMvH0f9GaKYMrcc9wPxVh8h6LfWTKBAy0bFlSp1OX6/CSnRdcu81XrcrnB1azvoyhAC
+        fwMDD/EHvzE6gu+W4GyVqQBY4uMdZM86oHcjP2Asso3welcfR9nfB/lsGG2kqeUG/CXg+yKrXbvW
+        QrUPtbtGSgBrvOBsQxem/0bGoB3UiqVakrEN1rxEDx+STsxQnp0zR3j/+s6W4ysf30xqTfWf/lNy
+        rn4BYKkPDht4vScrxEguwKs6lEkAZu/lU0vruoaRHWN0Ji4cek0afkPTycQZExv/QBuTOr6q18uS
+        +5rPRnow3kX2TB4tu/k+IWI0AnfqZWnTtqp++txB19esZj3a0agO+QP3cKe+TbWryYqq4z4j3mON
+        xs0vbGqKwcaG+rbUp6H6Ustz8DrfViIkWHPW9LXgg79jyaWq+fRyPW6tTK5itcwGRwzZTVF71Oxv
+        AApdLrlWKveMqraHD3lXCbedg5WQ3WGPFmNWUrcd4gh36rekerqaoos79caIAFPoHerNmJftH+7V
+        O8s4zp5UgnmPIwYdNioawOxOoTsr6tVzK72XXb3wsrXj7/ve2Jjtik1FiNu42zoDd+pl7yXP3da2
+        sa7zewDrAndHCEU74cieFMjJhPbdkoaMzHZEiTMldWwzwLtSt8rYrKF6altXMz+olhbhxYHHjITI
+        jpmJenRyNVyWLX9pgdHnkxgR4kGGrCc4j8jMhgmiqNMPeXiVCnzsDeWDcqHouf4P3EzCs+6aiJzS
+        4N7OdJC9QbIxvWYuQy17IuRzHlBYSYM0UrCer9k1DYzkUlbTNi7Ap2zlMpkUIW9xIHR2RuTkySxw
+        pKjXin2rqp3qYStNGryoNbV5psjvMqGOaPAx60EE3u2t/HXdLACA7oac3fhz2xL8kNu0K2m8ejui
+        KYcA7C6D9fCDffG05nsF2s/TsmgK6xcA1uXhiBErvzSCK5KAXP3HkiuM98mzej0eUv1rRzWfXrZp
+        L5N6ldqTzZk+Dw4eCs22EPTRQCyX+q6WrXSyWd8tVFjMyHacTfIQ8ZkjEjm4O/LAzCzSpR2/16zg
+        XrN7BTTd0VWapm29pKejrHybGgSZgfWBcMJtCf4ToIlfePh+y4j1suU6N51b0dOUiMm0CBk4B5p3
+        +i4htDHAt1utSLIbNYjgHkLDn4HlXjhgILw1LXGoxbC9KJMSJVTJthE3JGL2ic8SXvZCztoQOIDv
+        nZNfSNdt5IbqudcIYH0gHBUQbbpOctaE1krFcnJKZQ3iz2jbRS1ZfZvK8lm9XVLNe5iGuW4SOl7O
+        0qPTXIzced26uqRLya2rNxmxdqCPci35CywJsb2zl62qh6XU+bgtdBS3PAa+ZUFy1rExK46/pR6+
+        vqbpWTK4UtZLy72XMqW+B7CcDYcF0VjxEsnZEEZt/X3Pckr1aSu95yhcXNJTVsKXxXOGXrYDndfq
+        ulX1VJa883Kzu4ckVlDL7txGcjYRnfrgd5IMnHnvSgDrNeEFYWj3RBiQ/6ZR4NW2bDUv6s+pzZ9R
+        /fpO/bi1/Xna1nt429TrtSzqz2kti8ZeLfXDOUKf6R+Ws2UM3sCc1bcvf3n7cgUjHhM0lpYObYgq
+        Oyr+XK7fq6LT0kdy3aHsqLOep0l+OvpjzGKu5hz1tJs4EnCjIxNkpMk39rcGWhLYd3zNRNE+Dt99
+        +8M22nx6brUeBRF00j+lRFydK+zhh7zvG2WhHZuGC7qclpSM0hC+e0To42NYkENHKLUlpWs1pabs
+        ky6bATP4Q5as+raoKdU0l1wBbAjaATl36irJmTWSpm/PKJOa/K1gyiFd+vYPeT9usJxK/bBVSK9a
+        s9rF6BA1VsdtSt8ak9sY1jdZo7waL7FFFwy8+7aYok7bN3VUWT2Ux+n6rhM7RwAbQ3aXLcY2QITd
+        L5yHR6mrPkSamnF7b7nmZKGbxlgesDetORLdvfPBR+d6ssBO9n9f+fHlu5cANsbtHgf09iB6SDRy
+        0LDVXbW8ZOSsdUp1W5OuLbcxivdEo6d4WgihiXqp/CE57g/OWT0tacrq6fi7Me2jx2163vpW5/SU
+        AWwM7T0hZN6QV0XQew93inTIrhv6RcZpVfVt9Ls1te8/SWOQ74lDbV9sEVKOqBZQ2kbfruW4iZu5
+        l5EfiKfhhCztB50IvM1DXdr24BudqeNfAJcVaa1InzRG9K4EjAWCOA9lnNTtjKVS+6atmNUUexsf
+        aal6Qdgxutw/QPy+8adyZ01Hl+xNTv63H5dyuaTqmaAEOt1O7qwZZc8Aejb0Fkl6D/OPo4AChVpO
+        e/MSgCAnNgks+HAnubPRSF4gqQX+jjkrq5XWWiVRfzdpULsHgZ7+FmPRubjhWapvAAhneie5s2HU
+        3KQStNGGDNNY87gtW3mqG1hebMRjgsJBwqSRfAeJkQT90PFV3SnW//S/qCWpOvYcSngTmwUB5xRi
+        aX+DIQc/VVZusvObW9PWLh2Y1dWllUpJwwBEbs8yGh66lhV0rLnVWng1ShCTELt6YO1TONK+C/p6
+        CgbJcaVcyl3bttVvg1CSELodkCuPEJN6ri1Zdr06quo5DVRXZUTR/CCwzyzen2QtWvjp+H/VVbNF
+        2zCTileCioQZkb7+7DfB+iwerRZgRMHFJTWNtjzSZyTMivw5/d+f2lvM2RBqTZ5wDnMaAqnfPabJ
+        6wOjZvV83NattfRUZP3S1nMluYtjwz3xNrnCRMRjMbIlK6Y0eJZ39NxQ9VK3+v0Q9RHOXgZu6cjY
+        sMFSTawxLUZyI6LTt65WZ4VD1HR8yo9N5hVQQWzDwdYxDJHbsYQmcezY4PD3egtvW675i1rT3lXJ
+        1sqx2T90dTPAc+b0ZO6AB24l16qEJYDeMCHJUokWAPdxuutMm58C8k6guOO4fRzlkgEI4mHjwFt1
+        JawJFL9uVJdWejAPYEzTGzNvCUBgD1sHYnsgnKQ5jS4AMqZ1vgX1DtPfPH/adClKrlfC3nVDax5v
+        LaIWgTcnofhKVqVv+3aZ97kWYlJcQB9PTwsDxBWpmhVphMW+BqSf9jITGrYgecUTW3LGgaclTSU3
+        uGTpKe/563NWJkybhInYW0DCX+G8ShHJ8b4gBC1Gw107lRWtURCAcKLb2J5Z0JybhG3rvkscQ1Jz
+        6ZfUhlqiTmYrK6PAx0PiVkay5THSloWd52YkwZbHS3MVH0cOieKS2vamBCBTLDYbOP0KnFhw2ETR
+        osy57uZwLl1NmswArj+mpZfHctwGJ/IDsUiwMJs0C5bRbe0jJ/2eAA0dzHXKqm9jOX6/hpiN+30R
+        1P4Jlw6jdiYCoLM2Hkuqe36kURzzaMQvA/pA5Ifkg1jY8GqwWZarARMVL7cxnbVG793nmM52ayHA
+        H74/5ZqIhi/C7LhlL7bGtNVpGQexZqnHbRmT12IJQIIY9uOf4oXJrQthDX/4fvlyEzXod23TNC6p
+        7gAENbFJ4AF8YWfAhtcR/lDfLbGtxp5by90psv4DALliKaeIOq6DhbHoZcpL6n+LS+rqknlpNViy
+        etzjAPJbeU7LMqZSkwsYrYh3DaGey4TMqzSS90EFhCNpNhp6fce0tbY9bO24zd+UzLBlQNtHYS9B
+        EQ3Ag+ptrnt62mpWtWRYdjPu1mPmxnwaVb+oZKHFLgbe9Xm31SjRw/GvrmXOa4LBsw/1raq9pWsq
+        y9NFfsdqDHsVx+QsEbJBR3xzaDoKWxadBs0xcbI+6jy8za19RnXdPm+1JyYot1WClfj7oZjriqcS
+        ujvFDnZ5XLsxlrJ/ybnV7OWTM8pV7ok5cTTvW49MvUqcaYo79fZ1n3xR28gVQn+w/t162XovD0tX
+        I/NkxGDkGWkMAEvSFXnF3tL0lHLY7hIhzeyv0Jk8krWRx4Az+YE7RlWp7WVa8hnxipddp6Vks1Jd
+        jfhwLRvhY0zo7CUWtJpNccEiItPfjHrKMbzHAVk+zH8p0RhI4Neq/uG59L9+Vj1POAXYYsus5rSO
+        tA3hrrDIlana4tNJzf2U63Ur9rh8RNyDDdY9segoZB4SQR0ivDuVRV22wRcIu7xN1ACdZPVjPj+k
+        HLR7Ikj8maucxvlXHz7elGO1KwdtYeb2n4e0pbcV+1Ys+pofR1rKYzEyuW+rqpc9AxCH7kCivl7Y
+        t++ziT3MWe2l96FqGv24pYetzh5Ai9q3+kS5VkKM2PBaJNNTJSgGtV6sqdQ9CGQ17finbZeto/q3
+        t21+GK3i3N6+5vEJgAAk9hJ4OoAwVXsWiQ2COd8hr+kTcpQgJGEat09+F7byAxG92EazmijXrSqB
+        Fnfr575DfSc9Tc9rC7BMqU4sF5K6HrcmNlXClYSZ0APnxu4zrEdnLXxb0lPd+l6mrpWsWi+P8/ts
+        LXXBJYDkmAFtf70D3fm5cx7eTpWLS1m23eG1es51X7MRiIST2GoQzcO2iJCdQbOlP15rzV1tFz/M
+        5VZrXm4kco+zoKxzRPYe3meqqUGGYQrqZ6NaKs1j2ZkkSgoa5QSy/10w0UvvUlgakESTXlis7m9p
+        YKOwI4zOTEaYR11ErW04kZiLU/VKZl/CiWPfjks4P3wcnElkAYXoHb/LE5WUM8JpYJ+lmbGc/j8g
+        8NNQ81DrVmrHZV1XhwklEzD+2vdtEBb4L8gKvNtSzPtUZnTCRo5F/TKwupXEE139fVarNUGdSleK
+        Tlwuoqcag8HLwhCKBgyLv6Ql9AkGKVsEdOX34q1j7bKVVNxaCQpyLEdyf/ap5GxtIr79l7TcvV7u
+        XeoyIPUMfzL0rs0WY7BGPloWbDfeMWLwIj+wHjdyLHpn4aVFrjPFcj5tx//7ZFHAohXSKNxCFr2N
+        XDy3nhDLDZSdvYxih4yNHAuaJGxGaq68YXuRk4+Sp1JAI3bBFo0sM6RcQnZ9nuu1NPF+ACemVitP
+        22ikUMkLQPk+t2Aa+T0WjDKmjr0KzDiBxzK8cwQgH0/ChF7/kZqiUZOHiy9zqVllAFdO+dMl1V6y
+        5Tn5qBqINvNQ/qeMEXzK6pamzPvdn7bRhrXUKQD5eBsIqbOFE4Cr7Azkqj4OfJduAnJ1JQND1aaQ
+        V/rHkZeuume8e1hS0zn5sNwRj8JIFk7mFTpqnwNZBb7M73qWZ/RdX5nyMsrdVE7DPOiYoIg5V2Xu
+        F4twJThJOMEXOLXQ72InjoHYTOrh+K/2Yk6zYbGOJzmec3d8xNikvtOOA6KFc3mVtQysQZltwk+m
+        51IddGWxwq0e0/G3RQdnNPnqkVU/5L75iSsBTsLJvYCzfcK2CWdMEd4efI+MzhIm+Eohv81KxxbB
+        9NduFMVtCIVBjt1s0Q233ooYAwOKKItzj+7PkOWGKWNBozZIOZfXkU4OWoveR/h5ZNV1MK4sGlD6
+        lCupgoSzeD5zWFii4oLzpMLmtDr+jyXvMevHMhWJc39JhpMp5ARMROHORvZ6QHnFjmwi7XVv3is/
+        mGzZFsq3q35Je0lLjqc6PaTKAuKzR7RDFn3uVlioco08GyxVx+0y5JFwQlvk3rfh4R3bILHXEY8J
+        OuskWhre98tx62PZ046q8IJvL2g8+mHzSmPiSpXaywbgniN5nC3ql5jREcOvLDfAKFvP+bH7MrUV
+        nMwpfDkD5kyuY4dmiBN3dp7cW34EQlJ7rvtxg4Pr0/Gv9gNHGr6bHdHo2dYLdmexbAKQBoMixGEV
+        ASjjdOcS5BS+j31hNNzPZYfeG3hPEJd8cCsgXdMY8NXFwez++bj11PeWASh8EnviUdvAfFkiBuMg
+        7+81ecySvdS3tmeYT4UJcrX/W98DEGrl2POy/bSleLHHig3w21amwm3+EsNedDIyY4yseelRyLIW
+        50vuSxjW0fQodnFh2urxt8HaTWa9Stqvhw0pzdXYaegnAfXajpcYXj2njyPbg3ETV8Oo6tNcXNpx
+        m/1YsMU13NZGUn2bSq4Jl4lo1xj0CSbY9hbig7FDu+SGAIRx8X/7pjwL9mcjBPzqaeTWAIG6iirv
+        asp7tv9QwrRuZ382Dm12UzxNJnEmra/Zo2KCXqFmh3qS2zzeS7b155SpQAYuM3JbEb1YfI392RqM
+        1rDApP1a0/NWPqH7UNJjluKq29mfrUWOMvFZhGnUVrCxIZu5sXQuCUIjxRKAtFZsOwzc2cIjMXEv
+        IUlplvWy9eN2DN98QTg3Efu6nf3ZBgyZTfHOwpm3Z1pzJwYGA3DWzl2lfilHCxBoctYxv0MWrQ7B
+        sbeUEZd4WJQ6pXa+onXg6bTVKy12DqyD/jWUUxHvRrfiA7yuj6WqAX6uaicXdAM+9DiyNwIaHX3n
+        rNH7Q7ZF3+lPxG8cbgntVvrHcdzcpZLdI1Davdq43mODUccqrInV42JvWZZUdrWeqDjsYMRjDoPj
+        k4DOrB+u5kwCZyxIQ3LWMS5cycV/JrBmPxLgh+Pva1a9ALAO1oHoSi0Ze98tF+CBzRwopRLOsUot
+        yzYH1tE6EMvHdOzPakdWX5BDt9xPqazTa7aMNLHRGeWsw3UgYoTo2FsS9NjP0zgomsl6DqzD82vi
+        MMa7gJu3M7aqD64qizERF0jsU4rcWl2PuDQM9qAJ7haLf2+b7esZsfAGD2mjIEGL0GSGN+W4la6Q
+        Tk5wfWcxJQy64aeBtaV2HCQLsA99/u1WJ2Q+S/dcLu/Uj3FuMDgXzlYgHXPt2yJ6p+HlUTvBUgOL
+        NPZUJ18zGZNUgENFosAVP/gNPCehiIwP81XhbIgWmb0feBm/SKaOra0PVRbPuprz5h39jvhxQqav
+        edQS3yRXW/MxnV23cdwK9LhrSbwzFdxu19zUlK1hceORwDl44504y2WXjA8BRIxEzqQfq+qSa0cW
+        irk8Wo1ldb/tyA0sF1x6icPZevTkt18/lpo8OHsI6nV5UApZbWfCECBaD2LorkUaWTuugeYom+97
+        y+w3Hrc2HbfTIZxvGZx45CgIMd43ehVLnqrfpq6sBC4vuaunUV5GFAfEdReEPdqvW5bGbjTuuqGh
+        eMWOcrZfwC5FdPM1tLp5IB9sA7c8PGXVP68P25JVL0+1PFJScrafwy5blB0YTNhd8MID2/aFOXf1
+        eukiVLdjP4oBC4te2Gy9dGQLNi3qY24rlaY55baXfRh5fqTOac11T0sGYBv6u+wxbGhgvF4GbdfF
+        5nOaRlUJ8JeNb1jnBWZRDXRmMDmfq3mg5jnb8L8pFuNNQnhVWPiNbmCxqWT/wPBBGaMfjjujHFLX
+        wKjw38bxbBzGyPLCRh+l331gqXhxjXXWgH9w8Pap7d+H49lq9BzgTR5N9W3JlulAb1ESwCEguc+P
+        27Qk9SqOzldNIQYShCW3X0FLWED7Ic0M73NXU16WsWRx45seRumAEwRgNBAtA2vC5ThyMRYxwON2
+        tJOECTa6WkefCqlVe1IXRsVyz131ii8Jw4ToYCNvtRLPRBiY2TaoptA7boAaCWDLVB6WjCPCl6C1
+        r1u/PE9Y075XQMAxF2U6DKIIda5faELY6PsFwxq+m2Znc97C6J4+bm3XvKRVtdy6DLWcikMGIsFA
+        i+jQl/E5jj55zrtIMCz8Qh1fJS0n6rIV2lHC0KJEUX3HDYZjNiXVXattBTmSe9JdeS17raRyLft8
+        wto7Ih5rvofFAdFn1shCoPvWWjZqK41Pc+7BUVWZj1ta1PGV+piVWpVQWcwmYowWGNPIqWhDOkyX
+        dc+qFWK4okIMOhlJhxUWTnTC2rGZb1f2dtwexvTcD1qOXF+wDJeIjFPituyWrvZtfWg18h3vYybi
+        h5YHb8ZeZbVu/i4QjPI1JOF6A9E7eRH/80pzBEM5W4VG50c1bAV+nuhpFLcYhRy6LvosDq3ThjDx
+        5WsEYISQv/JrB2WiDWlTLUCDEc1Z6nB85YHLks6/0NVaWnJZVsYJRYy1exLHmmUUjyQY23gwFuVV
+        xWnUDBak5PKBcDl9aLay8KKfXUr3klLWprHfIFoBi5RmbInT8LpuzS7X42+p7lDUcLEct6d80ihG
+        eyhVWQKwEo3te8GMGqgxM8POI2iRVB9d+m4eNuIBaSaXSEHH0nubEpLViNp/zAxYcyZivB3o0mMi
+        dJlCWx6JlUs7bnuucxnNciuNlqAsOOPPB9aPcIs8GmM+9cWU257QhriEZmtUleqTmxpoW8lb7ixO
+        gYJS6OZxq+VpzWGR+gfc8kjouUi9x3+6MQSjqsdU9+P/WDPCS6NrB41DY56tMtAoYuA98DzIwo7q
+        FfyWm9jAM+XjxERUUYSoM7S6sbjCkNPX1RyROsNEpbabS+7quXRjM2zHytK7GH7SBAhgAtb3ACxR
+        E6kTGWi1tYgASYzxMA1mcT50+YsjQK1+2foRNZWY3+OI5MPRiXXQyb9bOAUoq/gB9d2ff3p7D2+X
+        0dVD8r7IWWL6qcJobETxgDd5uK6N2l3xaP6ArZJRKCrp1uxvYfxEq7bkJtiuVJomDg/nD9IikYwB
+        XUAZTGR3gfMfECGtqLH1P/QwuurTtqTSIuBofUjVrGX1uORxzeOTSn+dIGpIpA5lU8O3o++fB+HI
+        wf/0ZeMiBSpfjT7CD2tWf9my0FxPhLnie0WrkEeOYmScV2+20uU5f1VU89BcKFvusWUQ2crvFzob
+        h040vE9FIpYBe+yJlLUMrKOIiDgq81QibONdX6Hw8N8KX4hn1G3KXyi774kUR/T3IyI1CqeBS4U2
+        Lrn241baQLpC9uxxG6X2/Xzfxo6MczPHFiV/KROWmCfe5Yg8b8JIbsE+wLdIWXCtGOxegE4R24Xs
+        YewWKVljQ59qLuLefqwdicrLlibTUj6o/SRRsCylfm4ykrmbM4/MRvrr1xxUJcfOl9Q172fEHY/z
+        itjOlRzE1IJmrshVTfsmnsvZReeORPRcZxG+wrkPGn6etM0KjywsDCPal+dt3xAezaXZFRVl2Lhd
+        QMXBQJMXfipljMajiYS+djr+p72lAs0A0YIK0VT5OVu3z7lq5UsAtgoUYSz4Fsoinm9tyw7mU1I/
+        YlIvy5wXPJiEsMCtlB2jVfTg1AJ6cnHdxkLRyH1XpZqwJNcEvzJc6oRLCnk6HCfsC2BMsCBoNjWZ
+        uFNlyanuah4jyT7iDxf1wUx8FNe9Q/hsNbJ9tjutQbYEZVFrVnXITuJGubpUt9yyaHBsJ+wS0NAG
+        3qZmi4Ladqm5zE3BwA3EM5NB4qtSUWl2BwZ3qR23KQ2kWRkkFSFXhGa+wZ9ja9lFAbeL5aUcexlG
+        IqT8eZfv1xHNge7415NAkduagTZF0+I3+Bo0qkDfWHjoS8i+BmTiTQi1MNOFpOrbhhahDIjydwOK
+        cX+JHIq1+kFzS2mvozERCMYbGBvve+TQ+9cHa2Q1k8ehPanHtJZlyfghh0uV4Jx9ZA8pTMAQSj6L
+        2oIrzumHrHYr0Z56oRhP1xjEq7IRC0R9467OmFCsRSUFeDCPwe4ZfgdFWi8v24bkHnskG1znHDDG
+        3O6hVnJF9UNq+/PIpiEmd0VjmBShZsyjafr82lK5N22LLSRyDlEKzLwTuhCmhJoXQ0Jn2g0s0Xxk
+        Ow7fE6GslETiXQCUNnlMtpvcpRRuVM4hRHckoBj0ZCKWP6D8ogtXVjM36Qj4b0FNz3ktFeatTupi
+        esXqj5yWQX0JLEtQpFrFQKJLFqrz3Hn8LamaVR+Pj4VjjYFJpaftiG6NB3ll7oItUHIB1SVd0tUj
+        t2MMRsszEX7LGkULP5Q6TuMUvIno23zTByfizJ6Rdg4kldFzqFa2OxQRpQUOXcxEnOm2NbxrhKKk
+        RP9EBGZdPcj3skFvLLx8aGWvPlJ/A8AAn4jqa6DjdTKONnVWors2baVOxy03jcyOEIaig4nUAG0w
+        /DnVv8YSD42wrcz28fmwFJKI4skniIrUrMjEzXLm4GpN6dGWIQRhlC9gEOFA/BgyHl6v6/F7zfjY
+        laNKcE4E6/exLxHrykz0rSdI5MGzJtIILvChvuwXiNBRhDubQpT8NhIKDFPirjcmjM6tiEPtA/zi
+        gVEux9dR5cIrvhK4v3296M+kUVtKPQo+9Y7bdGQc4yqYUhPYu1EqLgOdOt3qY9lp09SQPQYRSBLB
+        qV4KVuBtapOnlzUVe3Xa6jWVOo2MkJtzETwWKTfvM4199wV5Ck58nDpm9kS8Rqf1hAi+91o7/r7f
+        Awjo9g7xZ4rIsR/H5lC0/HmccvUWiHeLGQjSJgJCDTQ/lmNfpGTDoV/fuKaquBuKAFV+IRIRlKlk
+        57jSF9Q1j10l8XCbEY2JRm8WwsjeaFP7zgO0W0jZyZI4VnNmi8o9YQvuR6a6Hj4pFdtDkQKvgfWP
+        EgFyXDBkwHo/pSJe0hnI9GikBxDyrvZtT0t92VQ63DQmcBJIrc5xhgU+0ZNOY23AktVDqn5Elq9+
+        p5LiO0pdpx1hYjsJRy2NyQcazKK8XH3NY7E6TnKdsuox9V56oXVp23T8/jZSf6vdEPQSihgvooPX
+        z4KvClUvU3d5yaPUyFQ1rsIc4UMNNOPhmTMGj8LAWJ1SFdwnY890nKh2NRXiRCehe8B/vwUZa0HO
+        0W9tZoRUiBBVcKMOnZQTE9HdODebNll3M7+HV1+Ceh7qKjaugsZxgEE0J8NZ84RI31NHnly3sSRq
+        1+asHtK+J50OFUROhYHV0yHNJOS7KwtGimOQH1qftvp03AAEZOMPDm3cesNhNBHsAVzo2zJnFCda
+        JHXJpRM+FxO4T7UejdfOhjyCFc8/mjKNwj2X1HJZAMQE6raNKDY+ldAe5uCuMALTGRRLubYzQMh7
+        ngjTCJiLic4BmVYQEW3ge73x8G3pW+2KuHDOO8J1QByQa0O39awsJXOeiwnNARGPXiJEstMIxC/4
+        +VHoeClnFVlh1sbOprbRRvlvpbmYwEOL2EacLtki6RkkJuua2IrIJQb4xw/IpHffNFt+bFuZPWHM
+        QWyI7rFFcRfHsXttTn72AMAuqKrkulNtnq3bXq7FEIYZiayk5vsl9xsYmS2Ppl3ZSZi5fp0NfMgs
+        MKSjimegudhY3eOIHL5waAf38aPzFwBiYxSAf8esIZIGmb0fCpfodk7NAAxnZHWP+yQrPELd2hyO
+        DeJd8Rhf6SEfvGAh6JIqSe87E3hFt3y5MQ0jW8i4z7z7gvM1lIdZGluA3vRbmteo2EJ4k8RmGRGQ
+        aKkdwy/yr6T0d8ff5hcq8JYI06jP8CkiqFpE44S0mx+20Wpa9tBQD2pnCFXpcHMSxVL9XKfGZ5yl
+        2rxr1KzSWvI9/NhMErs5wEBR3BVC/2jQ+DYxC/AD4btKb5sIxajfr+kkggCnOsDPV53IkpN4WSyg
+        UZmz1tNDZyxpjSp8wLZboynB3akae3Nfn5GFNQMjWcCFYhW/uj+83cyFaJ3HGbUR6eNF+sFqH8+F
+        eBOPO7S2jMg0LpiGsRY8+5BnlVg9kp4hzVkuPGWM/AYXl6i68WmjkQM/eMesuRPRUg5yshewI3M1
+        rXvuhXnFmZDfgzEbUIclaXTW1QY0PmZ36pf77JTCeqdESFHKjzhmY7L+epYUGg/H7eG4PZ9X11Na
+        lq0+5dCxLAAv7VtVD7lN86uc4kag8bfxqQKG8Epg38ldKvWn5aW0533OegevR4xXo2aDgv4ZVzDJ
+        aGmeCZsT0WOrsMn1SkZzZymWseeOTgGE46nHTKzMzYiri5bXWS/MjpPdNwq6/G1iKBeOMDi96LhR
+        qoBk8n+h6tMx+DbCbcSh4DdcWDE6zc7grStfz6/ro5sTghooVSCv6VxYxjsSZCnlwpWAHDz8VGnM
+        L/UB8/F7HtQlVXyXKskqTBFNTCnHppimVf8v8J4WPggFLivvmN9Ege4E3glQumB0tMnsqS3zNhf2
+        o/vcd/zUAYNn/+GtPOfw40Hk8cbnfcagBIJLHu2Aqv2Ua5uvKCMvPJAonhpCD/JzjMqh8Z04d9VT
+        aamoOpaF12yCchZzEf13EPpR+ZF4h6vftm2Np6mYI+tZMQHChV/3GKJRjVx59w+p/kOZ/rqVyO7Z
+        gIZP9TeSwRBFo8GKV8gLNwXltK2mZz6gfq0q9f24te34n+eZ41Rol5Ah7PDYC4/a+SJzM4qpDXKt
+        mSFYqEvqUGrV2Fv6kKfJDcW1N+Sg5yK8lRsRg9t7x6Q3FnxPJo/pfewUgn5wTOh8r9T3ttVtzZCr
+        es7tIatJze1CVpdUS0dcNheLEplIuIPscyB0XQGlA5i2avPG68EpgEhIA07vmD3G9HwKvcamLLVb
+        AbJ5+u+3tYeyZ9U/1+m5bTWrZdQ030slnHuijeJwYWGR/Gu8tTzVrWWVhAXMXAgHZIN8TyxKiJy3
+        iCCbCC8FZVd7T5+PG8ynBmhtzmYa6zpqmWZ3vPY26p8qgs7rWyWi80Q5M7ukTgU8nQfDiJyq8vn+
+        oi7+oUvVi+5D6tDv8hrelfWyZNUvx23y1uC1THpzxXTpFDwHEGfG3Ra0DzyxFd6FJXhBJ0uFG/VG
+        AmW/S/vzcTv+K5caM3F2955qGJ2WW41DbS3qAjxhZTv+X7VV1ZBrFJkD4ppOzy9+uaMxxzxqy0gq
+        bzw/+SCXVJ7oHreJee54l56MaCKx78TBb3wdLJlBDn0mTo6iJ6bMhgsri95qCsAdAVZg/CqVGXt3
+        QrIcZj4iy1YJNLmIdnP3Er96j7USGBeKLQf9qn+PAsyVbHzET06+6oeBCESmF/nZCkcpBbOmI5FL
+        8oAVFR9Tj8v4pH559+4eQLweYUzQRL7k0ZKHyzDrvTRfJ9W9QXZ57pufizfjbEfkm7ewCsyRlRbM
+        K5tCsBORhTZ5xwyw55CFGwKt5qSD/Q3W8BPRHohcZSdxWBGFxO2LhahnVFHoau8tXXPr/SgUG4KH
+        KNPfhq8pIyNodEZGoHUmnjfTYxIq5MLEy/Aa9lhb1mGrHAis8sktKZE8VYPr7GJXU9m3z5PcRx5A
+        xkDiZlDBuEbw/Sl/Kk9Pq+RKVfYdLa9530v+AiDeDdITKzrIhbALcwimvKtS53ItRonm4v1KAZf1
+        cpRlQCapRvOItPGcTD7cdzMETZrqeSu9iJBmG7qKHOQcQHzYs52ALgQ7eBhPxWoQAxF1yqnuiXPC
+        UN+Rszas1ly5YvReQXWWRoNN4jTs7DENMX3tRaJHLafTszWhwHMJevwxQZJYedS23hiCJcycZbm7
+        GpG2/sg86dH70DIayRERdb8skOBszj1kpY8S2Z9hDIrnNULWAY5/VBMxDyTm7xYfR1FdCuWVXHcA
+        CTTSdUJ3HA0j6JzWTIdKvikxOFdp2serziUEkMCjjAlGYyXof7olg/FeEYRNBZwDSJBduB7QXyJn
+        TRfcae67OgTPHVUmIVLRTxxLUXHhuqBoguMfVQvyCaoPJ+QetP9nuff0lIXIgx8p8MRk+ECYSpwX
+        GFSF2OK7C11ZVs8jRAGtJh36nHlkz+KylsbdTLwFWGSyh1KktmF7igdnY7YnlquWC5eMPpDHDHyB
+        kCs6abl/7JRAgTYoHnOJ0bkngprioyUeLRPHRFKVuvFQr68tFT7b1phGVWtCO42huiseeYIuUnZR
+        RgfhcXkp15ZbanXg6zp63cgS//NIB6wxjCGWHhd6cqEYkWHwIWNfUvrpxw1KEHrR0ElswFRZJD1J
+        nz5OBPPIW9smDCcFiuh/nT4KVA9NEdAFLbN7nONUdj7wXHj8VAGdLzgn0X5WdonYZW5te/r659EN
+        EAR9aRx5yxh0XorQZKZ93Po4cmETQ+84elhjEO324QUFPVLGtMisqxdJDcnKxkfTQlCuk5CH1FFH
+        YZvRzV+gqL4Vvb2Lbz9uhXxjA9yeS4y7Bp8M/kB3WY1iPNyp9yM1Y24rfFNiV8tE9QKBoqm6ptLb
+        X9xcCtu0Mc89c1rDuKF/jYb23SROPa56yUWRJVM7F2qajhvqec6dNkOi7nljv08Fg7HxYpisWUl7
+        CuB06D7VOtROnA32yNbnU6nX7ePIU/Z6P25P2QUvL2jETnKng/upNqAT40hbwjl7c3rOo8y8fmrp
+        uqYN6R5pMQUuFLJw1XiT1Z/++F01AWRB3XdL916ycCtYCwMYbyRjhOLtc0HLmhTZE6/NnQ7jnhg1
+        Ri6836I3Dv70x+/UN+qNoTWncnpDiiGA3OkoHop9c0EPbu0lAj27pU4te5pW5T0XzbChexXHpwyR
+        9Celmb2ZTbkr/bw6WkcAp+MAY4yGZenQae5mI0ktb7GSeoDKd3np3SrUmnter1QOuoQAzui9G3MY
+        xF2ISEZAqCmm6pJZRKvI49MII7MdUU4J+13XSGBNy1OzM1LsW41klDqDZcQ802oAZ0ITbbKDGPbE
+        Gc4x6a/qmuBg453yI3tqacxZnQGcoSHGGD3FlwIKEfzh56/SdMrP10q9gNcTNblrzj9uxy0HCrdD
+        KY8aBN8Z2IzaJH/6h/pwTYNkl6Hw/WOamtL0fNygFwYLiNzMnJE97VlnGYjjiqc7PXq3SfYqVpFe
+        +AbAGbfqTWLk83xGgiJlIAm61rFCAafgjF83EHECLvxNeaQg8G1+2Ma+NRupe6zRhbXO2aKW2xTS
+        lbCEZIMTgoMb8SOcEN9Yx9DWQZzz/AWAs7E3ZJkZA4afm+CPTP/iqyx3Ntp6HET1uVDiPQ8SmjgU
+        tfc5SFuGnGcHzlqK2GYI5CnmD0smZZg5S6uCQi10n4W1aK0wEp4DkGKm8B3uRLnllQOrWsyFIv7c
+        DNEljbdcnvOa6pzb7dirdnRN6OTcWdmXmx7ZDymxq99PfnmJe1DflelyMS4xc9YdEMpAQrtfQhrF
+        vhrw3Fn/848b9HTKyJzysBnM9IMcISSpW6msx+1ee8ZQ8eMSp2EfAqGR4YbEyVrJe9UWiCyhzSnb
+        S70XRxjF6xHdWRW2yGbmKaZuAlSTxVRmWpFGXtRTrgwwULrnVHY6PjmAw2PgmDSMeC0KbaL26Fz1
+        ST3lXY1S9K0QkTXVNtSaxkP+HMCRGenJiDaat4lBNh7KIjloH+3YBRuju+LQvQEBUVzxRuDbsmel
+        OdtFnDikiWah/GQgPoUWV00KANRi51D0TxzkBE9RocsBwiYU+P3y1L6eydXKhix12ImDnDSCU6Fb
+        XY1zsI1cqEsX6k/3XN6BtYC+icOfJBIa+F8OyGTOXDQdp/N1K4qABuPk197ATsBFBybuxResRhc9
+        vLPDYrYZhV1rkDEXWGv6ujMCF5g4cQASfDeF4flFlcxSDEzw2K1/RSbnBAEchoS2wJh1k0PcHtFr
+        B+vU0BTdFh2BiFtqwuA01b14u5rs3gNc2xKRicObMGRsHgPbQIkB/GGh1RWU+YZG47xOGeZefa9J
+        us5VrW87lrs7cfgU2vwGEq7PZXLoDYELN7ekO5+Uul8kgnPHEdmjUD2J9R1rGs3055CazGzW7VL7
+        Xur08Eg5NIesH08apWsJbW3/e9tcVDx9LAXfuePgDJl6mQOIS/SmP5Ru546DcI89ehdFIJsdGOii
+        Zn9aUfc7SzPAEUydTO44GnckIL22q0GKA3tPunhJ7XErPc2cpYkJSh8fykScxKDJQ88jgQZoC96k
+        6jtUE1p1E4wQxZ4NhaNY+E1k0DFBjQtexWjQDeXIbEFHBZ5hm1CHP33N6DNZ8hgu/AklcCHDpXhO
+        HRLFnwvovdoZ3S1ahwBvm0b6x9fXvxLAQVH8Uf8JLgYN7rvAZ8Z2ArkrljBcZuoAJ2e0yFxHLoGj
+        WElGs4g2zQzh73IpVaiS1JnqICWu1o2H/AITRvbVo3F9fI2qlxvjZP3KFr1n6ZLFUh5y862Z5hpB
+        deCRGIg1trbFhV9zqLUuUsHdlrmHuTq+WmdUhyOJITPvWTMIcFIN9QHmq2zY16rnsSYjMLZ53+MA
+        wGX+qe8aWVQuPCEMoWUM937m9+M60bNct31/jhBHEgPOxp1WHKnpUQvBTzc1m04BxtfMVW2Xy8ab
+        tdOOW3e8oQ5FEoPIxkoWWFgbjaJZuVG6B5YwwzDE29fU6VFQZd3hzwVCMQGqtWXFZJiCzNRFgkcd
+        TCTGLIaPH4iBXQuj/e0naNaQFmrJ6l38ExkSQ7k+8HRGnWXJ10157WpU9W6bEe1ZQR8u7EvWIzmB
+        V3r41Cj+EoYAdRCQM0bAvGOv5C1kMdhY8TgvU+mSiXchkqcSY/DUIIds3CH35mLnZTrnEx25Mdbo
+        5T1s0AvDu3G5JDbSxtii1i8woWZv55Fn0kbUDhNa2F0MxCqO5LT441YB/5hDhJZoG4+59zzi4DV3
+        Wji4tja0aLBpY5+XEQO7mXNaOgmXD2l+ysYLTHK32KZnBqrlZSt7q1XMnY82mHAK/YkwcrXy2ppG
+        fUkfh8ui6pL6Tg+3ULnuaXY8B+fDbk8ISR+2E7l7T17aKZKFlrha5rRrSK5Px/+xHzcABxtxrUGI
+        V8RJeGNKPvbisjqpUssp4e2xkYusdOg1dz4mu/IuJQbELUL0kczJOf83TULqQCDaMesZPhKYJFua
+        aOGVwuo0fxEkpa7zlzYrqUN7uHrIN2SAt3lwbn/QZjTNX8zzQRw1Hd2hppzgwv68PR2/X7HU7eWW
+        Q5PYFoMA3xBvQdzH5BOnRPz46vAgrjAIdgRQd/UIXLkuSn3MEwu/qea7cA936vhHmMC24OKm59SP
+        Bpnu/jjKcdvHnDuAA4U4eBgvKIwMl+QNnQsMurq9WI6a/PZIr9pxu8KRZoOTQnF/7fiq1Kbmzsct
+        3XRI/pgkpJ7jR9LxJfX8c/0CwOFDYjDngfDahTVIDeDyLrIEq520oWK59tQBRLcbe7aE9LRHD3yq
+        HTMdWrOaWipPNX/pQcDtx9X8Z5b30GqwqEOMOErgkDoaS5sa78cAXoKAYGLlbcj7Yji3hZ097OeI
+        tiPqhy165GfRa6JvEOaDXh7oKFmIeJ1pIhXHbL8aAzJlB/SqJr5eQAr3TLWjSjZjcZrtl+AmWYwX
+        CE1vuYZ5waMAh8R+iSHdqb2GmWrqotZTuGW/79fDhvUeedTmc0YBvS2gJG0A6PwgSZ27EKMDCjUB
+        dLVWek8iXeXWZsq+q2Y0hHJyF0Kwx5ZckwO1GYNE+NOkjd+bX8Wcr1tplUC5i/EI1q/QDVWJRi7J
+        pP5h7mLwwUdMR35abB4w+za/JZ+/AHAxrMaE0GtY15g5+JZWt5jaeIPSbTsjCoKXiNKcTUN7z4tj
+        UBjdWKb6dNwI49I7MiV1kI4axc2B0eOINdcJnj5IjmrfcCIr7VhCehkUw9FfhBi5PRj9vM0TqHGG
+        vjOduKdn1qOJTAE6m3iaKJVOdQiNGjnMjj3CbyeDwTG8TW3PX7pi1AEwYpoZA192K8Yw69ywMCmX
+        AA5m4Z8G7pWThti2PJn7Mxpgev3ORd8HsvpT2lq6+3W5B/BQipr2x07cLmjgJsYe8pX2SU0Kruhp
+        kWpXD6LQ81os1cuFEosQt+/Ub7Pj4rQ9crBKKyRdbLWnhyZXY2Q0A4+uiFFX7Gn6tgLC/9vF6OBN
+        IgHdQijNJxng2mNe1wzgoRW6aBtaHuwbCIMn4NTDaUl569uM4e0QAP80ym0XjxAmIKmspkvOUT2Q
+        Igb9D/lOQUg/o2DUKkn3UMMIa/PxfCLP5txNUEm/TkcOBhlKGFUIZmGDeV+l6zSBwo7YjFnrtD3s
+        eTXbBSeYBGA4lP8RA/rPAlPybL6MknLuXvNa6qGYxFB/bwzyzGq0ZOHZw3ZyotizRuycC8W60Sm+
+        P31+b4SpTcamOAcJ/ixtzZ11REv6Bb9aL1t3uhbTMLlbUyayne3Vekm7Ubk0ObwxcuQwzpma7QTR
+        Zw42fIvRGMR9uV3+Qm24vrU1lQ7gMRbaYLtmdFi7YdF7gQnWSVOj1knDFzS2G9GAPGzrjCuz7jF9
+        z9XjJplxmZ2N00Cny3DwnAyYtATwmAiNjnXdIV1iRm+5sbuYttX9UDJXSJO9Md07IpLtBEUOCkUd
+        GvGSQxMIbgQQYinGmnd75Lcd8vutOlmj12gvdkv1DYAHSvhTw2D2XCIiN7tTP84F7V1M712s8AXR
+        YMLqARSuOgiyeSfW+dH629TmrdatRvXFvlW1psp3CMqCV9pY7wG8Db8xseg9RQXgtAz9W3VNx/+E
+        5LXr1tXoScwi9za4esJdpFy4FIxBqjfw1GhttQN4mEVMU+rAUmS0JKIN+jK93I7bh22UhpsFlYzu
+        dWvqIRc1yKY/QREvKA0VA7zyq4dY+GcBF+qogUAra2CVhr7Y1UP5ktoGRuKz3eCzYjQ65+BPrGj4
+        8cjtGIsBchEDKDqt257QIMvHLBE/+FJN/co3Ga1sR5yMMGyWgxRiWy0n2jWPmdM3MKgeNXHG+7bx
+        Y1h8IUIuxo20O27FiQePr2o/pTld9txMdV9BxU+NqWWuAB5Q4Vhdf7Jb1qAjV1crF44zcyeHUdZU
+        r4oCvI3PeywGFnhZ5uzoWT0ecpvxZ0uo0/VimH13HUUQ6PEM3az18VB2AA+KcIUg9EqIofMtmcg6
+        i+sjxeT6RqYNHsncUyA91QZk738FNqJ3cUdtMMHF/MZR/Ulk0ZPGdz2lMBJW7veHdyy14HGqgtoa
+        uadggozBRlA7DrHqfhqv6fLoU3B2tw9fPOcvADzF05tEx6wTYzSSDyfDOj2v22qhxJh2Azf7OQJ4
+        iqQ9saj16YQ+9dxCLfk3rpxyTyHSE2ZX4P5cdGijwPdsKGBGp0EPsqJfwbuaew6afXEoPJgEA+eT
+        93IkRm5hcuFTFiUbMtmbTnLPQdWT6Oi8MGfT6zx1VE9mOXBlnhUdtbmwHjPuGgE81MFVw5AvRJvz
+        sSPnk1d7Tzz6SMCUbejM2ttYBoCHPbhqzBTNheKeb9mlOUK1JtA3tAdKAI96cJXAFYKJaYZ23pGr
+        G+RmULdiQxzISLrxRRCtyZW2GmRuzBw16WTvcodBKTA6c+IW+wBGgunyktS/t9Vs8xVnPnF7+rgR
+        jGgYWxV4O0pHtXhQO97bcCFDiltWK2fgu3C4ZshhBXi9jME9IZBJp5NQbD8KO9ahqegUA30PnXNs
+        WszHTcZOkWEXh+Qel7T1DMCjJcDMw5gLAsi9Hch4xoUP+aBTjnglnonHSMBI29VXzRHNrLO8dwPB
+        do/MKAROpMFJ6J3Qn1eAonbOTtteNBiNNQhj8brzFwBeInePPFqz/W9gg9bI+VjfW6r9cWuraVhp
+        FveydUuXTYaJ27fkqp4/X3Izc4v9taHdY0NQwI1B5cD73lp2FtOKTetxl3J9KlV5xJBkLt6p4kcg
+        9xL1PXa8sTiOddGojcDrPSkiKIJd9r21sMS/zUA1p7V2fnAqkMoXYV8sajfmHmEQEn/gBS16WhD0
+        3Eto70rAcKTo2L1GJoQXlTDccYMHO0klAyKlrqTip8TDK+j5vSZeDysk/WF87icZ1abicvIUcJRI
+        SDy6QqdLPmoE3H2qSUgfc6e8nq44WlfxxpQv6RdKSDywAg/PocYnAL+vOGvg1TYuYjAx160gT6cV
+        xizm42ZlZgbgIRasvgEbaHT3Ljb47a8TAfd/tjgzrnmCVeUjA2uGcveFb+drwvSdjl1V5sftv6B+
+        4+UyRzIQDIYY+jimxNLp6mVbB0fky6mtuSOAx1/QWB16uInenKfewvQynOFAmOZUHV8Vjy78Nie8
+        4X1LyHaU54KkjfoMcsmweKp4hwtrXZ5JzpubnYFlbsazdZMrFA9kIjdazpjjO57sOWcBJy1lWopl
+        gXw+jC5OwUM2GGcQdBDcRgYlRmirPzQft2nJdXo+bmvbaB4jg0EcMbV5lau65C6e7y3V3QFP3Adn
+        LZx6ie9TAO/Cu0diCpcjS2ijsuVhUpKXPOK0/3oCALPM1Cp14T2kiD2g4KDBgeD1Xl9Pq9wJ2lgB
+        H9Kr47qVBuB9VKNTaSMcMb8LTdlEd/KHWGS1U/nB/nbqgxqGxzfuJG8RjeQ8vBNgOEcA74O2J9rP
+        CRcKUZXDPcrx3kqFCUWKZa7mAOsUugaL46t6d7vUMoD3YQ0ers0dOXOoWTcevDBt83HL1+tSy0+l
+        78LQk9J2k3sf40iEdcJ+SiBC33gGwJjyCI7VPMY+BfA+snckosbg1HpyUvsLRExPqUIy5ne6ZUqX
+        PhafMVc8R4jqiO2/j01Ec+BfMSE7BuJH9VCO2J78QELGWS0yr6KcBrzNOiR3l8EEs2z5Wq6vPwRp
+        brP6rAOaO6rYRv3C+XC18cSGs+4krtGz0cAYPo4Ml72x2hkql/wZeKBFbH/8wIbtLEjQ2ISJ3ctZ
+        y9dfUUA9xEJPoAMbDnFJHp3zcJHNuYBkc17Bvhs6AvUvt9iGdrGitdJbhpI0r9bNPDlbV2PrAEbI
+        jETBnkaAelyFIwbcsiuWt3pmxclzxJKEG/cNdjAZex7qG3NoidNP5ojlfVYy70rDtkRdW20vU7kA
+        EGyBVA+xqK2m8JgWaJSzjOSs4oGrPh6CQJhFCdR36qitK/DeLsUKxW95bd9oSgAPtvDP/aJCsb3g
+        p1EYZLvP5vJUs1eAOg31IBKiHnURW4fgZ3GdNaStSXQ/S/vHpdrHbzqivudGrQa811XwO605JNrC
+        66ry42M+s2ytESvyHlP3ciFNzenrEm9j9ghCt3XqPZP5MFN9cUlqzeqZKV496uKsIe7x3q/Eekya
+        WuPlvO6nsvS0QBEGBA+TRvGTtBQqQRmuPmC3iy1ijKQ9RiLdnFzlDqe5cSvGxuIJ0WTWFCR1zE6d
+        RjTBDVRa2Z+g4asZxj0E6ymvl+Pv03MWATlaTtzhGD5ikfYy/3ideNCI5DjsXGgl1cs+upZ9D5sC
+        8YwiBIdt/QUK9Xmu2hDh2zw+qcm1dE3R5XHrbu8YeB5b74nIYfNrwro/sZaui6/rdfucv3Dw8zql
+        vt02ob5xlHAEqQ9HXalHUO/m4Ra+g0AtzPrzjIZf8lQelvxFfffXrd4xgHf3cKuNpwG963cEDXlX
+        X7ZtlbUOyANPub4HCEgZsdKQhtYcYjuiIQPfKS01IsuTXBSFBo8ON/WRHc7ayKJzjvDDFqTR6BnV
+        3pzn2Gtk94zGoC+kM1aqtb6+HyaVs2SlsdoiRqzUfBx9RENDLw4oT6q9s3CRKLYIGXU1wGHE+v67
+        ejwcMIJBM/xWdgCgJmF3GjAvarHoXdnPhz2yJ6CgVf2n/3TM/V6h69lo122JEbc6yvKgx07P+Nxz
+        PP5lRG+FwMvg913LuQ+avTzVND7dJzuMxKRs8A/dWSsfkvHdFx/TXp5GJoUypu886EG1ZwmNvsli
+        wwNn8D7lIHF7Ud07nUfWAM+smQc9zODl3Bj8znqXBhJbHMhjb2kp/bjN7d3Dpr4nD2aY7dmAzFce
+        ScYlJLg4BQhmWCGL+Mbwb5FB1iTbEpXwbFhf8a7OgxlZO2TRRA+pFaQuIpQLqY1mvZcUHYa0wkrD
+        yyC4X5yljGJeqK3YEmlmmiMTNrLweXGaGlwx3DIQriCxGP9MG2+ULvGL9qdUAgSECreMlVLzy0VA
+        56O4NkLhX5yeU3s6bssBU6+S5F80iv3AtU5dp0HMkI29ONZiEl//c2pjDT4Zilv1FyS5Jf0LyRth
+        WljMmn1FYcDslKFe1RfFGXi7DdnkXFplZY5v1OCIEcs7MBB7vRzHcmXw6mEqwasUh2tAsXDzOGUT
+        rqITMxCtJgtDt3xV8pUSIOBaKI91qG0vQhJUNnyC/fHJHajBCaOWztx/pYPfXEMO1ziEMv41XMoN
+        INihNRAJlaJk1oZ4glxbSkspPEnZO642GebBjrahhNkv6MpDk0Pj/AVAsGNsRyJyJJyzTAIyFQNt
+        kf6IRUC8lJPl84pqXL1oDWpnzWM0S262liyz2AwRumrEVlfjUwI5y1wjtQj8oFp142dEf4xYCnF/
+        mS6WA7ylo8CbkzoN6Pld9F2lJSQYd+cowuZd2udBa5BCgG+P22VJektZdCgnIdUNA8MkzC+Fas6a
+        /KI7W76oydFlh8ShUCiqH9EqlnH7OAYmFTGnx7JLuqrH4pSaQ1QDNkUsFfWA3IE0mNGzhMcm/T0a
+        +8I0+GHERhwE3k4iNu/3nRQNHP+o5raVfUcptwhcrgV+SVRK8b40h70GzjNnhbqpK1tL/G1Pvs2d
+        k14vZeJ2sGsJ9duJoofEKCmep+n5dtuxPatpEoGmgepMrNih0CxlIGBowYbgjyK39j6np4wxdzBQ
+        M3YSPIjT1JezdQcI2BRnxczSoasE+afUyWiNtX61Dczr5nIXvpXnhV5RsowLEOnjsKO4S4L+dQM8
+        f1Ozh7e5wlKrJak9OfXK8VU9pTE9nzVdN2JF3ATODKw2m7MjCUejrEIknzPH4S1nNTCjiUWVh275
+        h1iFhSYPfwKnmZyXxSU1jKIGFIraMAT/obDmzoYweGf0P79uYym6OxBB0J6ecwcIXhmxmm4Gxh77
+        wji0Aq3PPg6pgObpafOvYSmSQfDLsNF2CLoXZ7VkfFxyn4HsTWrJSTTdhwUh6QWe1EtWyzSFSBX2
+        d81L2EHLougI7BDIM0jeAYziRwwkd2CpVtSCtnNDxI7YfuSxwvF340jHB5pYLQ3uFUqU9WMBxWaE
+        7mmXERF4H5PmUwPoxEiR7cRLBJqvieRRlH2BCs1Htj0dKGKzXvq0Qs7690xmTbQKK+qqc1VdAHi+
+        H9YfDWATsT7AIAS+ORveBa/xwm4wfaDfRCzdcOAMvl+04aw9GsNRZgiOMfr/NThBuOEguJYXjMZg
+        XTioxVxOL0lgF5Do2iipsrLoslvvW52PG0DAm6hlDvbAa2LJghOrVu5oPZXJVi5JWaNtoKAGh4dY
+        TtyAECtUMTt1XgjzUn0DEJAjYslj/eg6Z4ON1FFUb2pdNb9t4VSVrgxu7zv9KDW2MBzLTjD5y3Gh
+        ozBg5gKkQFiUK6Jp+i/lyaxlQCTx7vTESUnhl22PHD28KfekvgcIDgi11KdeSK3Y6lieOfZQvkNR
+        T59X3Mml8cg8GZG1ONL0zfpTAQ2M4TCWyPoFQPAtcFsfb2rUr+aWAoLNEMCBRtQlChtnY/bKn4dY
+        /TT4E8Syp3ZdSyca/WAnQYatO+ugOaNIU1ajzPyi9TcAwYvgSNPLe3NHIYNiFsLL+nVrRRwa3ARK
+        +uK71FKc78FnN1U1QtfT5dJKBwhcX0oIKo+LUokw88xpOP4xfpsqmonW0QD4UMqG57EXCAGviiDs
+        szfo8OADstkOHuI6KEx0aHQXtwka9vAuNdQdU+ofR0aAwPHFDQO6qZQzWsZgVW6dtTzlK0auvgcI
+        Fn4hKfCB9RNQ2ahzojnC4KzKbSzaFrDHyA5ER0M50mVTvdmYoAsNZnxHxiXsOTWofrL0bBj+5Usb
+        VstWPuaau6IECFAMJWyONz0VguAsODr45SakX3TCxJQN6GAkHT8ZoerIwhtrYfmR/3ykNpdUEcxX
+        RmmsFJlt6C5yA9GcYEJIl6nWqyeTtb5suYb2y039+uKh53Z9WhJ4wYaBjW+myEkhfhwjIYKLN7cs
+        qZpZ4A/eNrTXs9Fr3GktAhJL5kMQWJBFzb8m4Y/UGawhT/ucjVZ9dhPnBhQjWJLFeKwfX1VeL8v2
+        udgs2izq5bjtJIIaUBRCtrhATwCok/J1Wpd99bK14t/FD8KEpmkw9gsZtXwzh5KtCmXw4ahhsX+m
+        9tLqQNFg7RcquHFopPnSovcOrfPu0lEZc6/ef0Y0JijeiCNoueP986hzbsoYWwcN9tzGZ2ER4jtc
+        OsNApwXjWXYdO4oE6pk2LvGt5FBr/69GgMCZxS0CS/UlhGRYdd7Dh20pKmGWfBvinOTCZB5Sqfc0
+        dlXW9bjNReSNBlwEOxhEe3u+nQ1qYfglH38b+EuQe6PsSTl+Xxc/CEV1pR1dFHbZID2joNbpcyhq
+        mNJFHV+VNVbN+ak5gTVwZSkpXurEw8jE1Ei3eQ3SOKAGYmwNQnyO74qB4Lh9yFN6ljzEAdQTUsTP
+        vSDIc+Pzc6kuOIioYT7wVx2fhXMEr2uo48ouUdJJ0TiiHevR0I7wy1n0TlssbV44v5QbdQIltpDg
+        n+sktr4UDfZzbhA4+yEFPEIVycU8VD/+/ya5Ge0iJxTNuvFpB4ws8Mb7ZNcYq5et9+P3OXeHuydo
+        5UytW0sHHvkucRMIiYAsIvviEE3QK9pEYZcNmnuOhHmlZxs0gEyz8PNoAp/rLFru5LotQyGABiSF
+        Ek1ml/cuMf/xhXdFLac/57BjMEKS3uRXue3kvsyhRF/UnsQyZUpzJoPJ1ESSBgSc+Iczg+VU3FKc
+        AxVFE/E1KqzmwPNkCVVbJ9qhbBKsW5hXH8GkXgJEHAUbhfaGMavZYRNhzur79Pk5/cNfd8ohh/xL
+        gQ/Mq0jORsDkFhz/uEABQytIlTTSUHHTgMKThIqgO+Ho4SUjX1Y2fIbhJFNpu20x3kwRXXEaXqHF
+        H7XZfuS2GemCkKBwakXEd7F/vlA0FA9LVleqEefATcMw24LAmTwafVyUxcBDrRtARDcIqZ6J0/ny
+        SwmKKcEF8Np+UlFEcEQoB4qp3TRAYqL6BUAEORjVfx6RrVDKpynrl1KyqbiUb1QhStK5Uk8tdWoa
+        jSgGSvjzqZKpwu/csoO3GInBnFeGaD+ym+EPQvXoFSyONdzukv+PaDuiTEHJvrfkAC8vmUUQUf08
+        t5bvZ0BNlR7Svo/yUKt23C7xmF+yRQYR+aCkQt5b4SSkv8R/3u5adXx9t2QQze7cOgyXFYv4nhG8
+        pJ2w4l4cOdjOt6UamXZqa5HY3FPksWLp+A8ocDxPYVzfGkvS06Z6CUzuSREpMY8mHMIYo9VyyCF5
+        C3fq5VqCTFuXtn0qazgVlYPaaU8G0fjOlq9xp9/0GDzDHx+JcfFpGi3uQiHygee8VPqcBIIfgjGz
+        8uSLSUGGf6sdt2lbk4sQ6Yg+IzMg9hcnxKwFOkJQtZiSMbn80wh+SEiSRcc1lcA/AJUdJobHWJ7M
+        24UWEojx1cg3xZY+es6Rf41k5OPIprkWawfXPPTf8EbQ+C6klsBnExGiXGpEHeHNySoNn7TcOaet
+        TBHJA4kGeaGw1KFxnXx+QDYGjn/1cZRLVi+Xy3NClYZqFXvgQqSuh35Ao5+Q2eEvbNmNXUImhKLU
+        /IA8oeCz59EJvCJd8phfGJkbI241AiWEdKQHjEhyFE8+cxESagoVoJpONI0iyicKzacljE445wh+
+        YuSHEtI0Hsaxhtwib3ZGUaBGM3zC8UGxqcyxpsX837ARvt+Woqat72OVUq3R5O5Yz8w9F1/GGnzi
+        FUcRU5xa6xV6GNFNQS27Fi+BxGD5k02keznnrjIPQ5lwCMcaD+6R3zrWUdpHpF1I9h3P12gjr5cl
+        TVyKGlOSKAse78ZuvsDo2ML7TSdAVlrz6fE3qLhGa72wAvIgIm+EKW4cRRAuGcUA3Uqn8CnwAiDf
+        rMasJGwVOEDflLVD5NcALa255hYoopEoSjhCa2D9pXdkCdk7P6IkrlJDwWGSxl4CXzUsu5VoAjJy
+        KExCMyz+W5fU9vQUZJisZGAaUROO9U/HM+IKW1aOOdoaRvLIA22PGWM83yU7DF63KLP3sRSLq1x/
+        qOvMjrkdDhgpk4XNFxl5OpAr1QrVuaoH20UeedTtiUZnr3kthKz1GWaCQh1fGUMRssr5ftJdR9P0
+        lAg1jzwKB8JcAcKRXsfGM5w6exo+X7/8SvQxksDrByjMmQlzLrLX8Cq1lMLZNkUCxEF46IODEMLM
+        fWO7cK0zTgzB9tXIV+s0MpGL6GvkbzIaPpYzwaBDlZeQn2RyU65tc/6EABH1IKze3I9qV6bHWTMR
+        ltPLb3+Ui4cXwKXUZjWfSMyzfh8tnJXFtOt61zZTAkS6KPY18P64nNH0bRAOZSRMlADRYs9NghB4
+        IywJPfMUI+sp0Z5HMW06xnJMVZXPxDlQ5oNaMdJdtZRRWVECRIM9G/lR+ZRPubTk4BqASFutJ7sd
+        mjgpoK/djtvjeCpPxEeCmLmAYrWFw+FmNrCmL9Caz+7K4rFxuaoyySASRLHFUKiLc4deszcIShbf
+        XlX+tLdUcjisZAUY9rLiSUHMwpvYJE0S5vIpLAeKuVOAKIMRFV9sbOvIp5eWdzEeMMF9eaC6RkO+
+        srnI82Moxz/1gkkfaDkQNNryuVXgA6uFi7T+80TjEp3A9On6JNIXYyCNPWxZNKykwiQmhRUqxhMS
+        ns0kypBgCNQ3el/LqJbT83Fbiw6Noo+5yrtU970lKGt84eQZa9FauFNvTvQbBpGJslbh255+twix
+        qHeA6BAQrrovMMxHwkFOhyVq+CFNz8qyygWpaarQ2jydCDbg9rG4IHSglqDuDd8tq5s4LN71oRPP
+        VnJyor6r80SBXgNhQ1Ngc2UIS0u4FBzDmxx3HowMM0Sd4rgiRv6b0F0dvBTE0LJgGr9U19LHzIeu
+        AmG900HkmhHmdGj64OHltFOm/HJL9kDjciSul6cKIUVyInKx4fpmxGBb5T4t6VrT2VccsI8clPwF
+        0fEqHEhygMTBt8dtTc2KnUFkjBKue8VP0iCsh9oFkcddXvM0uGkm5vLdUPkh6kErHbdJTOfaivRw
+        l6x4BLLmNRJICSfhCIxhXTlPeMEOaqA0tnB3SWmGANEfjBYWpNH9IFxHi8+wLZzd+4YRDXQdd6vj
+        q0rjac11zw0Q4GlRBh6sBIiuCXYyYH0RHIuKKperORrwi59jxxozxjkZa35mHxHmywhsvCPF62VW
+        H+Niz62lWhZBKaLRZ0GBe4Moh+HEkiMBn3p2d3y9m4sz0sgXZSTw+TM8yNz7Tq8Z3pxKfTputeRW
+        kHf1bU/ltCMRidHZ2OfBgMYJrNtcHkvRft4Jq5JZfGDfLttTS5fn8nsmLRSbh/yuAdHHuXMe3iPo
+        OilmPs/1fYUrx2ELdo+AFtHCpBwiqP/s55GyzhQ6ACgaivFo3KmXQ121ikFWULoBhTKISAP2FPpz
+        RXjM0ouHu1FtKlAwwSWo4uCXv1MZv+bRx24DLzqAhy8BR579VH8prtRiJUuA6K7gVmEYZDCQFVoI
+        VPDaRaIr8fD8JSzfjUtuSc00QhTYQehnVrCunQb20ACTacISKOvPz5EnbDgrRPxSFux2yVoRMvYz
+        ooCTiPNL8ZHeqHMWaaiqh3TZZ3+YGhuEgEaQAQX9BY68V1hH9bUQI9rUjYoLxb4j2beMRpqKFBlA
+        nLbn0pQphytONnLb1mHWFOHIouvizSv3NR999acAMQzCPdJo+VpNyeo8RvB5vY5aKNK+wiM9DaOu
+        RyQRnZ1XjOJFJp1N22gPaomoFy+PYWQh5/dmUwklGQavNOhN1SwxSt8VZbpZO+jlrJ7zaHugbB7j
+        +BtQZM0UTkSfBEolZGxDXbz3ZNVLfRpLai+UNA45ZPzuuE4Ai3gGv1ZVPh8ajWxgM7nzS8rQL94V
+        Rfbsrq3SCqw6LpcFAWIcepCgvzG8l+xQB+bJbM4qIhCnFeebzGMcdTfZId1EYQ2KJfxUM+7IUn9D
+        tj5kE8JPzCQnzWMcgj2OhWXhy4UY1FKIMLEDdjL0MZWGWtOnso4VIMZxuCcGSZ/DAWF0QUNQu1im
+        8D5+tKGW1J6GYIvmqOrVnfFX0o7JgXB0L3UQTjRXPDLKv/Kw5HuAGIffTXFIP1xwEU5YvrqNbvPn
+        vFfUx3QKEOOjDlmVvKcnKld0FDPYIGGuS6v8dquMaAKigCTV2Mk3NloOHXdFMSduzkbl6Z7V/WRG
+        uznexC79EZUOXhAb4V0JdaPJwApaiN/qm2WTTv4CGMyMdn+ws1jLNb8US3aWXKMMi1a6ewL5GEyI
+        m0uPbjUIAc2MRiMIq50O7SQWnx0hBnELPLGId41D/mFQsHTmTWERRgIDhuqf55I6ZkZOGQSRZCMz
+        2lVCGYWDQH06awuLnPzGKLOWv6iWp7HQD5kqilRjFCiP0A/vU46Ma4uF13XaSsCIm0UeNZ1tnHdT
+        ApL1wCPGQ4zCjkQkNJRjbz2YGQL9y69fkCaZ0eADbh64pIwUtXfsoxnKMSXEzwOK0S7BaKcK9e3F
+        ydd5LJXD6FCTMRWtNAmpzedtXdNTljYkYwFblUUlMsLMaMyCciKMjunTGceCGjswqlxVU6lx+Jpb
+        Vz/kvW2XbeFHzIx2tQgb2/1wZOF0GFXgAJNuzgpsMz4eJUgw8cKshbMw/O2MEXgFOWipNE35UvLn
+        z/mmWG8GVhMtw18fCabYre9gVCaayEUnWGex8My2lxkNbOCGgc+DQZ1lZ8F6eJ8t1JTXrHlwJTuQ
+        PTOaWSrjEFXciZ2AWjOH90bS4viqyIi+q61brbmhes6lqhfYx/gvP0CUA/sIve0W6e+3vZggN/So
+        V1EwQUc4nhptQj/bEfW8jVnwp8b4L2J5xNl6WikQ4cZDieI+aYyuG+EQHlawdDVWpGjHLUMQqltI
+        U7HiODt6adiLH88jXDbV1w0xvJromD+KgWUpg+IKGu6Ne5jdclijVunQGRvAdXBqxYA+/sPqTXl6
+        3nMt9enOlDB7ZGHjUKa2YDaQKMvdjMZghNJg9YocPoy0nk7P1dZnRicIcRwRXr5ZTaIGn1Wy8HKa
+        tjYnSrfIO2QZrfpe1h3ACn9xPm5Px3+19xvxgHQaJ+FQwoY4gTcnwY5IU0tn1sllq/M64Od885Ir
+        wWisBTsKQmIWI+hrVTSkfS8ts4AhpgvRxyjxL+8neBsf5vT1CKPtN+aeUN+V25AuTPZdR37I5jcK
+        YV7P2Gj4syp823Iq65rHw5IhOgfoKdQvqNrNI4LZDiSzn4iTJeV8lnIRqvjSulWVylKqNVWNvxBx
+        QwQS0/CK6LN1yDFbKuICFt+ot6nJZUVz+n4oBixwN1kEXP2yNwTf51o/bx+ZkBXB8sufkFGDwf8i
+        OxCX/1XFeH3BMvy49cRzSP1N02eyLfvw2KC7RwTA7C8+RGoGckagrUWuswRL6DUlGQVoR17YxuNj
+        S8UZp502zMoB7O1bUTKZ0SxZ7DyICHMRC7etSsb89RwAF157Om51m8o8Q2KWerYIIqOACFu840jX
+        cPLhlGuB3TIbzloPJde7x/BpTHp9yVbseeS2AgYnm4jJeupcakGTAgu3F+L9ZA42ovQrvt2Yxp5t
+        47pA+aUwHzofnXGlQCZq07JE2bW4WYeXYHTOEfYxcO6cnfFzFfm1SlcLjNPMdnOyt9FfOIX6OHIL
+        nKRS812I4sB4M6hImvCSfExHh1IGqpFbsgccePn4WNqa9vJ4J8jFxVYDR9fMWY0JsfUYJ3dPWma2
+        5zYDG0/FWauKGzWogEHUqYl6pHhIewmEeC65eeS7WA7Vy5L2NDMa38FeAko9LmJlP/ESIWUJyvEy
+        8NDMaC+TiOU9Vm7Ili94JM1QyxyYOrOStdTPjeaxG1rxQ/xSIjYW4jeqa1qyJt0E4r0Yc9Xt7KY8
+        GDuYB2Sp5XIxuoXe+92i0vR8/H7NLdFHyT9VgcNzsaN2QBK7LBL2K/Q8QQnWXmoJXgI7RvfYoNgh
+        tc4Woyb4ttSfZU7cjkDYFzeGy2V26FkDwYqm0J+ibyMLEtwxFFu8i9BTnJvtfBQDr4uOHwl/w4TG
+        JY9Pd3vSM9bkgkKd7dAbcJiFq5DwL6yHnsKnNScDmBstQ29XDIanLsJ5Cxaf8rfaS7tg9a3zbB3m
+        oaY0p+uc0T7DcPCpjLw9EYzm1jkJgHVyAIB9AowWWy0Vx9TcaBmDPQmy0wtzltjfIjqimLvQc1db
+        L46Ju+aTE0XV+Ll6RVidhYx5eIEIZpAk/R/cFvb9Q3orShcL4+WD1vYFawvv4eekps2MzhXCLQIH
+        jlMJ0QwM1302bdp72HLkH3cYHMp69GkaUT3GbBtPazoCP7jxwIdDFONxM+FeuufLJSEaCrq86tCj
+        eGwsFp7FL8EC+h64U2/LXo4bssGTqAGM7qZqwLRp38G1oMuIushC/8ZCMZ1LYxneWFMq9Q38ht/X
+        tT5JBGJkPb3PHzkhDb9eFKoI5Xaqix+VGbd5POU2DyclFTf19U2I/JUv5hQ0x3mx5KtmqqMPud5T
+        1RgSEXD3gOlqgHZJHJW46znsBlOyhvpGvd3Gc5gHHnFIZSOzE0qDuCIOLHw5z4VVx+Q2mhvtRl+X
+        cJZG3NmLQvDjcXt6uxBFImJA9wnpVazjIt6xNLGUshUHHuRlBwIPVOGzvgp0wP2koRV0mm18xOWk
+        zH6qINRCpfFUWFVtG0/5Ht6SbBE1AbsVuxzFwFXayX38bT1ysLFmmdF+HG7kE0aJZLi+bMTCy7Za
+        CLBuDn7LoeMhCcDRauRmZEYDTNjNgPWJOWNTXBpJW9A2xNkaeBZNUdNn6vKc+hFGtmeoSCl2LzIt
+        pyH66PiaIEUVVyFBr5B3Yg8soh0R5Kg6ETtdbqJk/PRSNiFm2cwEwu18AItIhuZmcA5ebRt1MUik
+        Fa8TVRQL9jGSTiDSEknM7Iyp5x9/aouuGqtM78EtfXgytT8dOxPH6mtwRDGxBzfdmD+i0pFtNvY8
+        dRIsR/iaXW2TDYpNfJtPJo4TxUvB4Le3jvbMaJcMG4RuAAIte8jrCHfq3SnXx/yvYAgvl+P39RB0
+        tgWpIlf/TzmQGQ0xYVdhfFeB4vsFLwKvNvHsk0+GF+3tIxOaOoLwucUaNMEI+cJPyrsZKJGXJd74
+        p0lmKfbgO2lF7H0Fky1YF+a9tb3sqm9jejjQkSPCJD4w8aa2KaLXGv7uATJpTk7Ky4/OGydOK1nH
+        jwSGRn2VGs9Ve29YMaaqrq8QSCb6DIysMqNjtPOAIPr9E5lOnGmjXZknc096wzUELvM0XHc9CZTD
+        C3OWOcYb0UYowJjFmNr5/OOEov8H99fHIVpRFy4mlYfqKeqfaXoSC+hJBNYrBimTmC5hHCHGIqmL
+        t0OBfzy7cNhjG8SIlgZLlDjiZHgFpw17VmZ02A2CHtro/MAU1ZGMNvC+YY7I7opD28NH6Mu/gDXW
+        ircEo1deCLbH/3US6Nz+GbC39F0YHRlgZgCbj90CwsTCYuzNGx7LsFkxY+E8Ss6Aownx97kgh4DQ
+        6ATVNiobublH9qbHRAkbPabfLUYKMAbmdqATo6PP2iPeBMNEiKeC1SFGijQRVuEH+t68ltzUQyo9
+        N+C2hDOcP4xFB6qQcWJ0DK3rsYZrzESh04DAJZeyuqaxQ+PDG2OR14eWOh4brmkqo2P8uLD4ilEo
+        MVHYn/Hkl33qYpQM4P8PPGBTZkCEGePal1LEMJIyV/38zvncaFMr4in4BbWsxhgMg1r6GJivpdMP
+        hpIBPHRu0D6hmHeXkYSVH74d4kiRR1+kWI6bPMdfECNzALMHsvzDxNoj2cBBZpoA9Y848NvpWMgi
+        Yoz6dGNixnMfbe5xtj+SMTLo2ZF45Ehf3cig57be81hU3tWYMmzNufdcIBTaUGpkR3VqjHalB24r
+        C3/Zd45N+PI0BfOffHCJ5jqWM/JPRiQvjo1B6eySB03QJNvKuLJNEbCIKPTY2JPyV4jgV7Lh921N
+        baSxdyAgkgAPvMkonPPcYbSEg3i7lSfg8yS5XRx/35UPsJdkyJA0WTmWVrHvesNmWIxaAmjenhAy
+        fZlOeFHkNa+dkDowsgnwqEBUpmCieDeGyYdoYskFlNdGlbzWsN80DM8fOHZzFEPqzdTxX2kYcmqM
+        4TwB/8dCJCCA28Tni1pGMhbQ+lhFjBrpGTAIZpe2LgSVBHAQNBgIfT3ORMd1HvS6pPeEpM8+Yi+3
+        GMEEbJbYWR0SoVODREVizA2XqM14zdRVmrcLfdMpfKgDU3yYPgGGCITqxImLQs+GtzwSXyCNWof9
+        9RuLIWR9D20FEit3Ss+ZBlZ8NtZDdPIdUXnoYZDqDIH1/cxEoXkaOPJaZFV6v8U5qMaXm1uTfYzR
+        iNSCMWCIzrZ2FT2yEFBlaLlhC4+azE2yoWQNlA7AQcLkNf2PciYag5k7ZwSf7Ljxq8K8MO1h56Mq
+        eOksMuKeGGISTBQ6M/Ie5yJpiSYZrMdxOv6n1ze0DbCZhuIaJeJDDbPSsrq3nZa+ymkAD4uRNcBm
+        iJHnsQ1nETkaapvYZQDkdPafO25TLQYUKCAtAzuzvPgK+eja8Wcd4okwUSJjMoapWaSy5p4nCqFB
+        esFEsfNUyQSBEqQtNSMV5peYxtwBwXHnL+X9MJHfMfWPuUme+5x03iCirMCvWLBqV8W71QPalxjx
+        AnjoHqM1Me+5oDZmjTT5kiWyPWLWGkwUoaA3/T5FzBMjSIDYyN2BFmCEiWJ2HPmj4B8xH7eHsmS1
+        jYECVAlgIYEFSMTEijB4aS8QTO6sq7ltftKzPrBs2cE5RApgSQHDYWQikM8cgDv17VBr2reZgNzY
+        XVMY+57M27KQhQGmWe+pzVOfugqeDOisnFmDxiHSYYR0VfCUIclD48Mp18cSdfhETenS2sj3rImf
+        ykSh3u7iTr3NZZV21uZBT2/au044vSVF2HJg1Ayw+YfsChSGPLf+cRT10I7/fwkherIcv18pgUPY
+        ANYdiBdBNkYCP3zrpG3SMfynM9qVYtk+v30TcLeaLJwcDXsxMTIH2PLC2H2FN5Wpd+LKIMRHjEPF
+        +KHE1a581XZj9ESW8ZyQQnRjByjhGF4DXfskUYNkUSMbUHQN/tKQ0ICwlC/diJSv55AMCJkozgWZ
+        oePCN0aSSCqL0TDAHhpz3WEiwynSTka+Psim06Zng/mwIwkCxiIkCr/mY0QDFjnjPS2rfzv151Kf
+        OoQpX6KAPb1xITgWyFUxHnmLXRV0nIDAC+bZsNAhGj9sBKARhmY8NcZc2oFRNoB1BY7RBCsXDxr9
+        Coc4XxK0UYyiAWxuEDUVQvtz0ditYJQA9D69rnAGidEzQGyU9ECb7DJx16CPcUu3+jYkSEDzc9H5
+        QYN+41fIpCZ964r0S1ueiylhy6MZLYhZeVZt3DNZsOScTy19HI+PqdjsGxJDMPEVQgoeXlcYmw1U
+        U7qUJT9mj2gjvCMTU4f63ccZLZdpKozTuPA/r3Pv7R93tRMGTnPrIu5Z58WUVUgA4gCepfhw8Pts
+        gFaLUSTAHuv3dMRsnFPCAmk4SVN5E3dJe184YjxZUnt6CB2Lg7yB+1UTDH4ghmDBtA8QQ+RbMGlK
+        RUCgAJtxEM1ZxoZhzD0nC/6WbEe64RNEoq7reN0MC0V6i4zJHQPfZ6KE57O+fzfzoQMinAo8s+Mg
+        PTFMF157aSw0CLMUqMWRsQ7Bqq3ZTpiVeRfu7E59j+j2eNQ8kTAzTjewR8T7nYmpR4bIvrBhVSRD
+        9YVs2XBoHX3In5okAmnqbYZ+U2cqEA4c5De2wYJGs5esGJ9gUu0fYdCE7m/ubBmBcLhmokTjEjNW
+        NACikztKtdN5+N1BVF70izVrbWMxnfD+V3c/wDl1z/I9jJDOcxstKBAGIM3ebXijXr3koabn1ArZ
+        j1NjHBc25lGYJdr5lm+X5Hj6WG3NpSGowrOMkQTRGgS/zhilBIo79d6QAX41DHSv4PtUjLOOnYN8
+        19hJQcKDkuk+DIZjKYiK3ADGF7zpXdrTU0nlXZ47X6LPH56J4iWTMXyF+ZJ8+yV9TnW/V986uxOj
+        xQDL6cShLJVI+fPo6E8N3gjHLsJRA+Kqxfo2yuCXcJ04db/H6561kc6ZeC5otF2RSxAYQvLGGHY9
+        DXUpT6Xv3+Dv8aZnRXEQlg11XsxuJ7m7zr6gLqk9jvV+iBfbTBrO8elfHoe5ty0MAhhRJDrSof83
+        fA4oMqZim+yl+VQy6MQ6slwyj37YAu+fvNvz9ZPY63BA9C5ljOcGa4LXdU+RmZVJ/WXXI8fylIni
+        l/M3ADWIEWSAWYIQ7hhlONYLKRf/WHK95sq8h+GtLMJrB0aIAWa5QRj853IsQbKqX9K14K+yfS/s
+        57P3nwOjw0BqJVTwnqRi18F/fe8D/Pt/arlOz/8hAA==
     headers:
       Access-Control-Allow-Origin:
       - '*'
       CF-Cache-Status:
       - MISS
       CF-RAY:
-      - 87c7046ba82d527d-LHR
+      - 883aac5b49edf0bb-CDG
       Cache-Control:
       - public, max-age=3155695200
       Connection:
       - keep-alive
       Content-Encoding:
-      - gzip
+      - br
       Content-Security-Policy:
       - 'default-src ''self''; font-src ''self'' fonts.googleapis.com code.cdn.mozilla.net
         https: data:; img-src ''self'' image.tmdb.org m.media-amazon.com ia.media-imdb.com
@@ -1851,9 +1406,9 @@ interactions:
       Content-Type:
       - text/plain; charset=utf-8
       Date:
-      - Tue, 30 Apr 2024 10:58:33 GMT
+      - Tue, 14 May 2024 11:50:54 GMT
       ETag:
-      - W/"c2e3a4a1baac735fe589e05928e76f47"
+      - W/"7445af935a9d2860ed2f7f7efef3fd0c"
       Last-Modified:
       - Sat, 01 Jan 2011 00:00:00 GMT
       NEL:
@@ -1861,7 +1416,7 @@ interactions:
       Referrer-Policy:
       - strict-origin-when-cross-origin
       Report-To:
-      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=MtZM%2FUMLL4%2FXhEOzwgl7UsEA3ZWpTUUVsOCR%2BWrdxpCPfRN0HQb7fTNgWr%2FyFi3K3gOB8027FrkEKCzH2N9Q6P6%2FD2NKTuClfVvuDhcB1jqVTuJ3n15XF%2B7EklEllY0b0nopmtRWhBI%3D"}],"group":"cf-nel","max_age":604800}'
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=d4RCsiafUYGgQbwWRQnXmT7Li%2BAemJroeQEfY384rW2lAzrnPPUC%2BqT9lDPFNTmE%2BbIHc3C5%2B4rNfxRiy3jtt5iUnRWZBNh8k1361oFv%2BxjD6JWLV2qFL6EAoKgELesu93tjHpyZtR0%3D"}],"group":"cf-nel","max_age":604800}'
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -1871,7 +1426,7 @@ interactions:
       Vary:
       - Accept, Origin, Accept-Encoding
       X-Cache-Backend:
-      - rb2
+      - rb10
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -1881,117 +1436,15 @@ interactions:
       X-Permitted-Cross-Domain-Policies:
       - none
       X-Request-Id:
-      - 6965fbcf-328f-4cdd-8613-a366a95a063b
+      - 3eb2be5d-2920-4deb-9e02-507bd4030033
       X-Runtime:
-      - '0.025327'
+      - '0.018355'
       X-StackifyID:
-      - V1|877d7c1d-f660-4d52-b448-6c41895b8c8b|C98184|CD4
+      - V1|3c3bdd9b-daf9-48e4-8419-7db915d006aa|C98184|CD4
       X-Var-Cache:
       - MISS
       X-Via:
       - fw1
-      X-XSS-Protection:
-      - 1; mode=block
-      alt-svc:
-      - h3=":443"; ma=86400
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Api-Key:
-      - mij33pjc3kOlup1qOKxnWWxvle2kFbMH
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJBcGZGZHAya09pYllGMm01cWpYRDdkUnJzSTA0WEx5bSIsImV4cCI6MTcxNDU2MTExMn0.URWWANxho_7dXQrD3OPfa-HdOI0Baf9GLXuPFugkWA4
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Subliminal v2.1
-    method: DELETE
-    uri: https://api.opensubtitles.com/api/v1/logout
-  response:
-    body:
-      string: '{"message":"token successfully destroyed","status":200}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Origin, Authorization, Accept, Api-Key, Content-Type, X-User-Agent
-      Access-Control-Allow-Methods:
-      - GET, HEAD, POST, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Age:
-      - '0'
-      CF-Cache-Status:
-      - DYNAMIC
-      CF-RAY:
-      - 87c7046d7d587772-LHR
-      Cache-Control:
-      - max-age=0, private, must-revalidate, s-maxage=600
-      Connection:
-      - keep-alive
-      Content-Encoding:
-      - gzip
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Tue, 30 Apr 2024 10:58:33 GMT
-      NEL:
-      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
-      RateLimit-Limit:
-      - '5'
-      RateLimit-Remaining:
-      - '4'
-      RateLimit-Reset:
-      - '1'
-      Report-To:
-      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=I7XrhJXJgYqW7LM07nV2HnR3FT62qWC3N%2Fzj4B4plvjjVnyWTRMHi5u9uDhISFEsjNpBQru5oA8fqqno7btRcx2e6Dnhkr00iWJko1oKcu2BOn3jCPY98uWkywz7DKAcIjGnbpgCIoM%3D"}],"group":"cf-nel","max_age":604800}'
-      Server:
-      - cloudflare
-      Strict-Transport-Security:
-      - max-age=15552000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      X-Cache-Backend:
-      - apigw1_8000 rb1
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Kong-Proxy-Latency:
-      - '0'
-      X-Kong-Upstream-Latency:
-      - '137'
-      X-RateLimit-Limit-Second:
-      - '5'
-      X-RateLimit-Remaining-Second:
-      - '4'
-      X-Request-Id:
-      - a8a5dfdf-f57c-41e4-9d38-54bc640da95b
-      X-Runtime:
-      - '0.134463'
-      X-StackifyID:
-      - V1|6462c95e-5b76-4b50-a483-687914526c75|C98184|CD5
-      X-Var-Cache:
-      - MISS
-      X-Via:
-      - fw1
-      X-Vip:
-      - 'false'
-      X-Vip-Consumer:
-      - 'false'
-      X-Vip-User:
-      - 'false'
       X-XSS-Protection:
       - 1; mode=block
       alt-svc:

--- a/tests/cassettes/opensubtitlescom/test_list_subtitles_episode.yaml
+++ b/tests/cassettes/opensubtitlescom/test_list_subtitles_episode.yaml
@@ -5,7 +5,7 @@ interactions:
       Accept:
       - '*/*'
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Api-Key:
       - mij33pjc3kOlup1qOKxnWWxvle2kFbMH
       Connection:
@@ -18,27 +18,23 @@ interactions:
     uri: https://api.opensubtitles.com/api/v1/subtitles?episode_number=6&languages=hu&query=marvels+agents+of+s.h.i.e.l.d.&season_number=2
   response:
     body:
-      string: '{"total_pages":1,"total_count":3,"per_page":60,"page":1,"data":[{"id":"2492310","type":"subtitle","attributes":{"subtitle_id":"2492310","language":"hu","download_count":6910,"new_download_count":9,"hearing_impaired":false,"hd":true,"fps":25.0,"votes":0,"ratings":0.0,"from_trusted":false,"foreign_parts_only":false,"upload_date":"2014-11-08T00:39:41Z","ai_translated":false,"nb_cd":1,"machine_translated":false,"release":"Marvels.Agents.of.S.H.I.E.L.D.S02E06.A.Fractured.House.720p.WEB-DL.DD5.1.H.264-BS","comments":"","legacy_subtitle_id":5885999,"legacy_uploader_id":0,"uploader":{"uploader_id":3282,"name":"os-auto","rank":"Application
-        Developers"},"feature_details":{"feature_id":149353,"feature_type":"Episode","year":2014,"title":"A
-        Fractured House","movie_name":"Marvel''s Agents of S.H.I.E.L.D. - S02E06  A
-        Fractured House","imdb_id":4078580,"tmdb_id":1010684,"season_number":2,"episode_number":6,"parent_imdb_id":2364582,"parent_title":"Marvel''s
-        Agents of S.H.I.E.L.D.","parent_tmdb_id":1403,"parent_feature_id":13370},"url":"https://www.opensubtitles.com/hu/subtitles/legacy/5885999","related_links":[{"label":"All
-        subtitles for Tv Show Marvel''s Agents of S.H.I.E.L.D.","url":"https://www.opensubtitles.com/hu/features/redirect/13370","img_url":"https://s9.opensubtitles.com/features/3/5/3/149353.jpg"},{"label":"All
-        subtitles for Episode a fractured house","url":"https://www.opensubtitles.com/hu/features/redirect/149353"}],"files":[{"file_id":2568816,"cd_number":1,"file_name":"Marvels.Agents.of.S.H.I.E.L.D.S02E06.A.Fractured.House.720p.WEB-DL.DD5.1.H.264-BS"}]}},{"id":"2491535","type":"subtitle","attributes":{"subtitle_id":"2491535","language":"hu","download_count":3158,"new_download_count":2,"hearing_impaired":false,"hd":true,"fps":0.0,"votes":0,"ratings":0.0,"from_trusted":false,"foreign_parts_only":false,"upload_date":"2014-10-30T17:21:18Z","ai_translated":false,"nb_cd":1,"machine_translated":false,"release":"Marvels
-        Agents of S.H.I.E.L.D. - 2x06 - A Fractured House.HDTV.HDTV.EVO","comments":"","legacy_subtitle_id":5876161,"legacy_uploader_id":0,"uploader":{"uploader_id":3282,"name":"os-auto","rank":"Application
-        Developers"},"feature_details":{"feature_id":149353,"feature_type":"Episode","year":2014,"title":"A
-        Fractured House","movie_name":"Marvel''s Agents of S.H.I.E.L.D. - S2E6 A Fractured
-        House","imdb_id":4078580,"tmdb_id":1010684,"season_number":2,"episode_number":6,"parent_imdb_id":2364582,"parent_title":"Marvel''s
-        Agents of S.H.I.E.L.D.","parent_tmdb_id":1403,"parent_feature_id":13370},"url":"https://www.opensubtitles.com/hu/subtitles/legacy/5876161","related_links":[{"label":"All
-        subtitles for Tv Show Marvel''s Agents of S.H.I.E.L.D.","url":"https://www.opensubtitles.com/hu/features/redirect/13370","img_url":"https://s9.opensubtitles.com/features/3/5/3/149353.jpg"},{"label":"All
-        subtitles for Episode a fractured house","url":"https://www.opensubtitles.com/hu/features/redirect/149353"}],"files":[{"file_id":2568016,"cd_number":1,"file_name":"Marvels
-        Agents of S.H.I.E.L.D. - 2x06 - A Fractured House.HDTV.HDTV.EVO.hu"}]}},{"id":"2493688","type":"subtitle","attributes":{"subtitle_id":"2493688","language":"hu","download_count":179,"new_download_count":5,"hearing_impaired":false,"hd":true,"fps":23.976,"votes":0,"ratings":0.0,"from_trusted":false,"foreign_parts_only":false,"upload_date":"2016-10-15T16:19:23Z","ai_translated":false,"nb_cd":1,"machine_translated":false,"release":"Marvels.Agents.of.S.H.I.E.L.D.S02E06.BDRIP.x264.Hun.Eng-Krissz","comments":"","legacy_subtitle_id":6764373,"legacy_uploader_id":0,"uploader":{"uploader_id":3282,"name":"os-auto","rank":"Application
-        Developers"},"feature_details":{"feature_id":149353,"feature_type":"Episode","year":2014,"title":"A
-        Fractured House","movie_name":"Marvel''s Agents of S.H.I.E.L.D. - S2E6 A Fractured
-        House","imdb_id":4078580,"tmdb_id":1010684,"season_number":2,"episode_number":6,"parent_imdb_id":2364582,"parent_title":"Marvel''s
-        Agents of S.H.I.E.L.D.","parent_tmdb_id":1403,"parent_feature_id":13370},"url":"https://www.opensubtitles.com/hu/subtitles/legacy/6764373","related_links":[{"label":"All
-        subtitles for Tv Show Marvel''s Agents of S.H.I.E.L.D.","url":"https://www.opensubtitles.com/hu/features/redirect/13370","img_url":"https://s9.opensubtitles.com/features/3/5/3/149353.jpg"},{"label":"All
-        subtitles for Episode a fractured house","url":"https://www.opensubtitles.com/hu/features/redirect/149353"}],"files":[{"file_id":2570094,"cd_number":1,"file_name":"Marvels.Agents.of.S.H.I.E.L.D.S02E06.BDRIP.x264.Hun.Eng-Krissz.hu"}]}}]}'
+      string: !!binary |
+        E8ERAMRozer1pfpCQiQoKr/dfDla7Igz1JkKcPNMHLPz3Rg38NYJdFgmRgQlrXG6G2CClA1k4BUg
+        hSOMBB9I6QDg9XXElhE5uIl+ZMwdflF/nXaxWxdhBA3x3w7UBkZRLC4soQejOcXYfgmKziYL8/sO
+        voOBLBqpBAdFulkcDOJ6kXwaHCgcQQhzNzNauy4OkRMMdisoRMOhmaBuBKeY3FU7tx8Nxc7Z4Kdt
+        68fF+uA6mN4O0VHsOpgUVkfRLxFGloxTXM71LjlFsMlP2wjDGafowzy2KawxbaWLfg7Ob6d2sSHF
+        dp6Gmx2w1wXK7jubHAwkF0UmRMbrL5wb1ZhC/AKF9e2PLYwb7Ja100W76VSOe+mJzwUHNrjB2ehg
+        8NaGSzdEdrB1U4ps7tlnds5eshP2hh2zz1yecM0O2Gmwm7QG17HzeY2OVZIv7PvJYXb8hh0fl0yw
+        cyZ1kR1+BsVmHkc3pQgDUAxuazc3bVwvknchp7Kuy6Zp6AIYmdku+DSug7IuwNyh2GMla0kx2dHB
+        YI6ZXdMMimCn/zA4WJbBb2zy80S+w6qxCxF7ihem0NoPz0NTBjd5BN/BiKJRpVoUS7cWTxYf586B
+        4sbZACO5KCgYqDQ4IJoBEEdQjPOldy1GjH55TyKJIcjcEx7JSJ6UkM1J/dhdAGxQ8Koua06Rpq4k
+        uOC6Liiis3Ge2u8XqwcjKRxsfNlEUyw2uCm12zSVShdlLWfiZAoEchhWwqFTioKrTXnqtDelKr6n
+        WMMAg11KSzR5fnV1xebFTQdrWPxvDIS7NZ9IyTlBzTlCBlur2OS6dvDT/2gZ3H+QpCkMDoaBrDyf
+        pJ8D+XJJPu/mKyJMMLBhaVIU8+C+SC85Fw7tQAm2rYDJYrMdfKan8jJXOdXcfx5lynsqDZZ8SmJJ
+        TzPgLkT40US3x/4vRe8Hp1Fu7w/LZrLUdS00xabjFEUs7YXTB2MvSvZ/93tq7JEuSlVi1w3Ih0OJ
+        sgaTfGge/a14pvgXURkpjKg9P81RBfKaa5JFOnZ+/OXbQD5Ovr238F9epYUW3rMpT3SGJshFxQed
+        +8nnIJiItGy32nWkK13X2HUDuoDPQlRNBK7yVRVrKp3+i3QmeCbKL0Ib0RipvPV/ePzp5Qd2LXXB
+        zteJnUzb7HXwMd4a9F9oXelCVcrDEuSCcq2O2orzpvDPMuDsOOvvHg==
     headers:
       Access-Control-Allow-Headers:
       - Origin, Authorization, Accept, Api-Key, Content-Type, X-User-Agent
@@ -46,32 +42,34 @@ interactions:
       - GET, HEAD, POST, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
+      Age:
+      - '48857'
       CF-Cache-Status:
-      - MISS
+      - HIT
       CF-RAY:
-      - 87c7045efa854911-LHR
+      - 883aac553b82f12c-CDG
       Cache-Control:
       - public, max-age=86400
       Connection:
       - keep-alive
       Content-Encoding:
-      - gzip
+      - br
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 30 Apr 2024 10:58:30 GMT
+      - Tue, 14 May 2024 11:50:53 GMT
       Last-Modified:
-      - Tue, 30 Apr 2024 10:58:30 GMT
+      - Mon, 13 May 2024 22:16:36 GMT
       NEL:
       - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
       RateLimit-Limit:
       - '5'
       RateLimit-Remaining:
-      - '2'
+      - '4'
       RateLimit-Reset:
       - '1'
       Report-To:
-      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=dWjeurGOva3PuJDbDf3yTj99tkhxmgaN47RTDC%2Bc8Pp6%2FsUBE%2BSYJl73IZazQzYJXMJuuybQlh9x9KFupC9NNF2lsm4XVMb4KrEEcfol3TUW1laZ2NqTCg%2BnbLo3E3Ea3XYwO%2FW%2FeWA%3D"}],"group":"cf-nel","max_age":604800}'
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=aSyt6bFV0OQU1yfXYb9LVWpNyLwoPECBCkqo%2BhSL3lkG3V%2FH1%2Fm4uJxOhX5WFDqYVdw2CiU8rbc4%2BMTBWbZ%2BmovgT43QwO4DZkl8MDZExNrh7OJB%2Fn5BiYON7OltGDf%2BeJ5HcPL8dF4%3D"}],"group":"cf-nel","max_age":604800}'
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -81,7 +79,7 @@ interactions:
       Vary:
       - Accept-Encoding
       X-Cache-Backend:
-      - apigw1_8000 rb1-temp
+      - apigw1_8000 rb11
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -89,17 +87,17 @@ interactions:
       X-Frame-Options:
       - SAMEORIGIN
       X-Kong-Proxy-Latency:
-      - '0'
+      - '1'
       X-Kong-Upstream-Latency:
-      - '55'
+      - '92'
       X-RateLimit-Limit-Second:
       - '5'
       X-RateLimit-Remaining-Second:
-      - '2'
+      - '4'
       X-Request-Id:
-      - 570c4106-3976-493f-91b9-ede2dad78296
+      - 6655615c-ceb8-413f-8ca5-b950af209ccb
       X-Runtime:
-      - '0.052064'
+      - '0.088905'
       X-Var-Cache:
       - MISS
       X-Via:
@@ -123,7 +121,7 @@ interactions:
       Accept:
       - '*/*'
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Api-Key:
       - mij33pjc3kOlup1qOKxnWWxvle2kFbMH
       Connection:
@@ -136,27 +134,23 @@ interactions:
     uri: https://api.opensubtitles.com/api/v1/subtitles?episode_number=6&languages=hu&query=marvels+agents+of+s.h.i.e.l.d.&season_number=2
   response:
     body:
-      string: '{"total_pages":1,"total_count":3,"per_page":60,"page":1,"data":[{"id":"2492310","type":"subtitle","attributes":{"subtitle_id":"2492310","language":"hu","download_count":6910,"new_download_count":9,"hearing_impaired":false,"hd":true,"fps":25.0,"votes":0,"ratings":0.0,"from_trusted":false,"foreign_parts_only":false,"upload_date":"2014-11-08T00:39:41Z","ai_translated":false,"nb_cd":1,"machine_translated":false,"release":"Marvels.Agents.of.S.H.I.E.L.D.S02E06.A.Fractured.House.720p.WEB-DL.DD5.1.H.264-BS","comments":"","legacy_subtitle_id":5885999,"legacy_uploader_id":0,"uploader":{"uploader_id":3282,"name":"os-auto","rank":"Application
-        Developers"},"feature_details":{"feature_id":149353,"feature_type":"Episode","year":2014,"title":"A
-        Fractured House","movie_name":"Marvel''s Agents of S.H.I.E.L.D. - S02E06  A
-        Fractured House","imdb_id":4078580,"tmdb_id":1010684,"season_number":2,"episode_number":6,"parent_imdb_id":2364582,"parent_title":"Marvel''s
-        Agents of S.H.I.E.L.D.","parent_tmdb_id":1403,"parent_feature_id":13370},"url":"https://www.opensubtitles.com/hu/subtitles/legacy/5885999","related_links":[{"label":"All
-        subtitles for Tv Show Marvel''s Agents of S.H.I.E.L.D.","url":"https://www.opensubtitles.com/hu/features/redirect/13370","img_url":"https://s9.opensubtitles.com/features/3/5/3/149353.jpg"},{"label":"All
-        subtitles for Episode a fractured house","url":"https://www.opensubtitles.com/hu/features/redirect/149353"}],"files":[{"file_id":2568816,"cd_number":1,"file_name":"Marvels.Agents.of.S.H.I.E.L.D.S02E06.A.Fractured.House.720p.WEB-DL.DD5.1.H.264-BS"}]}},{"id":"2491535","type":"subtitle","attributes":{"subtitle_id":"2491535","language":"hu","download_count":3158,"new_download_count":2,"hearing_impaired":false,"hd":true,"fps":0.0,"votes":0,"ratings":0.0,"from_trusted":false,"foreign_parts_only":false,"upload_date":"2014-10-30T17:21:18Z","ai_translated":false,"nb_cd":1,"machine_translated":false,"release":"Marvels
-        Agents of S.H.I.E.L.D. - 2x06 - A Fractured House.HDTV.HDTV.EVO","comments":"","legacy_subtitle_id":5876161,"legacy_uploader_id":0,"uploader":{"uploader_id":3282,"name":"os-auto","rank":"Application
-        Developers"},"feature_details":{"feature_id":149353,"feature_type":"Episode","year":2014,"title":"A
-        Fractured House","movie_name":"Marvel''s Agents of S.H.I.E.L.D. - S2E6 A Fractured
-        House","imdb_id":4078580,"tmdb_id":1010684,"season_number":2,"episode_number":6,"parent_imdb_id":2364582,"parent_title":"Marvel''s
-        Agents of S.H.I.E.L.D.","parent_tmdb_id":1403,"parent_feature_id":13370},"url":"https://www.opensubtitles.com/hu/subtitles/legacy/5876161","related_links":[{"label":"All
-        subtitles for Tv Show Marvel''s Agents of S.H.I.E.L.D.","url":"https://www.opensubtitles.com/hu/features/redirect/13370","img_url":"https://s9.opensubtitles.com/features/3/5/3/149353.jpg"},{"label":"All
-        subtitles for Episode a fractured house","url":"https://www.opensubtitles.com/hu/features/redirect/149353"}],"files":[{"file_id":2568016,"cd_number":1,"file_name":"Marvels
-        Agents of S.H.I.E.L.D. - 2x06 - A Fractured House.HDTV.HDTV.EVO.hu"}]}},{"id":"2493688","type":"subtitle","attributes":{"subtitle_id":"2493688","language":"hu","download_count":179,"new_download_count":5,"hearing_impaired":false,"hd":true,"fps":23.976,"votes":0,"ratings":0.0,"from_trusted":false,"foreign_parts_only":false,"upload_date":"2016-10-15T16:19:23Z","ai_translated":false,"nb_cd":1,"machine_translated":false,"release":"Marvels.Agents.of.S.H.I.E.L.D.S02E06.BDRIP.x264.Hun.Eng-Krissz","comments":"","legacy_subtitle_id":6764373,"legacy_uploader_id":0,"uploader":{"uploader_id":3282,"name":"os-auto","rank":"Application
-        Developers"},"feature_details":{"feature_id":149353,"feature_type":"Episode","year":2014,"title":"A
-        Fractured House","movie_name":"Marvel''s Agents of S.H.I.E.L.D. - S2E6 A Fractured
-        House","imdb_id":4078580,"tmdb_id":1010684,"season_number":2,"episode_number":6,"parent_imdb_id":2364582,"parent_title":"Marvel''s
-        Agents of S.H.I.E.L.D.","parent_tmdb_id":1403,"parent_feature_id":13370},"url":"https://www.opensubtitles.com/hu/subtitles/legacy/6764373","related_links":[{"label":"All
-        subtitles for Tv Show Marvel''s Agents of S.H.I.E.L.D.","url":"https://www.opensubtitles.com/hu/features/redirect/13370","img_url":"https://s9.opensubtitles.com/features/3/5/3/149353.jpg"},{"label":"All
-        subtitles for Episode a fractured house","url":"https://www.opensubtitles.com/hu/features/redirect/149353"}],"files":[{"file_id":2570094,"cd_number":1,"file_name":"Marvels.Agents.of.S.H.I.E.L.D.S02E06.BDRIP.x264.Hun.Eng-Krissz.hu"}]}}]}'
+      string: !!binary |
+        E8ERAMRozer1pfpCQiQoKr/dfDla7Igz1JkKcPNMHLPz3Rg38NYJdFgmRgQlrXG6G2CClA1k4BUg
+        hSOMBB9I6QDg9XXElhE5uIl+ZMwdflF/nXaxWxdhBA3x3w7UBkZRLC4soQejOcXYfgmKziYL8/sO
+        voOBLBqpBAdFulkcDOJ6kXwaHCgcQQhzNzNauy4OkRMMdisoRMOhmaBuBKeY3FU7tx8Nxc7Z4Kdt
+        68fF+uA6mN4O0VHsOpgUVkfRLxFGloxTXM71LjlFsMlP2wjDGafowzy2KawxbaWLfg7Ob6d2sSHF
+        dp6Gmx2w1wXK7jubHAwkF0UmRMbrL5wb1ZhC/AKF9e2PLYwb7Ja100W76VSOe+mJzwUHNrjB2ehg
+        8NaGSzdEdrB1U4ps7tlnds5eshP2hh2zz1yecM0O2Gmwm7QG17HzeY2OVZIv7PvJYXb8hh0fl0yw
+        cyZ1kR1+BsVmHkc3pQgDUAxuazc3bVwvknchp7Kuy6Zp6AIYmdku+DSug7IuwNyh2GMla0kx2dHB
+        YI6ZXdMMimCn/zA4WJbBb2zy80S+w6qxCxF7ihem0NoPz0NTBjd5BN/BiKJRpVoUS7cWTxYf586B
+        4sbZACO5KCgYqDQ4IJoBEEdQjPOldy1GjH55TyKJIcjcEx7JSJ6UkM1J/dhdAGxQ8Koua06Rpq4k
+        uOC6Liiis3Ge2u8XqwcjKRxsfNlEUyw2uCm12zSVShdlLWfiZAoEchhWwqFTioKrTXnqtDelKr6n
+        WMMAg11KSzR5fnV1xebFTQdrWPxvDIS7NZ9IyTlBzTlCBlur2OS6dvDT/2gZ3H+QpCkMDoaBrDyf
+        pJ8D+XJJPu/mKyJMMLBhaVIU8+C+SC85Fw7tQAm2rYDJYrMdfKan8jJXOdXcfx5lynsqDZZ8SmJJ
+        TzPgLkT40US3x/4vRe8Hp1Fu7w/LZrLUdS00xabjFEUs7YXTB2MvSvZ/93tq7JEuSlVi1w3Ih0OJ
+        sgaTfGge/a14pvgXURkpjKg9P81RBfKaa5JFOnZ+/OXbQD5Ovr238F9epYUW3rMpT3SGJshFxQed
+        +8nnIJiItGy32nWkK13X2HUDuoDPQlRNBK7yVRVrKp3+i3QmeCbKL0Ib0RipvPV/ePzp5Qd2LXXB
+        zteJnUzb7HXwMd4a9F9oXelCVcrDEuSCcq2O2orzpvDPMuDsOOvvHg==
     headers:
       Access-Control-Allow-Headers:
       - Origin, Authorization, Accept, Api-Key, Content-Type, X-User-Agent
@@ -165,33 +159,33 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '1'
+      - '48857'
       CF-Cache-Status:
       - HIT
       CF-RAY:
-      - 87c7046079650639-LHR
+      - 883aac558bf7f12c-CDG
       Cache-Control:
       - public, max-age=86400
       Connection:
       - keep-alive
       Content-Encoding:
-      - gzip
+      - br
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 30 Apr 2024 10:58:31 GMT
+      - Tue, 14 May 2024 11:50:53 GMT
       Last-Modified:
-      - Tue, 30 Apr 2024 10:58:30 GMT
+      - Mon, 13 May 2024 22:16:36 GMT
       NEL:
       - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
       RateLimit-Limit:
       - '5'
       RateLimit-Remaining:
-      - '2'
+      - '4'
       RateLimit-Reset:
       - '1'
       Report-To:
-      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=BvKVD0dib8%2FIyf2QTV%2F6FcLaBoRGu%2BuRFA5IIGv5hpARP6Ch%2FCpYNUKQnPC3o3%2FW0tV8D4dSs5cQNFgRLKbk8E%2BaWSpbsziBJUZCi6u2wnFBDMLqcYRR2aA7b8k9yTR51DcGnHOiL9w%3D"}],"group":"cf-nel","max_age":604800}'
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=PxLxx2dkQ9h5HiW4JKjlz%2BPIVjefN5icBv7VnPnvSZvXYffvatofmLcYdQJiy4Gq%2BneUQvuPcXyOEjrvgOp28h2zvaaAoS%2F5R1Druzy4S5mcC43sVlUpb3bUoNNRAs%2FEcfh%2Bg3oKVck%3D"}],"group":"cf-nel","max_age":604800}'
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -201,7 +195,7 @@ interactions:
       Vary:
       - Accept-Encoding
       X-Cache-Backend:
-      - apigw1_8000 rb1-temp
+      - apigw1_8000 rb11
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -209,17 +203,17 @@ interactions:
       X-Frame-Options:
       - SAMEORIGIN
       X-Kong-Proxy-Latency:
-      - '0'
+      - '1'
       X-Kong-Upstream-Latency:
-      - '55'
+      - '92'
       X-RateLimit-Limit-Second:
       - '5'
       X-RateLimit-Remaining-Second:
-      - '2'
+      - '4'
       X-Request-Id:
-      - 570c4106-3976-493f-91b9-ede2dad78296
+      - 6655615c-ceb8-413f-8ca5-b950af209ccb
       X-Runtime:
-      - '0.052064'
+      - '0.088905'
       X-Var-Cache:
       - MISS
       X-Via:

--- a/tests/cassettes/opensubtitlescom/test_list_subtitles_movie.yaml
+++ b/tests/cassettes/opensubtitlescom/test_list_subtitles_movie.yaml
@@ -5,7 +5,7 @@ interactions:
       Accept:
       - '*/*'
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Api-Key:
       - mij33pjc3kOlup1qOKxnWWxvle2kFbMH
       Connection:
@@ -18,48 +18,40 @@ interactions:
     uri: https://api.opensubtitles.com/api/v1/subtitles?imdb_id=770828&languages=de%2Cfr&moviehash=5b8f8f4e41ccb21e&query=man+of+steel
   response:
     body:
-      string: "{\"total_pages\":1,\"total_count\":10,\"per_page\":60,\"page\":1,\"data\":[{\"id\":\"879122\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"879122\",\"language\":\"fr\",\"download_count\":20172,\"new_download_count\":203,\"hearing_impaired\":false,\"hd\":true,\"fps\":23.976,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2013-10-16T16:56:06Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"man.of.steel.2013.720p.bluray.x264-felony\",\"comments\":\"\",\"legacy_subtitle_id\":5226251,\"legacy_uploader_id\":0,\"uploader\":{\"uploader_id\":3282,\"name\":\"os-auto\",\"rank\":\"Application
-        Developers\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/fr/subtitles/legacy/5226251\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/fr/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":960683,\"cd_number\":1,\"file_name\":\"man.of.steel.2013.720p.bluray.x264-felony.www.subsynchro.com\"}],\"moviehash_match\":true}},{\"id\":\"880717\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"880717\",\"language\":\"de\",\"download_count\":2670,\"new_download_count\":194,\"hearing_impaired\":false,\"hd\":true,\"fps\":23.976,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2013-10-19T00:53:25Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Man.of.Steel.German.720p.BluRay.x264-EXQUiSiTE\",\"comments\":\"\",\"legacy_subtitle_id\":5229998,\"legacy_uploader_id\":0,\"uploader\":{\"uploader_id\":3282,\"name\":\"os-auto\",\"rank\":\"Application
-        Developers\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/de/subtitles/legacy/5229998\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/de/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":962352,\"cd_number\":1,\"file_name\":\"Man.of.Steel.German.720p.BluRay.x264-EXQUiSiTE\"}],\"moviehash_match\":true}},{\"id\":\"880511\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"880511\",\"language\":\"fr\",\"download_count\":35322,\"new_download_count\":264,\"hearing_impaired\":false,\"hd\":true,\"fps\":0.0,\"votes\":0,\"ratings\":0.0,\"from_trusted\":true,\"foreign_parts_only\":false,\"upload_date\":\"2013-10-18T14:26:47Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"man.of.steel.2013.720p.bluray.x264-felony.www.subsynchro.com\",\"comments\":\"\",\"legacy_subtitle_id\":5229112,\"legacy_uploader_id\":1430515,\"uploader\":{\"uploader_id\":59162,\"name\":\"smailpouri\",\"rank\":\"Trusted
-        member\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/fr/subtitles/legacy/5229112\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/fr/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":962144,\"cd_number\":1,\"file_name\":\"man.of.steel.2013.720p.bluray.x264-felony.www.subsynchro.com\"}],\"moviehash_match\":false}},{\"id\":\"870964\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"870964\",\"language\":\"fr\",\"download_count\":22032,\"new_download_count\":89,\"hearing_impaired\":false,\"hd\":true,\"fps\":0.0,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2013-07-26T08:47:00Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Man.of.Steel.2013.720p.R6.LiNE.x264.AAC-DiGiTAL\",\"comments\":\"\",\"legacy_subtitle_id\":5105960,\"legacy_uploader_id\":0,\"uploader\":{\"uploader_id\":3282,\"name\":\"os-auto\",\"rank\":\"Application
-        Developers\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/fr/subtitles/legacy/5105960\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/fr/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":952177,\"cd_number\":1,\"file_name\":\"Man.of.Steel.2013.R6.LiNE.All.Version-fr\"}],\"moviehash_match\":false}},{\"id\":\"877697\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"877697\",\"language\":\"fr\",\"download_count\":17037,\"new_download_count\":130,\"hearing_impaired\":false,\"hd\":true,\"fps\":0.0,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2013-10-16T09:35:02Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"man.of.steel.2013.1080p.bluray.x264-sector7\",\"comments\":\"\",\"legacy_subtitle_id\":5225852,\"legacy_uploader_id\":0,\"uploader\":{\"uploader_id\":3282,\"name\":\"os-auto\",\"rank\":\"Application
-        Developers\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/fr/subtitles/legacy/5225852\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/fr/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":959227,\"cd_number\":1,\"file_name\":\"man.of.steel.2013.1080p.bluray.x264-sector7\"}],\"moviehash_match\":false}},{\"id\":\"880332\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"880332\",\"language\":\"de\",\"download_count\":7182,\"new_download_count\":216,\"hearing_impaired\":true,\"hd\":true,\"fps\":23.976,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2013-10-17T13:26:46Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Man.of.Steel.German.DL.1080p.BluRay.x264-EXQUiSiTE\",\"comments\":\"\",\"legacy_subtitle_id\":5227599,\"legacy_uploader_id\":0,\"uploader\":{\"uploader_id\":3282,\"name\":\"os-auto\",\"rank\":\"Application
-        Developers\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/de/subtitles/legacy/5227599\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/de/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":961964,\"cd_number\":1,\"file_name\":\"Man.of.Steel.German.DL.1080p.BluRay.x264-EXQUiSiTE\"}],\"moviehash_match\":false}},{\"id\":\"883552\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"883552\",\"language\":\"de\",\"download_count\":4283,\"new_download_count\":10,\"hearing_impaired\":false,\"hd\":true,\"fps\":25.0,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2016-07-31T14:29:17Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Man
-        of Steel (2013) Dtv 2h07min\",\"comments\":\"\",\"legacy_subtitle_id\":6698593,\"legacy_uploader_id\":2563175,\"uploader\":{\"uploader_id\":69315,\"name\":\"bergert_\",\"rank\":\"Trusted
-        member\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/de/subtitles/legacy/6698593\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/de/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":965287,\"cd_number\":1,\"file_name\":\"Man
-        of Steel (DT-2013)\"}],\"moviehash_match\":false}},{\"id\":\"5166256\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"5166256\",\"language\":\"de\",\"download_count\":1794,\"new_download_count\":14,\"hearing_impaired\":false,\"hd\":true,\"fps\":23.976,\"votes\":1,\"ratings\":10.0,\"from_trusted\":true,\"foreign_parts_only\":false,\"upload_date\":\"2020-03-29T11:40:37Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Man.of.Steel.2013.720p.german.srt\",\"comments\":\"--\\u003e
-        HI-Items entfernt, Timing teilweise korrigiert, Kursivsetzung korrigiert\\r\\n--\\u003e
-        passend f\xFCr Versionen mit Laufzeit 2h 23min 2s 688ms\",\"legacy_subtitle_id\":8148911,\"legacy_uploader_id\":1189705,\"uploader\":{\"uploader_id\":54111,\"name\":\"arcchancellor\",\"rank\":\"translator\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/de/subtitles/legacy/8148911\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/de/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":5276290,\"cd_number\":1,\"file_name\":\"Man.of.Steel.2013.720p.german\"}],\"moviehash_match\":false}},{\"id\":\"883560\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"883560\",\"language\":\"de\",\"download_count\":938,\"new_download_count\":9,\"hearing_impaired\":true,\"hd\":true,\"fps\":23.976,\"votes\":2,\"ratings\":10.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2016-08-01T19:13:17Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Man
-        of Steel German DL 1080p BluRay x264-EXQUiSiTE\",\"comments\":\"Duration:
-        2:23:03\\r\\nvia SubTools from idx to srt\\r\\nFull German\\r\\nHandmade corrected\",\"legacy_subtitle_id\":6699712,\"legacy_uploader_id\":1471910,\"uploader\":{\"uploader_id\":60439,\"name\":\"PissPott\",\"rank\":\"Silver
-        Member\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/de/subtitles/legacy/6699712\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/de/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":965292,\"cd_number\":1,\"file_name\":\"exq-manofsteel-1080p.idx.mkv\"}],\"moviehash_match\":false}},{\"id\":\"6632511\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"6632511\",\"language\":\"de\",\"download_count\":61,\"new_download_count\":7,\"hearing_impaired\":false,\"hd\":true,\"fps\":23.976,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2022-06-26T19:32:54Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Should
-        work with 4k BD rips\",\"comments\":\"Source German Retail 4k BD\\r\\nRetail
-        PGS to SSA + improvements\\r\\n\\r\\ncoloured parts\\r\\n\\r\\nIf the timing
-        is off, just correct it with SubtitleEdit.\\r\\n-\\u003e Synchronization \\r\\n-\\u003e
-        Adjust all times \\r\\n-\\u003e all lines\\r\\n\\r\\nWorks best with MPC-BE
-        + XySubFilter + madvr\\r\\nbecause there the font is not in the image,\\r\\nbut
-        at the bottom in the black bars.\",\"legacy_subtitle_id\":9150443,\"legacy_uploader_id\":9372469,\"uploader\":{\"uploader_id\":null,\"name\":\"Anonymous\",\"rank\":\"anonymous\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/de/subtitles/legacy/9150443\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/de/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":7601680,\"cd_number\":1,\"file_name\":\"Man
-        of Steel.Full - German\"}],\"moviehash_match\":false}}]}"
+      string: !!binary |
+        4ZhsASDXNP+tWmarHEjmECDo/nnauZ3RYAvZxAgUQPY75tVdukzt1366lKSRUumWGNIN6YZ0oa1g
+        nlSj6R7vdhHVKpZEQ9FGKBayaHIJkRBhVBpD0hD/914ung1zkon/KnFyA1pP9ghH1N/NsNiTK2Ao
+        vursHWhIMJRgWFwexRcYSTB0HSmKYbTVgvnrEfwIBnqlKWOAod4vDgyU9VB9DQ4wVII9mMeBsQxe
+        cYLCgYEpA4ac4cRMBSNUMQzR3YbBw8MxnJ3NPp4GPy/WZzeCmWwoDsN5BFPz6jBMSwHDeKuVxHBN
+        adpKgiHb6uOpgCEtwTDlNA81r6WGM4gpZedPcVhsrmVIMdxfLNYlOVs/2urAACOUN5Q0VO6oNEIa
+        Iv8EDNYPB1yYItiQveNhOI7Fjhc/4RxxjLILzhYHBmYb2zS1pToXWkYobxUjS3sIa7b37R2TXTO5
+        kOI9YKjwiYMBwBDcyR7vh9IPKBiTTNARYF4sXHbGJG81ugzmET5HmLOeYYh2dmAglcauNQGGbOMF
+        DDxbluCPtvoU0f6p+ne5wBOGhU6Mhw3jAXbAvUGaqvVESTIqYqVOP6Wrd4Dh3tnMCDYcA2/118An
+        G1Ga0LY6FwDDnK7eDYmrHSOUowaN5uzn8RBjeKVIz3oMtecQOy0YfcKw5gAGzrUuxWw2t9utTYuL
+        pRetnCYC+ylvnOGmCI02RWoAldaJrW4cgo+X0kbIY3MMCAaehYBC84WmlNGcRJnCIgEgsxZlw2/+
+        ZxubNDWhlOLn0xBSmkXnAtZHqLIhG7lRm/Injwcy1NPfGCYfXOqtJs8x49GSyJ5jOI7DXtIC1gWj
+        oEJnw6G9aW+3W1vWQ7mPx3NO7THNMYMq7OJsy3mYbT2eG67d0xPGGG3uiaIKeyWdiqPLh1Tk9rZQ
+        rUnM0DtCjOCGCZL+JLWNbPUysBoVnof1e0t59fu3X/zW717hzJdba92TyqN751rrnl7g6IhnxgVj
+        yaYMkEXTBaXQK+m4JRd+uJRCqJMSAD8Y4AoCJLYfMaPf0c4waTpFUfe/wARkNEApq1/acSKogJpi
+        QlMpz4yjzNaHJa3Zvw13JRsN7Ynz2UeU+aJoShl9IEa7jkDzIVFHmxXRssNeqVx5GCNcV3p+mn5Q
+        IAwFGQmQqIbJHelNpwwhRKCOz++y/eg/vxJFZ4X22bMXzUv/xu+efZRkfhigRGhJtCVYpGcTx7dg
+        VCkOPsUsukA8C6H91eXiU2ymDClaraRWyCuV44MqwtUbQbm4Q7vLH5Vow4UhjHKjpP9PaCzFHWvK
+        Siv6HhC9YHgCi/SM4ipRM6YsLyLyKL2EUtk94dySi71SWVp4UIzrtBm/QvPKKTS0OKsd5VrRNZQy
+        CrpYvfxYcSJosiyg5cuthNYkirHli6KE1qSlVMuOhlUZIIymcyGQVyrHQ8d6nlmUmnGvr5BXfMqG
+        qIZTi8sr0YaSkKC/nqMfGKH8R/SyXhE7EzX7CCaCkFL3QvN6ZkJyqowqSlJzKpo5uHxyuQ5TiM4s
+        P84rKtIziiuQYL2+Q/Kl9ctd86YXRxqvoFIyIdUbwi8VZPBCle6Sppvqo5xmNSUmWomHkYbwhukd
+        paYjhoMGYVInJtsZnjA/l5Kr/HFMNs1+JYQ79PZd8666uSAX6+RyrBjt/OzjCVXnw8354tAl5exP
+        3uWK0Yc1F38trj6s8TTUfZ/3MeDuF1uKiyOa/v8vI0V473ERzb6ij3adHpyviJ0R47OPiBUk+34u
+        pmHB9LTrNaX8014rothRSsdn8/F4tvHoQkgZzrDqeNdJUIbK9EziGqNgSjJN7DZkc0kUkH+A5Ysh
+        oul4pbrmQ/PeVMM9AZtatUoIQzMEPCzlHzGzbwjdUW0oJyi0yqKXH5E0ijfSraxfrlnVWXKDmGHc
+        EL7P+3j1Fm3Xwy6lcMg6ofx4h2pCBb/sXq8hwgj7vI9vbRyPI0h4/93KeaxuFLTSqdWUq3Irqqne
+        Zi1Jp0hD7mzmqy/la6pV0PqPtPXh6jL6dHv2Wk22OqUu/nrKeEh3928z25im5Bg29oSG9+NdO1+u
+        8FTpUnI2JZzwSwVQ6ZDUjJw0vah1suw+kgdjDZENkzuqDWdGdLQTtue0hhHdUr6gm69n1F3Q85co
+        +6UYePxt05qPDsIMvrdY6MF1n/exX6++vtmimtB2+wz9jPy85HR1gVjv8x6KQh5TSGt2I8o4HpL8
+        3XQ6MwyrrNajLyhNE0b/rKVClg3yNYlGW6b1fjX62spp6Ga4ndxpE/2DWUhouMWzMTx3GwI69ijh
+        bwQbAgo+unTW4reULwXtTSuIdsd9+vqief4K/Yx+v9+uh9c+VJfRz2i24zXv8z6uyVpn/z3mXc8O
+        TSlW5AuKqaJDnPLhZ3ty2Euua0Xrt8J734VHI8/7Rr2gg82lnaugXjQVpOuUYMFqrlgntXtcQ7Cp
+        Nfcspng/p7U4E9v7bIPNqDTPJPpvAylJqOwFR52vQSswGDUNXHQl2PzvJw==
     headers:
       Access-Control-Allow-Headers:
       - Origin, Authorization, Accept, Api-Key, Content-Type, X-User-Agent
@@ -67,22 +59,24 @@ interactions:
       - GET, HEAD, POST, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
+      Age:
+      - '48856'
       CF-Cache-Status:
-      - MISS
+      - HIT
       CF-RAY:
-      - 87c7045219b44058-LHR
+      - 883aac520875f0bb-CDG
       Cache-Control:
       - public, max-age=86400
       Connection:
       - keep-alive
       Content-Encoding:
-      - gzip
+      - br
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 30 Apr 2024 10:58:28 GMT
+      - Tue, 14 May 2024 11:50:52 GMT
       Last-Modified:
-      - Tue, 30 Apr 2024 10:58:28 GMT
+      - Mon, 13 May 2024 22:16:36 GMT
       NEL:
       - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
       RateLimit-Limit:
@@ -92,7 +86,7 @@ interactions:
       RateLimit-Reset:
       - '1'
       Report-To:
-      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=FAK57h8uWsC5mRqxsnHJdzxQj371h4gJ8HQOXdX6wf8SUkcE7qG%2BiXUUOfXOliD5zKeOCOsxu5y%2BnH%2F1btrMLO0WAouwUC0AsBcbxOYJt%2FssVieKNhY1GmFxrcPoK%2FbDllkxJmZOZ0o%3D"}],"group":"cf-nel","max_age":604800}'
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=tTqjcI8yBc7ICygnsukgGWDrDrS8nZ4uTcJUjpo4MIFXG%2B%2FyPChyFa0UL1kK99IK1u164KIhhbpxZ%2ByBfafEkKB%2Bsg0uGkc1R3H5Qm8U5sZgV5jVkSmi4DjVL2%2BkOAXvfJdgQwWpJns%3D"}],"group":"cf-nel","max_age":604800}'
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -102,7 +96,7 @@ interactions:
       Vary:
       - Accept-Encoding
       X-Cache-Backend:
-      - apigw1_8000 rb11
+      - apigw1_8000 rb7
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -112,15 +106,17 @@ interactions:
       X-Kong-Proxy-Latency:
       - '1'
       X-Kong-Upstream-Latency:
-      - '114'
+      - '259'
       X-RateLimit-Limit-Second:
       - '5'
       X-RateLimit-Remaining-Second:
       - '3'
       X-Request-Id:
-      - 3e3b1a3f-12c0-48d3-8c29-c7eb0731399c
+      - 5bbec10f-8cfe-4ef8-845c-3460f69d8d3c
       X-Runtime:
-      - '0.111334'
+      - '0.088874'
+      X-StackifyID:
+      - V1|9166a000-6453-4931-acd6-ecf150259d01|C98087|CD1
       X-Var-Cache:
       - MISS
       X-Via:
@@ -144,7 +140,7 @@ interactions:
       Accept:
       - '*/*'
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Api-Key:
       - mij33pjc3kOlup1qOKxnWWxvle2kFbMH
       Connection:
@@ -157,48 +153,40 @@ interactions:
     uri: https://api.opensubtitles.com/api/v1/subtitles?imdb_id=770828&languages=de%2Cfr
   response:
     body:
-      string: "{\"total_pages\":1,\"total_count\":10,\"per_page\":60,\"page\":1,\"data\":[{\"id\":\"880511\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"880511\",\"language\":\"fr\",\"download_count\":35322,\"new_download_count\":264,\"hearing_impaired\":false,\"hd\":true,\"fps\":0.0,\"votes\":0,\"ratings\":0.0,\"from_trusted\":true,\"foreign_parts_only\":false,\"upload_date\":\"2013-10-18T14:26:47Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"man.of.steel.2013.720p.bluray.x264-felony.www.subsynchro.com\",\"comments\":\"\",\"legacy_subtitle_id\":5229112,\"legacy_uploader_id\":1430515,\"uploader\":{\"uploader_id\":59162,\"name\":\"smailpouri\",\"rank\":\"Trusted
-        member\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/fr/subtitles/legacy/5229112\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/fr/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":962144,\"cd_number\":1,\"file_name\":\"man.of.steel.2013.720p.bluray.x264-felony.www.subsynchro.com\"}]}},{\"id\":\"870964\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"870964\",\"language\":\"fr\",\"download_count\":22032,\"new_download_count\":89,\"hearing_impaired\":false,\"hd\":true,\"fps\":0.0,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2013-07-26T08:47:00Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Man.of.Steel.2013.720p.R6.LiNE.x264.AAC-DiGiTAL\",\"comments\":\"\",\"legacy_subtitle_id\":5105960,\"legacy_uploader_id\":0,\"uploader\":{\"uploader_id\":3282,\"name\":\"os-auto\",\"rank\":\"Application
-        Developers\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/fr/subtitles/legacy/5105960\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/fr/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":952177,\"cd_number\":1,\"file_name\":\"Man.of.Steel.2013.R6.LiNE.All.Version-fr\"}]}},{\"id\":\"879122\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"879122\",\"language\":\"fr\",\"download_count\":20172,\"new_download_count\":203,\"hearing_impaired\":false,\"hd\":true,\"fps\":23.976,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2013-10-16T16:56:06Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"man.of.steel.2013.720p.bluray.x264-felony\",\"comments\":\"\",\"legacy_subtitle_id\":5226251,\"legacy_uploader_id\":0,\"uploader\":{\"uploader_id\":3282,\"name\":\"os-auto\",\"rank\":\"Application
-        Developers\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/fr/subtitles/legacy/5226251\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/fr/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":960683,\"cd_number\":1,\"file_name\":\"man.of.steel.2013.720p.bluray.x264-felony.www.subsynchro.com\"}]}},{\"id\":\"877697\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"877697\",\"language\":\"fr\",\"download_count\":17037,\"new_download_count\":130,\"hearing_impaired\":false,\"hd\":true,\"fps\":0.0,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2013-10-16T09:35:02Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"man.of.steel.2013.1080p.bluray.x264-sector7\",\"comments\":\"\",\"legacy_subtitle_id\":5225852,\"legacy_uploader_id\":0,\"uploader\":{\"uploader_id\":3282,\"name\":\"os-auto\",\"rank\":\"Application
-        Developers\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/fr/subtitles/legacy/5225852\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/fr/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":959227,\"cd_number\":1,\"file_name\":\"man.of.steel.2013.1080p.bluray.x264-sector7\"}]}},{\"id\":\"880332\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"880332\",\"language\":\"de\",\"download_count\":7182,\"new_download_count\":216,\"hearing_impaired\":true,\"hd\":true,\"fps\":23.976,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2013-10-17T13:26:46Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Man.of.Steel.German.DL.1080p.BluRay.x264-EXQUiSiTE\",\"comments\":\"\",\"legacy_subtitle_id\":5227599,\"legacy_uploader_id\":0,\"uploader\":{\"uploader_id\":3282,\"name\":\"os-auto\",\"rank\":\"Application
-        Developers\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/de/subtitles/legacy/5227599\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/de/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":961964,\"cd_number\":1,\"file_name\":\"Man.of.Steel.German.DL.1080p.BluRay.x264-EXQUiSiTE\"}]}},{\"id\":\"883552\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"883552\",\"language\":\"de\",\"download_count\":4283,\"new_download_count\":10,\"hearing_impaired\":false,\"hd\":true,\"fps\":25.0,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2016-07-31T14:29:17Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Man
-        of Steel (2013) Dtv 2h07min\",\"comments\":\"\",\"legacy_subtitle_id\":6698593,\"legacy_uploader_id\":2563175,\"uploader\":{\"uploader_id\":69315,\"name\":\"bergert_\",\"rank\":\"Trusted
-        member\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/de/subtitles/legacy/6698593\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/de/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":965287,\"cd_number\":1,\"file_name\":\"Man
-        of Steel (DT-2013)\"}]}},{\"id\":\"880717\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"880717\",\"language\":\"de\",\"download_count\":2670,\"new_download_count\":194,\"hearing_impaired\":false,\"hd\":true,\"fps\":23.976,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2013-10-19T00:53:25Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Man.of.Steel.German.720p.BluRay.x264-EXQUiSiTE\",\"comments\":\"\",\"legacy_subtitle_id\":5229998,\"legacy_uploader_id\":0,\"uploader\":{\"uploader_id\":3282,\"name\":\"os-auto\",\"rank\":\"Application
-        Developers\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/de/subtitles/legacy/5229998\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/de/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":962352,\"cd_number\":1,\"file_name\":\"Man.of.Steel.German.720p.BluRay.x264-EXQUiSiTE\"}]}},{\"id\":\"5166256\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"5166256\",\"language\":\"de\",\"download_count\":1794,\"new_download_count\":14,\"hearing_impaired\":false,\"hd\":true,\"fps\":23.976,\"votes\":1,\"ratings\":10.0,\"from_trusted\":true,\"foreign_parts_only\":false,\"upload_date\":\"2020-03-29T11:40:37Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Man.of.Steel.2013.720p.german.srt\",\"comments\":\"--\\u003e
-        HI-Items entfernt, Timing teilweise korrigiert, Kursivsetzung korrigiert\\r\\n--\\u003e
-        passend f\xFCr Versionen mit Laufzeit 2h 23min 2s 688ms\",\"legacy_subtitle_id\":8148911,\"legacy_uploader_id\":1189705,\"uploader\":{\"uploader_id\":54111,\"name\":\"arcchancellor\",\"rank\":\"translator\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/de/subtitles/legacy/8148911\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/de/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":5276290,\"cd_number\":1,\"file_name\":\"Man.of.Steel.2013.720p.german\"}]}},{\"id\":\"883560\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"883560\",\"language\":\"de\",\"download_count\":938,\"new_download_count\":9,\"hearing_impaired\":true,\"hd\":true,\"fps\":23.976,\"votes\":2,\"ratings\":10.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2016-08-01T19:13:17Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Man
-        of Steel German DL 1080p BluRay x264-EXQUiSiTE\",\"comments\":\"Duration:
-        2:23:03\\r\\nvia SubTools from idx to srt\\r\\nFull German\\r\\nHandmade corrected\",\"legacy_subtitle_id\":6699712,\"legacy_uploader_id\":1471910,\"uploader\":{\"uploader_id\":60439,\"name\":\"PissPott\",\"rank\":\"Silver
-        Member\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/de/subtitles/legacy/6699712\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/de/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":965292,\"cd_number\":1,\"file_name\":\"exq-manofsteel-1080p.idx.mkv\"}]}},{\"id\":\"6632511\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"6632511\",\"language\":\"de\",\"download_count\":61,\"new_download_count\":7,\"hearing_impaired\":false,\"hd\":true,\"fps\":23.976,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2022-06-26T19:32:54Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Should
-        work with 4k BD rips\",\"comments\":\"Source German Retail 4k BD\\r\\nRetail
-        PGS to SSA + improvements\\r\\n\\r\\ncoloured parts\\r\\n\\r\\nIf the timing
-        is off, just correct it with SubtitleEdit.\\r\\n-\\u003e Synchronization \\r\\n-\\u003e
-        Adjust all times \\r\\n-\\u003e all lines\\r\\n\\r\\nWorks best with MPC-BE
-        + XySubFilter + madvr\\r\\nbecause there the font is not in the image,\\r\\nbut
-        at the bottom in the black bars.\",\"legacy_subtitle_id\":9150443,\"legacy_uploader_id\":9372469,\"uploader\":{\"uploader_id\":null,\"name\":\"Anonymous\",\"rank\":\"anonymous\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/de/subtitles/legacy/9150443\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/de/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":7601680,\"cd_number\":1,\"file_name\":\"Man
-        of Steel.Full - German\"}]}}]}"
+      string: !!binary |
+        4ShlASB/U/3vq5Y51QYkEwQIuhejvdlvNNhCNnsRaAHZN4zr7nd/+v1aoUCpECnVE5UhLZt2SBva
+        E8yTuH4xRCWKJtGKV0Khk02S2oV4Ia7E82Y6/aL1QtyzMdSwP7c4KX+QpSn0BDPqn2JY7MkVMBTf
+        mI0ONDUYSjAsLkeJA0YSDD89URTDaKsF888T+BEM9D0RlAKG+rA4MFDWQ/U1OMDQCZ5gnv6YzcCK
+        C5QBDEwZMNQMF2YjuZRCYIjuOvx5RZgSGM7OZh9Pg58X67MbwUw2FIfhPIKpeXUYpqWAIS3BcEkF
+        ykgwZFt9PL2vZcppHmpeS3WcM6fs/CkOi821DCmGh+Sd1qUolz/a6sAAI5Q3lDS039HOMGk69Tdg
+        sH6YbGHlYGvJQuNhOI5Njjc9oY24erILzhYHBmYb2zS1pToXWkYobxUjS3sIa7YP7T2TXTO5kOJD
+        e71e27IeykM8nnNqj2kGDP2/fjAAGII72ePD0BmJBWOaUhYBVs/J5ZCQdpwIKirdrctgniDWBEJT
+        yTBEO/f/ombrw5LW7AFDtvEODOxaVoDGtBoANwxbodgOR8oD8oF/DZLt1BMlSVQkWwv6lC7eAYYH
+        ZzMYRijHIFNLBgOfbERpQtvqXAAMc7p4N5SrZ4xQjhoUzdfP46ESGZUiPesx1F8us9OC0RuGNQcw
+        cK51KWazuV6vbVpcFGRBOW8EnlPeBOtNI9psGtUKenICW904BB/vypWGOFnHxGDgWQiIOQ6aUkZz
+        LdQLFwUAlXUqGyFMONvYpKlJpRk/n4ZqlFj0B2zoNGVDNnKjNu1PnCBkmtsPDJMPrvQuk5eZtWjJ
+        aNdhOI7DsGmB+gBRUKPzJ7YRtx+3G9YupqyIlh1mZRUkYIxw9vppeosS4fBFxSCqYXJHetMpQwip
+        fdJtG/u7bD/6z6/udoT22bMXzUv/xu+efVQoUqBEaElyS1RJJc76265Saexa0+Oany1L8EdbfYpo
+        7LsfOi4XdQKbVDkJEgtGlaKRUyyiB/QshPZ3l4tPsZmy6hC3powhVnbBKISqemKEg5JfLuOtVlJ9
+        /IdR0lC5o9IIaYgEJpygkJ8DkgmqOGCTKikY5FsgsuckbiW1QqysggRUEa7eE5SLO6hJfqtEGy4M
+        YVQdJX1nDZTijjVl9fazQPSC0QeK6IUtY4pCM6YYyigZg4i7J5xjVqLqMGx0rVGMa59Iztx0gY4Q
+        OUQgvmpHuVtERgIZGFLtDtO9ffmxgzSeh/X7cHn157ff/NbvXkGRH24ltCbDR/eVK6E1vYGjo/ah
+        Wnb2CweiSqFJjJ0LgVhZBRE61vP8ov6P15cJ/BFbNkQ1nLpW3xJtKJEQ+VmOfmKE8p/Ry3pB7EzU
+        7KPtIg0pdS8072MmJKfKe6olNadiiIPLJ5fr4PhQWl5plQZqUiUlmESwXpl1SCj66eWuEU1KeGHs
+        iirIykoxiMKkIuWl9Z0c4ItHrt4RYgQ3TBCwIPnDFj8LtNY9/aBorXsSK+OCMRVTkgoZuIJKyYQE
+        FgReVkpEFKp0VzDdrXZa0ZQsslUNGWkIb5jeUWo6YrgKBP+T9amrqim5qo2nZNPsV0K4Q2/fNe+q
+        mwtysU4ux4rRzs8+nlB1PlydLw7dpZz9ybtcMfqw5uIvxdXHNZ7+GrjP+5jw1IstxcURTf//X0YO
+        89vHRTT7ij7adXp0viJ2RozPPiJWkOz7uQCePulp12vqqO1zSnutyKJizY5Sujabj8ezjUcXQsqL
+        ejBqe9ZJiAe1qVJiIg1EwZRkmizfIV5dqM0hsCSMQ81lxsrquRaa99YQPeyBq5Ww0FoGYTyYQ4/M
+        viF0R7WhnOD/FF/08iOyVdVQrhH0cX25ZiRy6AYxw7ghfJ/38eIt2q6HXUph0jdp/HiPakJFT3m8
+        XkOGmfZ5H9/aOM7EhzwCtlYeqxvtrlJqtcZKqxXVFFa5StL5zyB8GeKrL+VrqnVh8z+krQ8Xl9En
+        s+u112p1FTkNudd4KrW7/6+ZbUxTcawb/0z3frxv57sLemp3KTlb043Ay0oRlUJSj0zB9NBJtkwv
+        1YOxhsiGyR3VhjMjOroO23Naw4iuKd+hq69n1N2h5y9R9kuxsxJs05qPTlVZfbdyIIP/Pu/j747D
+        1zdbVBPabp+hX5Gfl5wuQyz1Lfu8VzmpjymkNbsR+aHwXwq/m078hXXFXtP6gtI0YfTvWqpqckO+
+        FtFmK5yhr0ZfW9yFsJz1dnGiW/SP1hnp707PxvQCbQholk7kl0w2BBR8dCXqwR8p3xU07lSQ7bX7
+        9PVF8/wV+hX9+bBdD699qC6jX9Fsx0ve533c57PZSDf2XM8OTSlW5AuKqaLJQMXysz05zFLtWtGe
+        oPA4tXA04hnS6BN0sLm0vi+paCpI10lXc8U6qQPjGoJpO9SzmOLDnNaywo+d/bVyo4NRayolQHCg
+        KEmo7Infy6oFBjbNQ0y4/bjdftwA
     headers:
       Access-Control-Allow-Headers:
       - Origin, Authorization, Accept, Api-Key, Content-Type, X-User-Agent
@@ -206,22 +194,24 @@ interactions:
       - GET, HEAD, POST, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
+      Age:
+      - '48855'
       CF-Cache-Status:
-      - MISS
+      - HIT
       CF-RAY:
-      - 87c70454580f531a-LHR
+      - 883aac5248cbf0bb-CDG
       Cache-Control:
       - public, max-age=86400
       Connection:
       - keep-alive
       Content-Encoding:
-      - gzip
+      - br
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 30 Apr 2024 10:58:29 GMT
+      - Tue, 14 May 2024 11:50:52 GMT
       Last-Modified:
-      - Tue, 30 Apr 2024 10:58:29 GMT
+      - Mon, 13 May 2024 22:16:37 GMT
       NEL:
       - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
       RateLimit-Limit:
@@ -231,111 +221,7 @@ interactions:
       RateLimit-Reset:
       - '1'
       Report-To:
-      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=BxsMYSlcPOe%2FtYLPtLB1dhnAxV6fZD%2FStpkfSFIsIAP2Ypd1P%2B13hEx%2BQNZiGV1FaM09JLrfF270OnE%2BCwQbbzj1YK%2BTxHeIrMhAxIjhc6E3cHQdXigPCSdl%2F%2F7WYXrlTwvRVWPucEc%3D"}],"group":"cf-nel","max_age":604800}'
-      Server:
-      - cloudflare
-      Strict-Transport-Security:
-      - max-age=15552000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      Vary:
-      - Accept-Encoding
-      X-Cache-Backend:
-      - apigw1_8000 rb1-temp
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Kong-Proxy-Latency:
-      - '1'
-      X-Kong-Upstream-Latency:
-      - '63'
-      X-RateLimit-Limit-Second:
-      - '5'
-      X-RateLimit-Remaining-Second:
-      - '4'
-      X-Request-Id:
-      - 1e7d599a-2975-4830-ad98-2786dab7c67c
-      X-Runtime:
-      - '0.061490'
-      X-Var-Cache:
-      - MISS
-      X-Via:
-      - fw1
-      X-Vip:
-      - 'false'
-      X-Vip-Consumer:
-      - 'false'
-      X-Vip-User:
-      - 'false'
-      X-XSS-Protection:
-      - 1; mode=block
-      alt-svc:
-      - h3=":443"; ma=86400
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Api-Key:
-      - mij33pjc3kOlup1qOKxnWWxvle2kFbMH
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Subliminal v2.1
-    method: GET
-    uri: https://api.opensubtitles.com/api/v1/subtitles?languages=de%2Cfr&moviehash=5b8f8f4e41ccb21e
-  response:
-    body:
-      string: '{"total_pages":1,"total_count":2,"per_page":60,"page":1,"data":[{"id":"879122","type":"subtitle","attributes":{"subtitle_id":"879122","language":"fr","download_count":20172,"new_download_count":203,"hearing_impaired":false,"hd":true,"fps":23.976,"votes":0,"ratings":0.0,"from_trusted":false,"foreign_parts_only":false,"upload_date":"2013-10-16T16:56:06Z","ai_translated":false,"nb_cd":1,"machine_translated":false,"release":"man.of.steel.2013.720p.bluray.x264-felony","comments":"","legacy_subtitle_id":5226251,"legacy_uploader_id":0,"uploader":{"uploader_id":3282,"name":"os-auto","rank":"Application
-        Developers"},"feature_details":{"feature_id":580760,"feature_type":"Movie","year":2013,"title":"Man
-        of Steel","movie_name":"2013 - Man of Steel","imdb_id":770828,"tmdb_id":49521},"url":"https://www.opensubtitles.com/fr/subtitles/legacy/5226251","related_links":[{"label":"All
-        subtitles for man of steel","url":"https://www.opensubtitles.com/fr/movies/2013-man-of-steel","img_url":"https://s9.opensubtitles.com/features/0/6/7/580760.jpg"}],"files":[{"file_id":960683,"cd_number":1,"file_name":"man.of.steel.2013.720p.bluray.x264-felony.www.subsynchro.com"}],"moviehash_match":true}},{"id":"880717","type":"subtitle","attributes":{"subtitle_id":"880717","language":"de","download_count":2670,"new_download_count":194,"hearing_impaired":false,"hd":true,"fps":23.976,"votes":0,"ratings":0.0,"from_trusted":false,"foreign_parts_only":false,"upload_date":"2013-10-19T00:53:25Z","ai_translated":false,"nb_cd":1,"machine_translated":false,"release":"Man.of.Steel.German.720p.BluRay.x264-EXQUiSiTE","comments":"","legacy_subtitle_id":5229998,"legacy_uploader_id":0,"uploader":{"uploader_id":3282,"name":"os-auto","rank":"Application
-        Developers"},"feature_details":{"feature_id":580760,"feature_type":"Movie","year":2013,"title":"Man
-        of Steel","movie_name":"2013 - Man of Steel","imdb_id":770828,"tmdb_id":49521},"url":"https://www.opensubtitles.com/de/subtitles/legacy/5229998","related_links":[{"label":"All
-        subtitles for man of steel","url":"https://www.opensubtitles.com/de/movies/2013-man-of-steel","img_url":"https://s9.opensubtitles.com/features/0/6/7/580760.jpg"}],"files":[{"file_id":962352,"cd_number":1,"file_name":"Man.of.Steel.German.720p.BluRay.x264-EXQUiSiTE"}],"moviehash_match":true}}]}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Origin, Authorization, Accept, Api-Key, Content-Type, X-User-Agent
-      Access-Control-Allow-Methods:
-      - GET, HEAD, POST, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      CF-Cache-Status:
-      - MISS
-      CF-RAY:
-      - 87c70456deaf06d9-LHR
-      Cache-Control:
-      - public, max-age=86400
-      Connection:
-      - keep-alive
-      Content-Encoding:
-      - gzip
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Tue, 30 Apr 2024 10:58:29 GMT
-      Last-Modified:
-      - Tue, 30 Apr 2024 10:58:29 GMT
-      NEL:
-      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
-      RateLimit-Limit:
-      - '5'
-      RateLimit-Remaining:
-      - '3'
-      RateLimit-Reset:
-      - '1'
-      Report-To:
-      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=zE1wclr0%2FvoThgHOldpUH0hLNNkKAfonjVtQj7mpw%2FOaLddQL7c5vbe23BsXu7%2BFKTclHdcbt2J3YaF3mc4t%2BEsQ%2Fmz7ioMDkhz49%2B4MjblE9XHoiGrryEyn6qq%2BADouuchSbhMuJlU%3D"}],"group":"cf-nel","max_age":604800}'
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=V5UggnBx9wO5LQwCM6SmvEmEXIihMCoAcs7uLHnXQTi7V3Hc%2FhVziBE%2FyNE%2F00FqZo19D6UuhePSlBb1Es7FEeHZVotpkg4yQXegn4q9sfbhFIGUDQQ80MGzaDsG1uQ8oc2d8dn7mNE%3D"}],"group":"cf-nel","max_age":604800}'
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -355,15 +241,15 @@ interactions:
       X-Kong-Proxy-Latency:
       - '0'
       X-Kong-Upstream-Latency:
-      - '39'
+      - '37'
       X-RateLimit-Limit-Second:
       - '5'
       X-RateLimit-Remaining-Second:
-      - '3'
+      - '4'
       X-Request-Id:
-      - 9cb3b4d1-2a62-42db-9f56-dcf192f691dc
+      - 9f6ac863-7815-4030-80f6-2d880c903987
       X-Runtime:
-      - '0.037389'
+      - '0.035332'
       X-Var-Cache:
       - MISS
       X-Via:
@@ -387,7 +273,7 @@ interactions:
       Accept:
       - '*/*'
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Api-Key:
       - mij33pjc3kOlup1qOKxnWWxvle2kFbMH
       Connection:
@@ -397,87 +283,23 @@ interactions:
       User-Agent:
       - Subliminal v2.1
     method: GET
-    uri: https://api.opensubtitles.com/api/v1/subtitles?languages=de%2Cfr&query=man+of+steel
+    uri: https://api.opensubtitles.com/api/v1/subtitles?languages=de%2Cfr&moviehash=5b8f8f4e41ccb21e
   response:
     body:
-      string: "{\"total_pages\":1,\"total_count\":18,\"per_page\":60,\"page\":1,\"data\":[{\"id\":\"880511\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"880511\",\"language\":\"fr\",\"download_count\":35322,\"new_download_count\":264,\"hearing_impaired\":false,\"hd\":true,\"fps\":0.0,\"votes\":0,\"ratings\":0.0,\"from_trusted\":true,\"foreign_parts_only\":false,\"upload_date\":\"2013-10-18T14:26:47Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"man.of.steel.2013.720p.bluray.x264-felony.www.subsynchro.com\",\"comments\":\"\",\"legacy_subtitle_id\":5229112,\"legacy_uploader_id\":1430515,\"uploader\":{\"uploader_id\":59162,\"name\":\"smailpouri\",\"rank\":\"Trusted
-        member\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/fr/subtitles/legacy/5229112\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/fr/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":962144,\"cd_number\":1,\"file_name\":\"man.of.steel.2013.720p.bluray.x264-felony.www.subsynchro.com\"}]}},{\"id\":\"870964\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"870964\",\"language\":\"fr\",\"download_count\":22032,\"new_download_count\":89,\"hearing_impaired\":false,\"hd\":true,\"fps\":0.0,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2013-07-26T08:47:00Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Man.of.Steel.2013.720p.R6.LiNE.x264.AAC-DiGiTAL\",\"comments\":\"\",\"legacy_subtitle_id\":5105960,\"legacy_uploader_id\":0,\"uploader\":{\"uploader_id\":3282,\"name\":\"os-auto\",\"rank\":\"Application
-        Developers\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/fr/subtitles/legacy/5105960\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/fr/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":952177,\"cd_number\":1,\"file_name\":\"Man.of.Steel.2013.R6.LiNE.All.Version-fr\"}]}},{\"id\":\"879122\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"879122\",\"language\":\"fr\",\"download_count\":20172,\"new_download_count\":203,\"hearing_impaired\":false,\"hd\":true,\"fps\":23.976,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2013-10-16T16:56:06Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"man.of.steel.2013.720p.bluray.x264-felony\",\"comments\":\"\",\"legacy_subtitle_id\":5226251,\"legacy_uploader_id\":0,\"uploader\":{\"uploader_id\":3282,\"name\":\"os-auto\",\"rank\":\"Application
-        Developers\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/fr/subtitles/legacy/5226251\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/fr/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":960683,\"cd_number\":1,\"file_name\":\"man.of.steel.2013.720p.bluray.x264-felony.www.subsynchro.com\"}]}},{\"id\":\"877697\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"877697\",\"language\":\"fr\",\"download_count\":17037,\"new_download_count\":130,\"hearing_impaired\":false,\"hd\":true,\"fps\":0.0,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2013-10-16T09:35:02Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"man.of.steel.2013.1080p.bluray.x264-sector7\",\"comments\":\"\",\"legacy_subtitle_id\":5225852,\"legacy_uploader_id\":0,\"uploader\":{\"uploader_id\":3282,\"name\":\"os-auto\",\"rank\":\"Application
-        Developers\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/fr/subtitles/legacy/5225852\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/fr/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":959227,\"cd_number\":1,\"file_name\":\"man.of.steel.2013.1080p.bluray.x264-sector7\"}]}},{\"id\":\"880332\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"880332\",\"language\":\"de\",\"download_count\":7182,\"new_download_count\":216,\"hearing_impaired\":true,\"hd\":true,\"fps\":23.976,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2013-10-17T13:26:46Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Man.of.Steel.German.DL.1080p.BluRay.x264-EXQUiSiTE\",\"comments\":\"\",\"legacy_subtitle_id\":5227599,\"legacy_uploader_id\":0,\"uploader\":{\"uploader_id\":3282,\"name\":\"os-auto\",\"rank\":\"Application
-        Developers\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/de/subtitles/legacy/5227599\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/de/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":961964,\"cd_number\":1,\"file_name\":\"Man.of.Steel.German.DL.1080p.BluRay.x264-EXQUiSiTE\"}]}},{\"id\":\"883552\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"883552\",\"language\":\"de\",\"download_count\":4283,\"new_download_count\":10,\"hearing_impaired\":false,\"hd\":true,\"fps\":25.0,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2016-07-31T14:29:17Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Man
-        of Steel (2013) Dtv 2h07min\",\"comments\":\"\",\"legacy_subtitle_id\":6698593,\"legacy_uploader_id\":2563175,\"uploader\":{\"uploader_id\":69315,\"name\":\"bergert_\",\"rank\":\"Trusted
-        member\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/de/subtitles/legacy/6698593\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/de/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":965287,\"cd_number\":1,\"file_name\":\"Man
-        of Steel (DT-2013)\"}]}},{\"id\":\"4614499\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"4614499\",\"language\":\"fr\",\"download_count\":4213,\"new_download_count\":98,\"hearing_impaired\":false,\"hd\":true,\"fps\":23.976,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2018-11-01T17:26:02Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Supergirl.S04E03.720p.HDTV.x264-AVS\",\"comments\":\"\",\"legacy_subtitle_id\":7528072,\"legacy_uploader_id\":2592971,\"uploader\":{\"uploader_id\":69404,\"name\":\"maxoudela\",\"rank\":\"Gold
-        member\"},\"feature_details\":{\"feature_id\":429415,\"feature_type\":\"Episode\",\"year\":2015,\"title\":\"Man
-        of Steel\",\"movie_name\":\"Supergirl - S04E03  L'\xE2ge de l'acier\",\"imdb_id\":8685330,\"tmdb_id\":1593206,\"season_number\":4,\"episode_number\":3,\"parent_imdb_id\":4016454,\"parent_title\":\"Supergirl\",\"parent_tmdb_id\":62688,\"parent_feature_id\":15301},\"url\":\"https://www.opensubtitles.com/fr/subtitles/legacy/7528072\",\"related_links\":[{\"label\":\"All
-        subtitles for Tv Show Supergirl\",\"url\":\"https://www.opensubtitles.com/fr/features/redirect/15301\",\"img_url\":\"https://s9.opensubtitles.com/features/5/1/4/429415.jpg\"},{\"label\":\"All
-        subtitles for Episode man of steel\",\"url\":\"https://www.opensubtitles.com/fr/features/redirect/429415\"}],\"files\":[{\"file_id\":4737481,\"cd_number\":1,\"file_name\":\"Supergirl.S04E03.720p.HDTV.x264-AVS\"}]}},{\"id\":\"880717\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"880717\",\"language\":\"de\",\"download_count\":2670,\"new_download_count\":194,\"hearing_impaired\":false,\"hd\":true,\"fps\":23.976,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2013-10-19T00:53:25Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Man.of.Steel.German.720p.BluRay.x264-EXQUiSiTE\",\"comments\":\"\",\"legacy_subtitle_id\":5229998,\"legacy_uploader_id\":0,\"uploader\":{\"uploader_id\":3282,\"name\":\"os-auto\",\"rank\":\"Application
-        Developers\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/de/subtitles/legacy/5229998\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/de/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":962352,\"cd_number\":1,\"file_name\":\"Man.of.Steel.German.720p.BluRay.x264-EXQUiSiTE\"}]}},{\"id\":\"4620011\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"4620011\",\"language\":\"de\",\"download_count\":2208,\"new_download_count\":48,\"hearing_impaired\":false,\"hd\":false,\"fps\":23.976,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2018-11-09T23:18:45Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Supergirl.S04E03.HDTV.x264-SVA.de-SubCentral\",\"comments\":\"\",\"legacy_subtitle_id\":7536643,\"legacy_uploader_id\":0,\"uploader\":{\"uploader_id\":3282,\"name\":\"os-auto\",\"rank\":\"Application
-        Developers\"},\"feature_details\":{\"feature_id\":429415,\"feature_type\":\"Episode\",\"year\":2015,\"title\":\"Man
-        of Steel\",\"movie_name\":\"Supergirl - S04E03  Man of Steel\",\"imdb_id\":8685330,\"tmdb_id\":1593206,\"season_number\":4,\"episode_number\":3,\"parent_imdb_id\":4016454,\"parent_title\":\"Supergirl\",\"parent_tmdb_id\":62688,\"parent_feature_id\":15301},\"url\":\"https://www.opensubtitles.com/de/subtitles/legacy/7536643\",\"related_links\":[{\"label\":\"All
-        subtitles for Tv Show Supergirl\",\"url\":\"https://www.opensubtitles.com/de/features/redirect/15301\",\"img_url\":\"https://s9.opensubtitles.com/features/5/1/4/429415.jpg\"},{\"label\":\"All
-        subtitles for Episode man of steel\",\"url\":\"https://www.opensubtitles.com/de/features/redirect/429415\"}],\"files\":[{\"file_id\":4743011,\"cd_number\":1,\"file_name\":\"Supergirl.S04E03.HDTV.x264-SVA.de-SubCentral\"}]}},{\"id\":\"5166256\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"5166256\",\"language\":\"de\",\"download_count\":1794,\"new_download_count\":14,\"hearing_impaired\":false,\"hd\":true,\"fps\":23.976,\"votes\":1,\"ratings\":10.0,\"from_trusted\":true,\"foreign_parts_only\":false,\"upload_date\":\"2020-03-29T11:40:37Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Man.of.Steel.2013.720p.german.srt\",\"comments\":\"--\\u003e
-        HI-Items entfernt, Timing teilweise korrigiert, Kursivsetzung korrigiert\\r\\n--\\u003e
-        passend f\xFCr Versionen mit Laufzeit 2h 23min 2s 688ms\",\"legacy_subtitle_id\":8148911,\"legacy_uploader_id\":1189705,\"uploader\":{\"uploader_id\":54111,\"name\":\"arcchancellor\",\"rank\":\"translator\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/de/subtitles/legacy/8148911\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/de/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":5276290,\"cd_number\":1,\"file_name\":\"Man.of.Steel.2013.720p.german\"}]}},{\"id\":\"883560\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"883560\",\"language\":\"de\",\"download_count\":938,\"new_download_count\":9,\"hearing_impaired\":true,\"hd\":true,\"fps\":23.976,\"votes\":2,\"ratings\":10.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2016-08-01T19:13:17Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Man
-        of Steel German DL 1080p BluRay x264-EXQUiSiTE\",\"comments\":\"Duration:
-        2:23:03\\r\\nvia SubTools from idx to srt\\r\\nFull German\\r\\nHandmade corrected\",\"legacy_subtitle_id\":6699712,\"legacy_uploader_id\":1471910,\"uploader\":{\"uploader_id\":60439,\"name\":\"PissPott\",\"rank\":\"Silver
-        Member\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/de/subtitles/legacy/6699712\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/de/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":965292,\"cd_number\":1,\"file_name\":\"exq-manofsteel-1080p.idx.mkv\"}]}},{\"id\":\"6556241\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"6556241\",\"language\":\"de\",\"download_count\":550,\"new_download_count\":75,\"hearing_impaired\":false,\"hd\":false,\"fps\":0.0,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2021-10-09T01:24:06Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Man
-        of Steel\",\"comments\":\"\",\"legacy_subtitle_id\":8834730,\"legacy_uploader_id\":9055317,\"uploader\":{\"uploader_id\":null,\"name\":\"Anonymous\",\"rank\":\"anonymous\"},\"feature_details\":{\"feature_id\":1373215,\"feature_type\":\"Episode\",\"year\":2021,\"title\":\"Man
-        of Steel\",\"movie_name\":\"Superman \\u0026amp; Lois - S01E07  Man of Steel\",\"imdb_id\":11949922,\"tmdb_id\":2787118,\"season_number\":1,\"episode_number\":7,\"parent_imdb_id\":11192306,\"parent_title\":\"Superman
-        \\u0026 Lois\",\"parent_tmdb_id\":95057,\"parent_feature_id\":1205428},\"url\":\"https://www.opensubtitles.com/de/subtitles/legacy/8834730\",\"related_links\":[{\"label\":\"All
-        subtitles for Tv Show Superman \\u0026 Lois\",\"url\":\"https://www.opensubtitles.com/de/features/redirect/1205428\",\"img_url\":\"https://s9.opensubtitles.com/features/5/1/2/1373215.jpg\"},{\"label\":\"All
-        subtitles for Episode man of steel\",\"url\":\"https://www.opensubtitles.com/de/features/redirect/1373215\"}],\"files\":[{\"file_id\":7525661,\"cd_number\":1,\"file_name\":\"sal17\"}]}},{\"id\":\"2627042\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"2627042\",\"language\":\"de\",\"download_count\":404,\"new_download_count\":16,\"hearing_impaired\":false,\"hd\":false,\"fps\":25.0,\"votes\":0,\"ratings\":0.0,\"from_trusted\":true,\"foreign_parts_only\":false,\"upload_date\":\"2013-06-30T20:00:55Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Superman.Die.Abenteuer.von.Lois.und.Clark.S01E09.German.DVDRip.Retail\",\"comments\":\"\",\"legacy_subtitle_id\":5066959,\"legacy_uploader_id\":464273,\"uploader\":{\"uploader_id\":41812,\"name\":\"Ralle1\",\"rank\":\"translator\"},\"feature_details\":{\"feature_id\":172454,\"feature_type\":\"Episode\",\"year\":1993,\"title\":\"The
-        Man of Steel Bars\",\"movie_name\":\"Lois \\u0026amp; Clark: The New Adventures
-        of Superman - S01E09  \\\"Lois \\u0026amp; Clark: The New Adventures of Superman\\\"
-        The Man of Steel Bars\",\"imdb_id\":635199,\"tmdb_id\":322021,\"season_number\":1,\"episode_number\":9,\"parent_imdb_id\":106057,\"parent_title\":\"Lois
-        \\u0026 Clark: The New Adventures of Superman\",\"parent_tmdb_id\":4515,\"parent_feature_id\":8874},\"url\":\"https://www.opensubtitles.com/de/subtitles/legacy/5066959\",\"related_links\":[{\"label\":\"All
-        subtitles for Tv Show Lois \\u0026 Clark: The New Adventures of Superman\",\"url\":\"https://www.opensubtitles.com/de/features/redirect/8874\",\"img_url\":\"https://s9.opensubtitles.com/features/4/5/4/172454.jpg\"},{\"label\":\"All
-        subtitles for Episode the man of steel bars\",\"url\":\"https://www.opensubtitles.com/de/features/redirect/172454\"}],\"files\":[{\"file_id\":2701439,\"cd_number\":1,\"file_name\":\"Superman.Die.Abenteuer.von.Lois.und.Clark.S01E09.German.DVDRip.Retail\"}]}},{\"id\":\"1546744\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"1546744\",\"language\":\"fr\",\"download_count\":87,\"new_download_count\":3,\"hearing_impaired\":false,\"hd\":true,\"fps\":0.0,\"votes\":0,\"ratings\":0.0,\"from_trusted\":true,\"foreign_parts_only\":false,\"upload_date\":\"2012-05-11T12:51:44Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Standoff[1].S01E07.hdtv.xvid-xor.VF\",\"comments\":\"\",\"legacy_subtitle_id\":4545822,\"legacy_uploader_id\":1465168,\"uploader\":{\"uploader_id\":60242,\"name\":\"subth1ck\",\"rank\":\"trusted\"},\"feature_details\":{\"feature_id\":116746,\"feature_type\":\"Episode\",\"year\":2006,\"title\":\"Man
-        of Steele\",\"movie_name\":\"Standoff - S1E7 \\\"Standoff\\\" Man of Steele\",\"imdb_id\":852891,\"tmdb_id\":1210425,\"season_number\":1,\"episode_number\":7,\"parent_imdb_id\":756582,\"parent_title\":\"Standoff\",\"parent_tmdb_id\":630,\"parent_feature_id\":8050},\"url\":\"https://www.opensubtitles.com/fr/subtitles/legacy/4545822\",\"related_links\":[{\"label\":\"All
-        subtitles for Tv Show Standoff\",\"url\":\"https://www.opensubtitles.com/fr/features/redirect/8050\",\"img_url\":\"https://s9.opensubtitles.com/features/6/4/7/116746.jpg\"},{\"label\":\"All
-        subtitles for Episode man of steele\",\"url\":\"https://www.opensubtitles.com/fr/features/redirect/116746\"}],\"files\":[{\"file_id\":1638900,\"cd_number\":1,\"file_name\":\"Standoff[1].S01E07.hdtv.xvid-xor.VF\"}]}},{\"id\":\"2627058\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"2627058\",\"language\":\"de\",\"download_count\":71,\"new_download_count\":1,\"hearing_impaired\":true,\"hd\":false,\"fps\":25.0,\"votes\":0,\"ratings\":0.0,\"from_trusted\":true,\"foreign_parts_only\":false,\"upload_date\":\"2013-06-30T18:01:04Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Superman.Die.Abenteuer.von.Lois.und.Clark.S01E09.German.SDH.DVDRip.Retail\",\"comments\":\"\",\"legacy_subtitle_id\":5066960,\"legacy_uploader_id\":464273,\"uploader\":{\"uploader_id\":41812,\"name\":\"Ralle1\",\"rank\":\"administrator\"},\"feature_details\":{\"feature_id\":172454,\"feature_type\":\"Episode\",\"year\":1993,\"title\":\"The
-        Man of Steel Bars\",\"movie_name\":\"Lois \\u0026amp; Clark: The New Adventures
-        of Superman - S1E9 \\\"Lois \\u0026amp; Clark: The New Adventures of Superman\\\"
-        The Man of Steel Bars\",\"imdb_id\":635199,\"tmdb_id\":322021,\"season_number\":1,\"episode_number\":9,\"parent_imdb_id\":106057,\"parent_title\":\"Lois
-        \\u0026 Clark: The New Adventures of Superman\",\"parent_tmdb_id\":4515,\"parent_feature_id\":8874},\"url\":\"https://www.opensubtitles.com/de/subtitles/legacy/5066960\",\"related_links\":[{\"label\":\"All
-        subtitles for Tv Show Lois \\u0026 Clark: The New Adventures of Superman\",\"url\":\"https://www.opensubtitles.com/de/features/redirect/8874\",\"img_url\":\"https://s9.opensubtitles.com/features/4/5/4/172454.jpg\"},{\"label\":\"All
-        subtitles for Episode the man of steel bars\",\"url\":\"https://www.opensubtitles.com/de/features/redirect/172454\"}],\"files\":[{\"file_id\":2701455,\"cd_number\":1,\"file_name\":\"Superman.Die.Abenteuer.von.Lois.und.Clark.S01E09.German.SDH.DVDRip.Retail\"}]}},{\"id\":\"6632511\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"6632511\",\"language\":\"de\",\"download_count\":61,\"new_download_count\":7,\"hearing_impaired\":false,\"hd\":true,\"fps\":23.976,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2022-06-26T19:32:54Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Should
-        work with 4k BD rips\",\"comments\":\"Source German Retail 4k BD\\r\\nRetail
-        PGS to SSA + improvements\\r\\n\\r\\ncoloured parts\\r\\n\\r\\nIf the timing
-        is off, just correct it with SubtitleEdit.\\r\\n-\\u003e Synchronization \\r\\n-\\u003e
-        Adjust all times \\r\\n-\\u003e all lines\\r\\n\\r\\nWorks best with MPC-BE
-        + XySubFilter + madvr\\r\\nbecause there the font is not in the image,\\r\\nbut
-        at the bottom in the black bars.\",\"legacy_subtitle_id\":9150443,\"legacy_uploader_id\":9372469,\"uploader\":{\"uploader_id\":null,\"name\":\"Anonymous\",\"rank\":\"anonymous\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/de/subtitles/legacy/9150443\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/de/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":7601680,\"cd_number\":1,\"file_name\":\"Man
-        of Steel.Full - German\"}]}},{\"id\":\"823209\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"823209\",\"language\":\"de\",\"download_count\":46,\"new_download_count\":5,\"hearing_impaired\":false,\"hd\":false,\"fps\":25.0,\"votes\":0,\"ratings\":0.0,\"from_trusted\":true,\"foreign_parts_only\":false,\"upload_date\":\"2013-06-25T20:11:18Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Superman.50th.Anniversary.1988.German.DOKU.DVDRip.Retail\",\"comments\":\"\",\"legacy_subtitle_id\":5058619,\"legacy_uploader_id\":464273,\"uploader\":{\"uploader_id\":41812,\"name\":\"Ralle1\",\"rank\":\"translator\"},\"feature_details\":{\"feature_id\":584412,\"feature_type\":\"Movie\",\"year\":1988,\"title\":\"Superman's
-        50th Anniversary: A Celebration of the Man of Steel\",\"movie_name\":\"1988
-        - Superman's 50th Anniversary: A Celebration of the Man of Steel\",\"imdb_id\":303111,\"tmdb_id\":464654},\"url\":\"https://www.opensubtitles.com/de/subtitles/legacy/5058619\",\"related_links\":[{\"label\":\"All
-        subtitles for superman's 50th anniversary: a celebration of the man of steel\",\"url\":\"https://www.opensubtitles.com/de/movies/1988-superman-50th-anniversary\",\"img_url\":\"https://s9.opensubtitles.com/features/2/1/4/584412.jpg\"}],\"files\":[{\"file_id\":901498,\"cd_number\":1,\"file_name\":\"Superman.50th.Anniversary.1988.German.DOKU.DVDRip.Retail\"}]}},{\"id\":\"7164656\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"7164656\",\"language\":\"de\",\"download_count\":1,\"new_download_count\":57,\"hearing_impaired\":true,\"hd\":false,\"fps\":25.0,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2023-05-08T16:42:39Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Superman.and.Lois.S01E07.German.DL.DVDRiP.x264-NAiB\",\"comments\":\"\",\"legacy_subtitle_id\":9544178,\"legacy_uploader_id\":0,\"uploader\":{\"uploader_id\":3282,\"name\":\"os-auto\",\"rank\":\"Application
-        Developers\"},\"feature_details\":{\"feature_id\":1373215,\"feature_type\":\"Episode\",\"year\":2021,\"title\":\"Man
-        of Steel\",\"movie_name\":\"Superman \\u0026amp; Lois - S01E07  Man of Steel\",\"imdb_id\":11949922,\"tmdb_id\":2787118,\"season_number\":1,\"episode_number\":7,\"parent_imdb_id\":11192306,\"parent_title\":\"Superman
-        \\u0026 Lois\",\"parent_tmdb_id\":95057,\"parent_feature_id\":1205428},\"url\":\"https://www.opensubtitles.com/de/subtitles/legacy/9544178\",\"related_links\":[{\"label\":\"All
-        subtitles for Tv Show Superman \\u0026 Lois\",\"url\":\"https://www.opensubtitles.com/de/features/redirect/1205428\",\"img_url\":\"https://s9.opensubtitles.com/features/5/1/2/1373215.jpg\"},{\"label\":\"All
-        subtitles for Episode man of steel\",\"url\":\"https://www.opensubtitles.com/de/features/redirect/1373215\"}],\"files\":[{\"file_id\":8100472,\"cd_number\":1,\"file_name\":\"Superman.and.Lois.S01E07.German.DL.DVDRiP.x264-NAiB\"}]}}]}"
+      string: !!binary |
+        E/YIAMT/5uy/ap1TowJG6H4qY2ZYva7MxzCAG14YOTXeVrQoBS1X5B9rd3F6zqGno9F0i58HdG0g
+        D/iJFIs6HT0gma05vJxaU8QH0M3SWh5xov4VZrdnitCCXfTuQFOgJcNOgSMMuuUMT64SDKNNFvr3
+        I9wIjb5TQkowpPtO0IjHKbnkCQw+8EI/VjYxTSk8WdCYAhgUo7E8gItOMqx0NdXHqRhmssGtZ+OW
+        3bpAI/RkfSSGeYRO4SCGaY/QsipU1zJcNkxOcoZgk1vPEZoXnGEK22JSOGKSs8e0BXLn1ew2pGi2
+        1d+70I8djvOjTQQNyUWVC56L9otoddNq3v4Cg3XmvIVt3koOrSczjFanVp+UZLxQIE82EjQWuxbb
+        VMRE5AvJRVV0ku/FyR/B3oubbOt8Ir+tdzD4+3ZogMHT2Q53Y/3YRspWNoKB0EWnkCSu21AK0I+4
+        XVzJXjKsdiFobDG3R9rAEOz6Hxov9t27wSa3rdn2VKMpRDwzrDmRzHfx8HCginFMAz3vWs5KhtLC
+        t9vFERjuZEMgWBVDbG2r8dau2TZlnxORB8OyXRwZcKNJLqosz9iCbhlPPWZ3He9lz5AKD6xVI8Uz
+        wxE8NOaU9qjL8nq9FttOq/Xq4l8i8E6hTEJpQrE0KQ+nLbCJRuPd+j+OkfyjOcZC44X3mbSwbNpC
+        tkCEYjUA4MrqsYy36MWu+TblUvq45WwkdY0qE/5IiyUv27Ir7Z9/HMi0578Mk/OE3pxcxFyjWt72
+        FcMwmk3S4pMFzkIavToRuk5xvV6LeJzifR3msBXDtvSMu3DJbONsFpuGeeB6np/ZHINxzzvRUU3z
+        E+JIPbQdz69FKEV/hvrCuW4qLRsC3wKfi71dhnAj/NIfn8blzY+PX91n9+XNPPNzK6V6Qh7pzZVS
+        PT3hSIRaVo2sZpiWO7Nof58B
     headers:
       Access-Control-Allow-Headers:
       - Origin, Authorization, Accept, Api-Key, Content-Type, X-User-Agent
@@ -485,32 +307,34 @@ interactions:
       - GET, HEAD, POST, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
+      Age:
+      - '48857'
       CF-Cache-Status:
-      - MISS
+      - HIT
       CF-RAY:
-      - 87c704594c165279-LHR
+      - 883aac52a90bf0bb-CDG
       Cache-Control:
       - public, max-age=86400
       Connection:
       - keep-alive
       Content-Encoding:
-      - gzip
+      - br
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 30 Apr 2024 10:58:30 GMT
+      - Tue, 14 May 2024 11:50:52 GMT
       Last-Modified:
-      - Tue, 30 Apr 2024 10:58:30 GMT
+      - Mon, 13 May 2024 22:16:35 GMT
       NEL:
       - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
       RateLimit-Limit:
       - '5'
       RateLimit-Remaining:
-      - '4'
+      - '3'
       RateLimit-Reset:
       - '1'
       Report-To:
-      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=NHqD3%2FxydzQ9FGOQIL1y11zBxqwhJ5%2F6paGB6CTnpk9Q%2FyrxKl4CE3mKrMca%2BDUul4kpKjqdv8tBEbja32FMe0uqf7fPl%2Bf%2BhquDZEezLAy2mtoONVjyQeTyxLtc%2FdDHbzhgN6NjPcw%3D"}],"group":"cf-nel","max_age":604800}'
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=WvzoC0GRYsYb%2Balajdbm0CDnU7vTq585CxWoVSeuvQt3gGPEnSP80j19VDbV89OyQPwK2B3%2BNADlOKtbONltohMI50Mfxr6bTeFf4StuCUfuVJ6yoMG76ueGV9tREtTqdc1b%2Fibnivs%3D"}],"group":"cf-nel","max_age":604800}'
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -530,17 +354,175 @@ interactions:
       X-Kong-Proxy-Latency:
       - '0'
       X-Kong-Upstream-Latency:
-      - '132'
+      - '322'
       X-RateLimit-Limit-Second:
       - '5'
       X-RateLimit-Remaining-Second:
-      - '4'
+      - '3'
       X-Request-Id:
-      - f3905e70-b75b-4103-b9b4-abc956b02ef8
+      - 8b1792c8-8642-406c-81b5-ac72bdd7b2de
       X-Runtime:
-      - '0.129223'
+      - '0.056598'
       X-StackifyID:
-      - V1|189d3ea4-f96f-4a90-9ede-a8530b84054a|C98087|CD1
+      - V1|bb019018-c764-415a-ac55-d9a093fe8be4|C98087|CD1
+      X-Var-Cache:
+      - MISS
+      X-Via:
+      - fw1
+      X-Vip:
+      - 'false'
+      X-Vip-Consumer:
+      - 'false'
+      X-Vip-User:
+      - 'false'
+      X-XSS-Protection:
+      - 1; mode=block
+      alt-svc:
+      - h3=":443"; ma=86400
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Api-Key:
+      - mij33pjc3kOlup1qOKxnWWxvle2kFbMH
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Subliminal v2.1
+    method: GET
+    uri: https://api.opensubtitles.com/api/v1/subtitles?languages=de%2Cfr&query=man+of+steel
+  response:
+    body:
+      string: !!binary |
+        E6RYAORS0ypKUdi7n6S6G/gvkp+ZfTz7SftrSgWLkIQ1SehAULZ3yllySXzZTq6VwnyNbeUbWyA8
+        VWBhAivunpCT2032iQtEW2SFLEx9NYFCFLJCAuN4UOTNy6vKmAU/t6JlGENb/vSyfeJn1D+f/SWc
+        4sw9NrfC0YHG5R5twy+xzBKOew0N/+2iwob3oQbuf/vEU889txYUIm94fb1E7vm8PNZUh8gbXglO
+        3H+amMo+KRYoEff8WHjDc4aF2ZFCa6UaPsXn/eQtQkY1/BxDSdNpn8ZLSCX23B/DMMeGn3vua1li
+        w4+XmXvooOHXLFBiaHgJNU2nj205ljzua1nmGlMuOZeYTtP+Ekqd93kaXhdvtlxEOfl9qJF7ToCi
+        RWjRblF60l6aX3nDQ9qfbGHnQ6iS+U2P+0Nf5HjoieiMW0+JQwxz5J6PYerysZtrjENHgKIzBJfu
+        cVhKeO1eSMv2GIc8vXbPz8/dvDzOr9PhXHJ3yCNveP1vP/ecN3yIp3B43VdGVEXkEGkGmD2zWGJk
+        lAIUqkyPMRbuP/G55qIcamr4FMb6X6kxpOGSl5J4w0uYnrjn25JNxo5p1ZO/NXwUiuH+kvJA+8B/
+        BosdzILRMCtqWyv0IV9T5A1/jaFwT4Ci4W1qlbnnH8LE8pFtaowDb/iYrynu5Ro7AhSsZbO5pbF/
+        zERiY8CSbXj942ZKpwjfGr6UgXt+rvUy+9Xq+fm5y5c4NeRk8/VG4HQsq6hZFaLBqlDVvCbnEmrs
+        90OanuaNhjxZx6jc8/UwsMTh2DEXNuai2MxDAJBZs3nVCCOPYWrzsV1KX9J42mcjz9l9woKON69g
+        pVdmVf7kCULGe/vY8GMaovQWx9RmtsVpQikbfuj3h00L4APMggpdvmYb+Pbx7a1Bl5ZswGmJkzLF
+        5iACQY+fwzu0EI6vOgaYlvQWrJfGAwS9D6XbhP1edw/p6/v7PUK3Xt+2d+l92q4fAKU9ICinIb0A
+        JZ0Jsnejy3Mblpqftnl9uQzpEGrKEzv23XedWGY4gUV6bRKbWxEaI9JOcRM9QOth6H6MZU55ao8F
+        OlTtkAglZYt1A2h6EoEgJT9cEp0zGj7+wxBa1FvUXmkPmphwYSHfBzQpBA5YpNcoHORLAG1FULXR
+        zqCkTLE50IAwbwkU6h4iyW8VnBfKA4WuIdjKmlDmeKi5mPfvBcoqCu8oyqq+TEtUjshIbKM0B1G1
+        BSFwUhI6qtTH/jEknE4kbdF1gYqQK5CBuJktCrXIZRJpYqjt32E6dHcPFVT8Zli+n1Huf/7uh7RJ
+        23sq8s1tlHOhyn38zI1yLjyBfQwDB52W/RcOTVULktR3oRRKyhSbQpIVmYX6j8eXFP8Iq1swrUDV
+        6mviPAaKkR/L2T8IUPyT3dUrozOYMU19l/ahtbPKCYVJaYFGe6qvnUA1icdYTrHUveLjmuVNFDRQ
+        kV6jxGZRZI1QIX7sH3fbtmnS9MJPapQSWDkiA5GWqV/SPZIQGqqXs5c1wZiDbRFbwC2acLl0TBa1
+        WS6xnFIZug3Ie+g/un9+t/0RsHt8/eNGsaGIUWTBmFbaLylHzqC+dhLkpMbwkpc+DkEt2rPe5wEe
+        2lqSk6jGeH9Jc+4fy4MSisqetezxoDL28Pc//3eKrI9s+Hs4pFg4xxi91VYJAZixJFROEOiGzzHM
+        eerRu8uGR9mETv5CRMMvocSp7pcZVQJqqeRELLhQh8n4ZCxHkCZt7SSqjAYZKgF6F1TjPAnPZLZX
+        tjnnZyY3DykECMpW4imEqFfZ4I1h4dQKV3LVSCDpSXcjN2o2cuiMhDULosNPSUxLaWmEkRbvhQKU
+        utFq4VaqBoMGJWWKTUPawNPCORSFXbQirtsCeCU8qQA+5euefS9wztnwjeKcs0GlJBRJbaYUhIxs
+        qQnA5YVIywYidUFgMyTvcC/r8n+FNKwI6rYkPFovVSAY2II2P667Prab5fH2GB0yY+Bj/SO0lp21
+        K83IBPd7lzMjk4Qo1whkTBTeUHVfCTdP3z4GcdGZogqlAJS86VKw2vEq1JqUJtIy8bKmQeNkZkl9
+        lxZULRk7NYIjoW5I0IJoyW0RvQQvDC0jrKKaE0HrylwqlF4i23a3AIjIPv+i/aLGcWZxqsdYptqw
+        bRrTdGI1puE5pjmyp1xKOqVYasO+WsqcrnOsfyzTaarXruymBc//EuY5Tj07/vn/wtw4zj5xYmOq
+        7CEsxz9iqozOjMSYJkYz09aOc09bEYvSOnQfUBzROgMOjCUkIm5bKIfDOUyHOAy5OCBhXeIzTi7s
+        EJXpNUmccBQZTQ4096nR5qJdSQ/8szgil5CU6SU/TlBB8TtmO19GCLUQZeOppFdbXdzn6TyKCHuS
+        buzugVlQ9FjpGE0H7e6Wws4OumfkSXgQu7KbrimwzfK4zXk4FbF4qX9hNbMZpxzfLcMKk+zKbvo8
+        TP35odHHZdk/hxp7hd9wau2c8aPub4MOqaadBmnVhYRuEt+mef421+oC+Q9pk4ZrLOyDMeCxd8aJ
+        +orsota9Ihc3vvy3HcOUj8RO3bb7yXapf+nGp6tJYALWSmmS4y+ItExAlB+lFFqFZWx/9LYFQ6EO
+        Q9gitOC2gJ6kq6M2JTijN6Mi1gpphAu0sg6UEmgU/17TMgxdzkmtpzy9jnmZscAo/JnR+3nEURhB
+        av/qRbgiY5jYbgEgHcbLf9hDTrMVoD/xHky/c5KITjpHZDEcezLWIFoLQBmwDCYJIjoSoPuROBPa
+        BAVCilkDmsMpUGaiIlCSrPMDagiy2QNEMiFP1w7lKQu4ccCCVm3pyep+75SitUuCUsWNIqW1eaAv
+        cxjQPWsCJk0GpGcFkZYJNKHpTrS3mWlagXcbqwFrRSfQrYAtgQfw6gO4ZG1wit36MU41LrF01zx1
+        DznN3TL13e0QylOHGkbONSbsj3ffp0v3PaVhV+spokBrpxy2FJVakhGkqzeJFpV7E8P3YRgi8k6f
+        HRoyReJZpUBt5+gc4+pye46+FUNlN6HMmAvwFSIBwFtQeIN5tj3H6w2OGDILFoVKHwPyIHCM7ZbS
+        XTvORBQw3U4LZdAS1IjmgvYljIBeJpcDNCLjgiJzwCH/YlZftRzAKAb1g8xaIx3cYBOUw+bLPXfy
+        7ARGsrVGcl+4cHKlVnLVwnntAHKpZ62kOXtsPvJkAUohaUfgRgaw/8SimpQXl6gdyQSMSmojxyYS
+        aUnmLe6Ikx47MoDXAKPbFkY86xzUgmoRt0heoZcyzGtTw9Tn4/E3/Fglx3DTnft67V6uqW9fcul+
+        fGf1UUwqqSwNbG5erVDbhjWQHNPyWM94eNpLwOJj/Wgx1Ebq/iAA3SFPPVJxVExJWcs2eG/Y7q9d
+        3XGWmrD8DK7IOkTtiQMJQZLi4KMxSitLmIs0CVgaUf8bKwFJqEIaVBYUjJJElS2L8w0hMw8hUj+C
+        1MC2oABjw+mVXJlVE8mCzvUmy6LocO2SCHb7Ri2sA8DlJ3lzpZAT0OhOoCz9BmmZ9BX5MKgzZRkX
+        cYVx7z82Wg/oQYZesrn7nH9LGugtZ9Ry4ZRX5ef3HHjv4nMgDeGxUyqIYBOt+e7pWtB/HSLSMt2k
+        R+9NrhZe8DoLUQu6Jb1F5wV59XkanPMy9Ow5lyf2nOqZySd2c8dKusweV5E2eSmHaKCDlQUTeOzK
+        bvrb4fDt+w2rmW02a/ZvlsZLydfTXXGbd2VnaIt7yENeSuyZuh9PMfvi2KQ11eNggWlm+Xhs2O/L
+        XA1y9ixVEQ02Fe1336faeRugO81maLf9lP5w86Smm6375XmFYWBnTE2/JgnDwIY0RYnG4qdcnmZ2
+        DjBgtafdh29v25t79m/28+tmeXyXhhoL+zcbQ38tu7KbLn9bOOrQfa7nyI55qizNbMqVnZh1mDSG
+        U2ySdHWp7FK58DGD49nIa6sLbMrp6fbHw+VQgXRv+zk4YUhqZ3W4mlseUWnyVOtcHW8UNxpQW1ZP
+        Fbe6M4cbtBs4TeZHsiVBMAxJSMpkdsyH1K4PmaXeLncuXxQjtSXwiB5tWDMF9dytpyldY5lDee3Q
+        Wasx7/nffPUDdf/SldWoNh8vykqJBBYNobMWk4lJ/n1mCuqZFU98z9bsNg7x0ecjOTsDeclODRMv
+        OmtZyxYsaFjsBAhnMgKQBqGWWimZQYXxjKnNuSol1CGwg3wYFojO2na9o20V1HP7wJv8qmk8Emwj
+        0t0oRhxQOss+uW5NlNpiZBvUUjunEmnZohS4uw2t2oI31dTJRAuqBbtF7SV54V7tw9RrKpDSFyOd
+        5qF2NN+6EQ/41+t04/D/C+GUlGjGC12nccZArUEW/bCETPAQCO3fqKEB9yLkjDH+LQJIQ4jMa3sP
+        9fbx7e3jGw==
+    headers:
+      Access-Control-Allow-Headers:
+      - Origin, Authorization, Accept, Api-Key, Content-Type, X-User-Agent
+      Access-Control-Allow-Methods:
+      - GET, HEAD, POST, OPTIONS
+      Access-Control-Allow-Origin:
+      - '*'
+      Age:
+      - '48855'
+      CF-Cache-Status:
+      - HIT
+      CF-RAY:
+      - 883aac52f95cf0bb-CDG
+      Cache-Control:
+      - public, max-age=86400
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - br
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Tue, 14 May 2024 11:50:52 GMT
+      Last-Modified:
+      - Mon, 13 May 2024 22:16:37 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      RateLimit-Limit:
+      - '5'
+      RateLimit-Remaining:
+      - '3'
+      RateLimit-Reset:
+      - '1'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=9eUiG30KiHjX%2BBiT4lzpNxCmndHqPgEBosby0ehp%2F5Baf5bs%2FIyCxs%2FzbsKbil64Ngpf2ySyJr%2FUl6T%2FqqFm76k4O3aYseyAQrv4giUpEDIQwd7Wg2opAglG0NQ%2B3SomzLL4vOoONHs%3D"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding
+      X-Cache-Backend:
+      - apigw1_8000 rb11
+      X-Content-Type-Options:
+      - nosniff
+      X-Download-Options:
+      - noopen
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-Kong-Proxy-Latency:
+      - '0'
+      X-Kong-Upstream-Latency:
+      - '105'
+      X-RateLimit-Limit-Second:
+      - '5'
+      X-RateLimit-Remaining-Second:
+      - '3'
+      X-Request-Id:
+      - 4d483b03-e407-47db-8a16-d85fc868517b
+      X-Runtime:
+      - '0.102130'
       X-Var-Cache:
       - MISS
       X-Via:

--- a/tests/cassettes/opensubtitlescom/test_list_subtitles_movie_no_hash.yaml
+++ b/tests/cassettes/opensubtitlescom/test_list_subtitles_movie_no_hash.yaml
@@ -5,7 +5,7 @@ interactions:
       Accept:
       - '*/*'
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Api-Key:
       - mij33pjc3kOlup1qOKxnWWxvle2kFbMH
       Connection:
@@ -18,15 +18,21 @@ interactions:
     uri: https://api.opensubtitles.com/api/v1/subtitles?languages=de&query=enders+game
   response:
     body:
-      string: '{"total_pages":1,"total_count":3,"per_page":60,"page":1,"data":[{"id":"939553","type":"subtitle","attributes":{"subtitle_id":"939553","language":"de","download_count":4471,"new_download_count":175,"hearing_impaired":false,"hd":true,"fps":23.976,"votes":1,"ratings":10.0,"from_trusted":false,"foreign_parts_only":false,"upload_date":"2014-03-06T16:36:27Z","ai_translated":false,"nb_cd":1,"machine_translated":false,"release":"Enders.Game.Das.grosse.Spiel.German.DL.1080p.BluRay.x264-EXQUiSiTE","comments":"","legacy_subtitle_id":5571822,"legacy_uploader_id":1563515,"uploader":{"uploader_id":63224,"name":"newkinds","rank":"trusted"},"feature_details":{"feature_id":586791,"feature_type":"Movie","year":2013,"title":"Ender''s
-        Game","movie_name":"2013 - Ender''s Game","imdb_id":1731141,"tmdb_id":80274},"url":"https://www.opensubtitles.com/de/subtitles/legacy/5571822","related_links":[{"label":"All
-        subtitles for ender''s game","url":"https://www.opensubtitles.com/de/movies/2013-ender-s-game","img_url":"https://s9.opensubtitles.com/features/1/9/7/586791.jpg"}],"files":[{"file_id":1023711,"cd_number":1,"file_name":"endersgame-1080p"}]}},{"id":"940426","type":"subtitle","attributes":{"subtitle_id":"940426","language":"de","download_count":1252,"new_download_count":62,"hearing_impaired":false,"hd":true,"fps":0.0,"votes":0,"ratings":0.0,"from_trusted":false,"foreign_parts_only":false,"upload_date":"2014-10-20T22:08:17Z","ai_translated":false,"nb_cd":1,"machine_translated":false,"release":"Enders.Game.2013.1080p.BluRay.x264-SPARKS","comments":"","legacy_subtitle_id":5864769,"legacy_uploader_id":0,"uploader":{"uploader_id":3282,"name":"os-auto","rank":"Application
-        Developers"},"feature_details":{"feature_id":586791,"feature_type":"Movie","year":2013,"title":"Ender''s
-        Game","movie_name":"2013 - Ender''s Game","imdb_id":1731141,"tmdb_id":80274},"url":"https://www.opensubtitles.com/de/subtitles/legacy/5864769","related_links":[{"label":"All
-        subtitles for ender''s game","url":"https://www.opensubtitles.com/de/movies/2013-ender-s-game","img_url":"https://s9.opensubtitles.com/features/1/9/7/586791.jpg"}],"files":[{"file_id":1024649,"cd_number":1,"file_name":"Enders.Game.2013.1080p.BluRay.x264-SPARKS"}]}},{"id":"939532","type":"subtitle","attributes":{"subtitle_id":"939532","language":"de","download_count":570,"new_download_count":21,"hearing_impaired":true,"hd":true,"fps":23.976,"votes":0,"ratings":0.0,"from_trusted":false,"foreign_parts_only":false,"upload_date":"2014-03-06T01:27:57Z","ai_translated":false,"nb_cd":1,"machine_translated":false,"release":"Enders.Game.Das.grosse.Spiel.German.720p.BluRay.x264-EXQUiSiTE","comments":"","legacy_subtitle_id":5571194,"legacy_uploader_id":0,"uploader":{"uploader_id":3282,"name":"os-auto","rank":"Application
-        Developers"},"feature_details":{"feature_id":586791,"feature_type":"Movie","year":2013,"title":"Ender''s
-        Game","movie_name":"2013 - Ender''s Game","imdb_id":1731141,"tmdb_id":80274},"url":"https://www.opensubtitles.com/de/subtitles/legacy/5571194","related_links":[{"label":"All
-        subtitles for ender''s game","url":"https://www.opensubtitles.com/de/movies/2013-ender-s-game","img_url":"https://s9.opensubtitles.com/features/1/9/7/586791.jpg"}],"files":[{"file_id":1023690,"cd_number":1,"file_name":"Enders.Game.Das.grosse.Spiel.German.720p.BluRay.x264-EXQUiSiTE"}]}}]}'
+      string: !!binary |
+        wRBoACD+t1Q7XT0vux1JfNQsbltaZYj1rTCqAzhO0/wfNpADPfMjOD46sD9ubV3b5hh0tUGWrWFh
+        FvgVUBj2IlqCJRKApUOcuxst+syk6Bpz1H+EWWzHAZrEhjZ1oB7QucDCnsIKupICn94UCbQ2Wug/
+        13AtNJq8KcscAvFyYWiEw2l0cWAI+EAGff1jGpMUy+MHjZYhoBiW5RmLoiaBiY/m10ejuhE4Y+vd
+        1Bk3LtZ5bqH3dggscNZCR39ggf0SoFWeNnUlcD5HjV/e2+imLkCTTKXA3s+jif4QYkZ32M+eXTeZ
+        xfoYzDwNlzxEh0We129tZGgoSUUi80RWX6nSeaVV/RsC1pn5LSwZbM6m6dTsWqvjvk8iEr5Xnge2
+        gaHxbGrZh/SFHTl9akPa+TkETr8sjod0cBAPkD59m5LcyiV9PBw+28v0QlVF8uznp2/ui/v6DAKB
+        8HRoQGDgzu4ujVscy7KmrVIEUEkR+5U9lVVeUqn6luyhr0F1dpUrVQhMdmRoTHycnNdjIODt1EPD
+        vNJVoC8UrhlTHggQ/DUQZmlb1Q2RouC61rv53DEELtl6aCUpF4g2ZKYT74bNCzsyBMb53LERZ3tK
+        Ur5JNmQqN7ansh9DdU5UkED89p5bqepiFTj4ARpnMS5BZ9nxeEznhSe7JYUFRyBrOTuzM+NxMmOy
+        4McDbOTWDG7qw98meG4dHaHxaBg2iZM3MyCJ1CB08RAAaGsZMiUpT3IhJiEZ48bObCqF5oEs7RUy
+        ypqszhwQPIeQXus/gb0bWHrJ3sXKWiRVXhMJ7Foz4bQAQAANMjvQxyJ0duQkMu2w/ltXARoULmSh
+        Kpw0phUZpEpVp6rcAlxAd1L5Ibb/Q5KJkl+V0nKrqZikJOXIsA++fHz0+c2XIxW2VVFXTbYSEHS5
+        2qrtZnNI7CHO27UfLcvgdja6edpMyu6Ph31AB2jT78qK7KIqmjjFaChsrD5vylxVZ4CkMa26KGu5
+        rajUFlZaxHD+cLgBz3+RJK1qXRaNrVX1xS8BNQWYQJt+Wyoz+lI1ch3vwDVb/63rvxU=
     headers:
       Access-Control-Allow-Headers:
       - Origin, Authorization, Accept, Api-Key, Content-Type, X-User-Agent
@@ -34,22 +40,24 @@ interactions:
       - GET, HEAD, POST, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
+      Age:
+      - '48856'
       CF-Cache-Status:
-      - MISS
+      - HIT
       CF-RAY:
-      - 87c7045c6f024911-LHR
+      - 883aac53fd33f170-CDG
       Cache-Control:
       - public, max-age=86400
       Connection:
       - keep-alive
       Content-Encoding:
-      - gzip
+      - br
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 30 Apr 2024 10:58:30 GMT
+      - Tue, 14 May 2024 11:50:52 GMT
       Last-Modified:
-      - Tue, 30 Apr 2024 10:58:30 GMT
+      - Mon, 13 May 2024 22:16:36 GMT
       NEL:
       - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
       RateLimit-Limit:
@@ -59,7 +67,7 @@ interactions:
       RateLimit-Reset:
       - '1'
       Report-To:
-      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=ikU8RUiXKFIKjyzHMlCeUxlVCALtoOL9q%2FQPY0Dd2dCZD6h9yooJSAy5W0F5DqYVbfQuKJnWyj%2BgMYzKQndpweNjKSO0p0UXrBh%2FYjy%2FEMYycCXh6Ig2%2B4Y09NKhi5x1gfDNGFVttGE%3D"}],"group":"cf-nel","max_age":604800}'
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=qaFOpy3yTZ03qJmUdhhxHedUBp08B3flfLuwnaO0NTqrOm9OwAMxT5Az4LHbkFTnKEJgI3JaoWGbELdHNjZdgW2DNUI4TxprDDKs2%2F9X1NUeHYQU%2Bc0uMdp6ATU9L7b%2FzK5JuRL%2B2%2Fw%3D"}],"group":"cf-nel","max_age":604800}'
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -69,7 +77,7 @@ interactions:
       Vary:
       - Accept-Encoding
       X-Cache-Backend:
-      - apigw1_8000 rb11
+      - apigw1_8000 rb7
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -77,17 +85,19 @@ interactions:
       X-Frame-Options:
       - SAMEORIGIN
       X-Kong-Proxy-Latency:
-      - '0'
+      - '1'
       X-Kong-Upstream-Latency:
-      - '29'
+      - '309'
       X-RateLimit-Limit-Second:
       - '5'
       X-RateLimit-Remaining-Second:
       - '3'
       X-Request-Id:
-      - 998cf473-4fb0-487e-88d8-0f9e3f7e7302
+      - 2943783a-11a7-4d95-bedd-57f774054173
       X-Runtime:
-      - '0.027634'
+      - '0.051178'
+      X-StackifyID:
+      - V1|50946b4d-13e7-49be-9dec-acbede6557ed|C98087|CD1
       X-Var-Cache:
       - MISS
       X-Via:
@@ -111,7 +121,7 @@ interactions:
       Accept:
       - '*/*'
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Api-Key:
       - mij33pjc3kOlup1qOKxnWWxvle2kFbMH
       Connection:
@@ -124,15 +134,21 @@ interactions:
     uri: https://api.opensubtitles.com/api/v1/subtitles?languages=de&query=enders+game
   response:
     body:
-      string: '{"total_pages":1,"total_count":3,"per_page":60,"page":1,"data":[{"id":"939553","type":"subtitle","attributes":{"subtitle_id":"939553","language":"de","download_count":4471,"new_download_count":175,"hearing_impaired":false,"hd":true,"fps":23.976,"votes":1,"ratings":10.0,"from_trusted":false,"foreign_parts_only":false,"upload_date":"2014-03-06T16:36:27Z","ai_translated":false,"nb_cd":1,"machine_translated":false,"release":"Enders.Game.Das.grosse.Spiel.German.DL.1080p.BluRay.x264-EXQUiSiTE","comments":"","legacy_subtitle_id":5571822,"legacy_uploader_id":1563515,"uploader":{"uploader_id":63224,"name":"newkinds","rank":"trusted"},"feature_details":{"feature_id":586791,"feature_type":"Movie","year":2013,"title":"Ender''s
-        Game","movie_name":"2013 - Ender''s Game","imdb_id":1731141,"tmdb_id":80274},"url":"https://www.opensubtitles.com/de/subtitles/legacy/5571822","related_links":[{"label":"All
-        subtitles for ender''s game","url":"https://www.opensubtitles.com/de/movies/2013-ender-s-game","img_url":"https://s9.opensubtitles.com/features/1/9/7/586791.jpg"}],"files":[{"file_id":1023711,"cd_number":1,"file_name":"endersgame-1080p"}]}},{"id":"940426","type":"subtitle","attributes":{"subtitle_id":"940426","language":"de","download_count":1252,"new_download_count":62,"hearing_impaired":false,"hd":true,"fps":0.0,"votes":0,"ratings":0.0,"from_trusted":false,"foreign_parts_only":false,"upload_date":"2014-10-20T22:08:17Z","ai_translated":false,"nb_cd":1,"machine_translated":false,"release":"Enders.Game.2013.1080p.BluRay.x264-SPARKS","comments":"","legacy_subtitle_id":5864769,"legacy_uploader_id":0,"uploader":{"uploader_id":3282,"name":"os-auto","rank":"Application
-        Developers"},"feature_details":{"feature_id":586791,"feature_type":"Movie","year":2013,"title":"Ender''s
-        Game","movie_name":"2013 - Ender''s Game","imdb_id":1731141,"tmdb_id":80274},"url":"https://www.opensubtitles.com/de/subtitles/legacy/5864769","related_links":[{"label":"All
-        subtitles for ender''s game","url":"https://www.opensubtitles.com/de/movies/2013-ender-s-game","img_url":"https://s9.opensubtitles.com/features/1/9/7/586791.jpg"}],"files":[{"file_id":1024649,"cd_number":1,"file_name":"Enders.Game.2013.1080p.BluRay.x264-SPARKS"}]}},{"id":"939532","type":"subtitle","attributes":{"subtitle_id":"939532","language":"de","download_count":570,"new_download_count":21,"hearing_impaired":true,"hd":true,"fps":23.976,"votes":0,"ratings":0.0,"from_trusted":false,"foreign_parts_only":false,"upload_date":"2014-03-06T01:27:57Z","ai_translated":false,"nb_cd":1,"machine_translated":false,"release":"Enders.Game.Das.grosse.Spiel.German.720p.BluRay.x264-EXQUiSiTE","comments":"","legacy_subtitle_id":5571194,"legacy_uploader_id":0,"uploader":{"uploader_id":3282,"name":"os-auto","rank":"Application
-        Developers"},"feature_details":{"feature_id":586791,"feature_type":"Movie","year":2013,"title":"Ender''s
-        Game","movie_name":"2013 - Ender''s Game","imdb_id":1731141,"tmdb_id":80274},"url":"https://www.opensubtitles.com/de/subtitles/legacy/5571194","related_links":[{"label":"All
-        subtitles for ender''s game","url":"https://www.opensubtitles.com/de/movies/2013-ender-s-game","img_url":"https://s9.opensubtitles.com/features/1/9/7/586791.jpg"}],"files":[{"file_id":1023690,"cd_number":1,"file_name":"Enders.Game.Das.grosse.Spiel.German.720p.BluRay.x264-EXQUiSiTE"}]}}]}'
+      string: !!binary |
+        wRBoACD+t1Q7XT0vux1JfNQsbltaZYj1rTCqAzhO0/wfNpADPfMjOD46sD9ubV3b5hh0tUGWrWFh
+        FvgVUBj2IlqCJRKApUOcuxst+syk6Bpz1H+EWWzHAZrEhjZ1oB7QucDCnsIKupICn94UCbQ2Wug/
+        13AtNJq8KcscAvFyYWiEw2l0cWAI+EAGff1jGpMUy+MHjZYhoBiW5RmLoiaBiY/m10ejuhE4Y+vd
+        1Bk3LtZ5bqH3dggscNZCR39ggf0SoFWeNnUlcD5HjV/e2+imLkCTTKXA3s+jif4QYkZ32M+eXTeZ
+        xfoYzDwNlzxEh0We129tZGgoSUUi80RWX6nSeaVV/RsC1pn5LSwZbM6m6dTsWqvjvk8iEr5Xnge2
+        gaHxbGrZh/SFHTl9akPa+TkETr8sjod0cBAPkD59m5LcyiV9PBw+28v0QlVF8uznp2/ui/v6DAKB
+        8HRoQGDgzu4ujVscy7KmrVIEUEkR+5U9lVVeUqn6luyhr0F1dpUrVQhMdmRoTHycnNdjIODt1EPD
+        vNJVoC8UrhlTHggQ/DUQZmlb1Q2RouC61rv53DEELtl6aCUpF4g2ZKYT74bNCzsyBMb53LERZ3tK
+        Ur5JNmQqN7ansh9DdU5UkED89p5bqepiFTj4ARpnMS5BZ9nxeEznhSe7JYUFRyBrOTuzM+NxMmOy
+        4McDbOTWDG7qw98meG4dHaHxaBg2iZM3MyCJ1CB08RAAaGsZMiUpT3IhJiEZ48bObCqF5oEs7RUy
+        ypqszhwQPIeQXus/gb0bWHrJ3sXKWiRVXhMJ7Foz4bQAQAANMjvQxyJ0duQkMu2w/ltXARoULmSh
+        Kpw0phUZpEpVp6rcAlxAd1L5Ibb/Q5KJkl+V0nKrqZikJOXIsA++fHz0+c2XIxW2VVFXTbYSEHS5
+        2qrtZnNI7CHO27UfLcvgdja6edpMyu6Ph31AB2jT78qK7KIqmjjFaChsrD5vylxVZ4CkMa26KGu5
+        rajUFlZaxHD+cLgBz3+RJK1qXRaNrVX1xS8BNQWYQJt+Wyoz+lI1ch3vwDVb/63rvxU=
     headers:
       Access-Control-Allow-Headers:
       - Origin, Authorization, Accept, Api-Key, Content-Type, X-User-Agent
@@ -141,23 +157,23 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '0'
+      - '48856'
       CF-Cache-Status:
       - HIT
       CF-RAY:
-      - 87c7045de9f20692-LHR
+      - 883aac544d8ef170-CDG
       Cache-Control:
       - public, max-age=86400
       Connection:
       - keep-alive
       Content-Encoding:
-      - gzip
+      - br
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 30 Apr 2024 10:58:30 GMT
+      - Tue, 14 May 2024 11:50:52 GMT
       Last-Modified:
-      - Tue, 30 Apr 2024 10:58:30 GMT
+      - Mon, 13 May 2024 22:16:36 GMT
       NEL:
       - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
       RateLimit-Limit:
@@ -167,7 +183,7 @@ interactions:
       RateLimit-Reset:
       - '1'
       Report-To:
-      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=4jbhkVWWePDO7WCzJppCkKF%2BzQt0CQkH7EquzNYqVN0846s4uuOdPWTW2TJM5hMBnGD2rlKFHKeZqJUYvkRE6R%2FsSJT5eDjuVpmCHxgEUBkZ52Aq9hCSyhWqrCt1hOEZGz45czpX%2Bmw%3D"}],"group":"cf-nel","max_age":604800}'
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=uc9GaD6yFSGAJhp1pVj8vff5jYYWrx4A7iSBNfJygNqkg5xiPAhgkImclVuTk01TmwjsJTrZQAlJhl48De5gxyAns2ZGNfm4MtCnzyznp%2F%2BgCrd7PBSx9bXwDroPSkrlvvf9ZQ4SbR8%3D"}],"group":"cf-nel","max_age":604800}'
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -177,7 +193,7 @@ interactions:
       Vary:
       - Accept-Encoding
       X-Cache-Backend:
-      - apigw1_8000 rb11
+      - apigw1_8000 rb7
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -185,17 +201,19 @@ interactions:
       X-Frame-Options:
       - SAMEORIGIN
       X-Kong-Proxy-Latency:
-      - '0'
+      - '1'
       X-Kong-Upstream-Latency:
-      - '29'
+      - '309'
       X-RateLimit-Limit-Second:
       - '5'
       X-RateLimit-Remaining-Second:
       - '3'
       X-Request-Id:
-      - 998cf473-4fb0-487e-88d8-0f9e3f7e7302
+      - 2943783a-11a7-4d95-bedd-57f774054173
       X-Runtime:
-      - '0.027634'
+      - '0.051178'
+      X-StackifyID:
+      - V1|50946b4d-13e7-49be-9dec-acbede6557ed|C98087|CD1
       X-Var-Cache:
       - MISS
       X-Via:

--- a/tests/cassettes/opensubtitlescom/test_login.yaml
+++ b/tests/cassettes/opensubtitlescom/test_login.yaml
@@ -5,13 +5,13 @@ interactions:
       Accept:
       - '*/*'
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Api-Key:
       - mij33pjc3kOlup1qOKxnWWxvle2kFbMH
       Connection:
       - keep-alive
       Content-Length:
-      - '64'
+      - '69'
       Content-Type:
       - application/json
       User-Agent:
@@ -20,8 +20,13 @@ interactions:
     uri: https://api.opensubtitles.com/api/v1/login
   response:
     body:
-      string: '{"user":{"allowed_translations":1,"allowed_downloads":20,"level":"Sub
-        leecher","user_id":699022,"ext_installed":false,"vip":false},"token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPdThucThpZFIzek0wd0ttR01zSkw1U0ZTeFpCY2MydiIsImV4cCI6MTcxNDU2MTA5OH0.RWMl_Zdfw95jL7mfEijK6DHKvaD01wDvIK71O66apyE","status":200,"base_url":"api.opensubtitles.com"}'
+      string: !!binary |
+        IXQFACCXufX63uw700E0P/AG18oebOskAXeMA7dRJx1tWOxaiAaP4XNIUY5rzAe0xBvwD7CoKrqn
+        a4AusBTFkQSeZSbKWALPZRjgpEbgMNP2X4DoXPEGLHF0Ihd4qVrN5HIM8KlOFEllBQG6wP+tQCKD
+        OyX68Y+Bin2MgAO+RAbXNRqR6C2zE+o3xNXuODQiYS7eZnZIomrgSyROfkAjEnq+3r4WfjWcZtvv
+        weqqrJV7Q//5svNBOOtkMsP80No2N8UtmdIMlwWnYZYGc+c5nDuv4byVH3YzxjZe9d+nVzopDjOP
+        zVyM8FUwL+EzqelAN5evh9vOlMyx2l4mwEAqS+kROhkGtiXxpG8BcLASMuIEI6ltRSpAaThxCD8D
+        Aw==
     headers:
       Access-Control-Allow-Headers:
       - Origin, Authorization, Accept, Api-Key, Content-Type, X-User-Agent
@@ -34,17 +39,17 @@ interactions:
       CF-Cache-Status:
       - DYNAMIC
       CF-RAY:
-      - 87c7040f799c03b9-LHR
+      - 883aac28cdc1f8cd-CDG
       Cache-Control:
       - max-age=0, private, must-revalidate, s-maxage=600
       Connection:
       - keep-alive
       Content-Encoding:
-      - gzip
+      - br
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 30 Apr 2024 10:58:18 GMT
+      - Tue, 14 May 2024 11:50:46 GMT
       NEL:
       - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
       RateLimit-Limit:
@@ -54,7 +59,7 @@ interactions:
       RateLimit-Reset:
       - '1'
       Report-To:
-      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=gtIXrUazafrV3S5%2Bj7jrjkGHcbnU0555iZUb3qPEiOVBKyi%2BL7RpVZCwakFquUrt8DeiFzYKoRMisQlGECWSG4P6b9npy5wnmyAynZo%2FdJTBwxvFJZ69DSHPl%2FrcobosRi2KuEq8cko%3D"}],"group":"cf-nel","max_age":604800}'
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=WXqVo2ioDT4J%2FHup9e%2FylIC7UgkYd84A6CAFt613F7NuK%2BgIOdqmduIM1kpuqCcN4ECnecWGglUt3EUqf1fuhWVf0o7vFroZeWjgkPqLQUxeNfdmwz7BUQNKeVPxYCcrLt5B0H0T2e4%3D"}],"group":"cf-nel","max_age":604800}'
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -62,7 +67,7 @@ interactions:
       Transfer-Encoding:
       - chunked
       X-Cache-Backend:
-      - apigw1_8000 rb11
+      - apigw1_8000 rb1
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -70,9 +75,9 @@ interactions:
       X-Frame-Options:
       - SAMEORIGIN
       X-Kong-Proxy-Latency:
-      - '0'
+      - '1'
       X-Kong-Upstream-Latency:
-      - '353'
+      - '281'
       X-RateLimit-Limit-Hour:
       - '60'
       X-RateLimit-Limit-Second:
@@ -82,9 +87,11 @@ interactions:
       X-RateLimit-Remaining-Second:
       - '0'
       X-Request-Id:
-      - d0c16dbc-2280-47fa-b966-6fa5d975bc17
+      - 8d05021b-8ebd-4186-845a-1db3123fcdfe
       X-Runtime:
-      - '0.348809'
+      - '0.278494'
+      X-StackifyID:
+      - V1|a4ba9ad7-b4de-4427-b25e-2ec29a96af31|C98184|CD5
       X-Var-Cache:
       - MISS
       X-Via:

--- a/tests/cassettes/opensubtitlescom/test_login_bad_password.yaml
+++ b/tests/cassettes/opensubtitlescom/test_login_bad_password.yaml
@@ -5,7 +5,7 @@ interactions:
       Accept:
       - '*/*'
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Api-Key:
       - mij33pjc3kOlup1qOKxnWWxvle2kFbMH
       Connection:
@@ -20,7 +20,8 @@ interactions:
     uri: https://api.opensubtitles.com/api/v1/login
   response:
     body:
-      string: '{"message":"Error, invalid username/password failed:1 remaining:9  ","status":401}'
+      string: '{"message":"Error, invalid username/password failed:0 remaining:10
+        - this password was already tried in the past 24 hours ","status":401}'
     headers:
       Access-Control-Allow-Headers:
       - Origin, Authorization, Accept, Api-Key, Content-Type, X-User-Agent
@@ -33,17 +34,17 @@ interactions:
       CF-Cache-Status:
       - DYNAMIC
       CF-RAY:
-      - 87c70419fcd73d88-LHR
+      - 883aac320c07f0d3-CDG
       Cache-Control:
       - max-age=0, private, must-revalidate, s-maxage=600
       Connection:
       - keep-alive
       Content-Length:
-      - '82'
+      - '137'
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 30 Apr 2024 10:58:20 GMT
+      - Tue, 14 May 2024 11:50:47 GMT
       NEL:
       - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
       RateLimit-Limit:
@@ -53,13 +54,13 @@ interactions:
       RateLimit-Reset:
       - '1'
       Report-To:
-      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=sjkNnNtMyvd0hMr1AkFPMUCtZST2TITG8uexVcw9BlicMkDYtzEazNR9OwoHN%2BFjCuzZNIPQdplZ2TswUykfWhL33GZu2DNTUXb0WvneIX%2BNS8ErRAphJGM0OX%2B%2FBVEYQiESt5dYMAQ%3D"}],"group":"cf-nel","max_age":604800}'
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=qIJjrKx7dRU%2FmUq%2BdrNjY0vJr5ykY6x1j%2BGvkCb3ad3nv9ymcWCK%2BkJqs%2F%2BPdZu%2BOQ2zP7%2BOK35l0wnI%2BTrbh7PEAZh24TGGd8pFeaM5WIc%2FNk28T53MfbMVWz39jjAhRAOrGgEHZI4%3D"}],"group":"cf-nel","max_age":604800}'
       Server:
       - cloudflare
       Strict-Transport-Security:
       - max-age=15552000; includeSubDomains; preload
       X-Cache-Backend:
-      - apigw1_8000 rb11
+      - apigw1_8000 rb8
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -67,9 +68,9 @@ interactions:
       X-Frame-Options:
       - SAMEORIGIN
       X-Kong-Proxy-Latency:
-      - '1'
+      - '0'
       X-Kong-Upstream-Latency:
-      - '278'
+      - '272'
       X-RateLimit-Limit-Hour:
       - '60'
       X-RateLimit-Limit-Second:
@@ -79,9 +80,11 @@ interactions:
       X-RateLimit-Remaining-Second:
       - '0'
       X-Request-Id:
-      - f352b4eb-7a4f-44d0-a6c9-a8a48e60782f
+      - 354850ee-d6ee-4397-aa33-f61a55ed55c0
       X-Runtime:
-      - '0.275053'
+      - '0.269846'
+      X-StackifyID:
+      - V1|85e0e9ba-d260-48ca-b3eb-6b1adf6d0b0e|C98087|CD1
       X-Var-Cache:
       - MISS
       X-Via:

--- a/tests/cassettes/opensubtitlescom/test_logout.yaml
+++ b/tests/cassettes/opensubtitlescom/test_logout.yaml
@@ -5,13 +5,13 @@ interactions:
       Accept:
       - '*/*'
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Api-Key:
       - mij33pjc3kOlup1qOKxnWWxvle2kFbMH
       Connection:
       - keep-alive
       Content-Length:
-      - '64'
+      - '69'
       Content-Type:
       - application/json
       User-Agent:
@@ -20,8 +20,13 @@ interactions:
     uri: https://api.opensubtitles.com/api/v1/login
   response:
     body:
-      string: '{"user":{"allowed_translations":1,"allowed_downloads":20,"level":"Sub
-        leecher","user_id":699022,"ext_installed":false,"vip":false},"token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPdThucThpZFIzek0wd0ttR01zSkw1U0ZTeFpCY2MydiIsImV4cCI6MTcxNDU2MTA5OH0.RWMl_Zdfw95jL7mfEijK6DHKvaD01wDvIK71O66apyE","status":200,"base_url":"api.opensubtitles.com"}'
+      string: !!binary |
+        IXQFACCXufX63uw700E0P/AG18oebOskAXeMA7dRJx1tWOxaiAaP4XNIUY5rzAe0xBvwD7CoKrqn
+        a4AusBTFkQSeZSbKWALPZRjgpEbgMNP2X4DoXPEGLHF0Ihd4qVrN5HIM8KlOFEllBQG6wP+tQCKD
+        OyX68Y+Bin2MgAO+RAbXNRqR6C2zE+o3xNXuODQiYS7eZnZIomrgSyROfkAjEnq+3r4WfjWcZtvv
+        weqqrJV7Q//5svNBOOtkMsP80No2N8UtmdIMlwWnYZYGc+c5nDuv4byVH3YzxjZe9d+nVzopDjOP
+        zVyM8FUwL+EzqelAN5evh9vOlMyx2l4mwEAqS+kROhkGtiXxpG8BcLASMuIEI6ltRSpAaThxCD8D
+        Aw==
     headers:
       Access-Control-Allow-Headers:
       - Origin, Authorization, Accept, Api-Key, Content-Type, X-User-Agent
@@ -34,17 +39,17 @@ interactions:
       CF-Cache-Status:
       - DYNAMIC
       CF-RAY:
-      - 87c704248ef2776c-LHR
+      - 883aac3b5a1b3cc2-CDG
       Cache-Control:
       - max-age=0, private, must-revalidate, s-maxage=600
       Connection:
       - keep-alive
       Content-Encoding:
-      - gzip
+      - br
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 30 Apr 2024 10:58:21 GMT
+      - Tue, 14 May 2024 11:50:49 GMT
       NEL:
       - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
       RateLimit-Limit:
@@ -54,7 +59,7 @@ interactions:
       RateLimit-Reset:
       - '1'
       Report-To:
-      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=pMciJfEElB0I52cd3EWJG%2BbyXLHrB8X%2FznPTzT0L3PHMMIwzir2Q1lVZXqAYo%2BdI%2FEw05IJj1iHvcJq7lyTbi63uGT4QvAxlX6Hh5fBr0PoXtCd7LWxs%2FQMmJhXCvQgoa3VaKpIjvyE%3D"}],"group":"cf-nel","max_age":604800}'
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=JsQ8DgYqEeYO9UiVzVGOx9%2BSivWuCdvv%2Bou9sX4jkuVAm6fuE%2F9fVHPoRdxv7edVVD9h70nN%2BTgJZpuk8psLtKUnTrSh3I%2FgFOPF6IRvlwn3LrgIrTExaL6arpnS%2F%2FcTUfwr9chn6LE%3D"}],"group":"cf-nel","max_age":604800}'
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -62,7 +67,7 @@ interactions:
       Transfer-Encoding:
       - chunked
       X-Cache-Backend:
-      - apigw1_8000 rb11
+      - apigw1_8000 rb7
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -70,9 +75,9 @@ interactions:
       X-Frame-Options:
       - SAMEORIGIN
       X-Kong-Proxy-Latency:
-      - '0'
+      - '1'
       X-Kong-Upstream-Latency:
-      - '340'
+      - '270'
       X-RateLimit-Limit-Hour:
       - '60'
       X-RateLimit-Limit-Second:
@@ -82,113 +87,15 @@ interactions:
       X-RateLimit-Remaining-Second:
       - '0'
       X-Request-Id:
-      - f954af7e-20c9-4bde-8089-8048a53375fd
+      - d6b9c713-a4ea-4c6c-b712-f8774d6f5855
       X-Runtime:
-      - '0.337885'
+      - '0.268172'
+      X-StackifyID:
+      - V1|2e604e90-9ffa-4ecf-b107-f235c872ae20|C98087|CD1
       X-Var-Cache:
       - MISS
       X-Via:
       - fw1
-      X-Vip-Consumer:
-      - 'false'
-      X-Vip-User:
-      - 'false'
-      X-XSS-Protection:
-      - 1; mode=block
-      alt-svc:
-      - h3=":443"; ma=86400
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Api-Key:
-      - mij33pjc3kOlup1qOKxnWWxvle2kFbMH
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJPdThucThpZFIzek0wd0ttR01zSkw1U0ZTeFpCY2MydiIsImV4cCI6MTcxNDU2MTA5OH0.RWMl_Zdfw95jL7mfEijK6DHKvaD01wDvIK71O66apyE
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Subliminal v2.1
-    method: DELETE
-    uri: https://api.opensubtitles.com/api/v1/logout
-  response:
-    body:
-      string: '{"message":"token successfully destroyed","status":200}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Origin, Authorization, Accept, Api-Key, Content-Type, X-User-Agent
-      Access-Control-Allow-Methods:
-      - GET, HEAD, POST, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Age:
-      - '0'
-      CF-Cache-Status:
-      - DYNAMIC
-      CF-RAY:
-      - 87c704287df248cb-LHR
-      Cache-Control:
-      - max-age=0, private, must-revalidate, s-maxage=600
-      Connection:
-      - keep-alive
-      Content-Encoding:
-      - gzip
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Tue, 30 Apr 2024 10:58:22 GMT
-      NEL:
-      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
-      RateLimit-Limit:
-      - '5'
-      RateLimit-Remaining:
-      - '4'
-      RateLimit-Reset:
-      - '1'
-      Report-To:
-      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=bLkZnL2b7rBeqpbH4wMewMbFIDsOizwKm4VoIfeaNmTxpCe9%2F%2B6crtRBDetuF1jAGLyOIZd6ta8S3iJ2J15GBCltWVk1c1%2FsOf6mI%2BMQeQbW0jl3wI%2F%2Fjqf3X9sXw6M9t0jnZ8Ttx%2Fg%3D"}],"group":"cf-nel","max_age":604800}'
-      Server:
-      - cloudflare
-      Strict-Transport-Security:
-      - max-age=15552000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      X-Cache-Backend:
-      - apigw1_8000 rb1-temp
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Kong-Proxy-Latency:
-      - '0'
-      X-Kong-Upstream-Latency:
-      - '72'
-      X-RateLimit-Limit-Second:
-      - '5'
-      X-RateLimit-Remaining-Second:
-      - '4'
-      X-Request-Id:
-      - a4c25696-158c-4c9c-a98e-2f56be890f6c
-      X-Runtime:
-      - '0.068948'
-      X-Var-Cache:
-      - MISS
-      X-Via:
-      - fw1
-      X-Vip:
-      - 'false'
       X-Vip-Consumer:
       - 'false'
       X-Vip-User:

--- a/tests/cassettes/opensubtitlescom/test_query_hash_size.yaml
+++ b/tests/cassettes/opensubtitlescom/test_query_hash_size.yaml
@@ -5,7 +5,7 @@ interactions:
       Accept:
       - '*/*'
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Api-Key:
       - mij33pjc3kOlup1qOKxnWWxvle2kFbMH
       Connection:
@@ -18,58 +18,43 @@ interactions:
     uri: https://api.opensubtitles.com/api/v1/subtitles?languages=en&moviehash=5b8f8f4e41ccb21e
   response:
     body:
-      string: '{"total_pages":1,"total_count":12,"per_page":60,"page":1,"data":[{"id":"876180","type":"subtitle","attributes":{"subtitle_id":"876180","language":"en","download_count":380547,"new_download_count":5603,"hearing_impaired":false,"hd":true,"fps":23.976,"votes":3,"ratings":10.0,"from_trusted":true,"foreign_parts_only":false,"upload_date":"2013-10-16T00:37:02Z","ai_translated":false,"nb_cd":1,"machine_translated":false,"release":"720p.BluRay.x264-Felony
-        [and BDRiP.XViD-NoGRP]","comments":"Fix OCR, italics, overlapping, etc...
-        for all 720p/1080p BluRay","legacy_subtitle_id":5225493,"legacy_uploader_id":847082,"uploader":{"uploader_id":48068,"name":"cipry_master","rank":"Trusted
-        member"},"feature_details":{"feature_id":580760,"feature_type":"Movie","year":2013,"title":"Man
-        of Steel","movie_name":"2013 - Man of Steel","imdb_id":770828,"tmdb_id":49521},"url":"https://www.opensubtitles.com/en/subtitles/legacy/5225493","related_links":[{"label":"All
-        subtitles for man of steel","url":"https://www.opensubtitles.com/en/movies/2013-man-of-steel","img_url":"https://s9.opensubtitles.com/features/0/6/7/580760.jpg"}],"files":[{"file_id":957714,"cd_number":1,"file_name":"Man.Of.Steel.2013.720p.BluRay.x264-Felony"}],"moviehash_match":true}},{"id":"3178800","type":"subtitle","attributes":{"subtitle_id":"3178800","language":"en","download_count":210404,"new_download_count":839,"hearing_impaired":false,"hd":true,"fps":23.976,"votes":2,"ratings":10.0,"from_trusted":true,"foreign_parts_only":false,"upload_date":"2013-11-07T04:48:10Z","ai_translated":false,"nb_cd":1,"machine_translated":false,"release":"Arrow.S02E05.HDTV.x264-LOL","comments":"sync,
-        corrected by elderman","legacy_subtitle_id":5259348,"legacy_uploader_id":1332962,"uploader":{"uploader_id":56900,"name":"elderman","rank":"translator"},"feature_details":{"feature_id":348318,"feature_type":"Episode","year":2013,"title":"League
-        of Assassins","movie_name":"Arrow - S02E05  League of Assassins","imdb_id":3128398,"tmdb_id":64139,"season_number":2,"episode_number":5,"parent_imdb_id":2193021,"parent_title":"Arrow","parent_tmdb_id":1412,"parent_feature_id":12491},"url":"https://www.opensubtitles.com/en/subtitles/legacy/5259348","related_links":[{"label":"All
-        subtitles for Tv Show Arrow","url":"https://www.opensubtitles.com/en/features/redirect/12491","img_url":"https://s9.opensubtitles.com/features/8/1/3/348318.jpg"},{"label":"All
-        subtitles for Episode league of assassins","url":"https://www.opensubtitles.com/en/features/redirect/348318"}],"files":[{"file_id":3249003,"cd_number":1,"file_name":"Arrow.S02E05.HDTV.x264-LOL"}],"moviehash_match":true}},{"id":"872093","type":"subtitle","attributes":{"subtitle_id":"872093","language":"en","download_count":145094,"new_download_count":705,"hearing_impaired":false,"hd":true,"fps":23.976,"votes":0,"ratings":0.0,"from_trusted":false,"foreign_parts_only":false,"upload_date":"2013-10-15T19:02:17Z","ai_translated":false,"nb_cd":1,"machine_translated":false,"release":"Man
-        Of Steel 2013 BDRip.x264-Larceny","comments":"","legacy_subtitle_id":5224905,"legacy_uploader_id":2020399,"uploader":{"uploader_id":67314,"name":"felixmartini","rank":"Bronze
-        Member"},"feature_details":{"feature_id":580760,"feature_type":"Movie","year":2013,"title":"Man
-        of Steel","movie_name":"2013 - Man of Steel","imdb_id":770828,"tmdb_id":49521},"url":"https://www.opensubtitles.com/en/subtitles/legacy/5224905","related_links":[{"label":"All
-        subtitles for man of steel","url":"https://www.opensubtitles.com/en/movies/2013-man-of-steel","img_url":"https://s9.opensubtitles.com/features/0/6/7/580760.jpg"}],"files":[{"file_id":953341,"cd_number":1,"file_name":"Man
-        Of Steel 2013 BDRip.x264-Larceny"}],"moviehash_match":true}},{"id":"869742","type":"subtitle","attributes":{"subtitle_id":"869742","language":"en","download_count":104307,"new_download_count":233,"hearing_impaired":false,"hd":false,"fps":29.97,"votes":1,"ratings":10.0,"from_trusted":false,"foreign_parts_only":false,"upload_date":"2013-07-09T13:03:41Z","ai_translated":false,"nb_cd":1,"machine_translated":false,"release":"Man.of.Steel.2013.R6.LiNE.All.Version","comments":"Total
-        98% Improved,Re-Synced,Spell Checked,Few Lines Added. Specially Thanks to
-        \"tinotpoldas\" \u0026 \"tosem\" .","legacy_subtitle_id":5079931,"legacy_uploader_id":1629008,"uploader":{"uploader_id":64860,"name":"igorrml_","rank":"Gold
-        member"},"feature_details":{"feature_id":580760,"feature_type":"Movie","year":2013,"title":"Man
-        of Steel","movie_name":"2013 - Man of Steel","imdb_id":770828,"tmdb_id":49521},"url":"https://www.opensubtitles.com/en/subtitles/legacy/5079931","related_links":[{"label":"All
-        subtitles for man of steel","url":"https://www.opensubtitles.com/en/movies/2013-man-of-steel","img_url":"https://s9.opensubtitles.com/features/0/6/7/580760.jpg"}],"files":[{"file_id":950892,"cd_number":1,"file_name":"Man.of.Steel.2013.R6.LiNE.All.Version"}],"moviehash_match":true}},{"id":"879204","type":"subtitle","attributes":{"subtitle_id":"879204","language":"en","download_count":56283,"new_download_count":248,"hearing_impaired":false,"hd":true,"fps":23.976,"votes":0,"ratings":0.0,"from_trusted":false,"foreign_parts_only":false,"upload_date":"2013-10-16T17:30:21Z","ai_translated":false,"nb_cd":1,"machine_translated":false,"release":"Man.Of.Steel.2013.720p.BluRay.x264-Felony","comments":"","legacy_subtitle_id":5226279,"legacy_uploader_id":338814,"uploader":{"uploader_id":39690,"name":"Babylonian","rank":"Silver
-        Member"},"feature_details":{"feature_id":580760,"feature_type":"Movie","year":2013,"title":"Man
-        of Steel","movie_name":"2013 - Man of Steel","imdb_id":770828,"tmdb_id":49521},"url":"https://www.opensubtitles.com/en/subtitles/legacy/5226279","related_links":[{"label":"All
-        subtitles for man of steel","url":"https://www.opensubtitles.com/en/movies/2013-man-of-steel","img_url":"https://s9.opensubtitles.com/features/0/6/7/580760.jpg"}],"files":[{"file_id":960768,"cd_number":1,"file_name":"Man.Of.Steel.2013.720p.BluRay.x264-Felony.English"}],"moviehash_match":true}},{"id":"877471","type":"subtitle","attributes":{"subtitle_id":"877471","language":"en","download_count":40570,"new_download_count":227,"hearing_impaired":false,"hd":true,"fps":23.976,"votes":0,"ratings":0.0,"from_trusted":false,"foreign_parts_only":false,"upload_date":"2013-10-16T08:26:55Z","ai_translated":false,"nb_cd":1,"machine_translated":false,"release":"Man
-        Of Steel 2013 - Bluray","comments":"","legacy_subtitle_id":5225826,"legacy_uploader_id":1534270,"uploader":{"uploader_id":62354,"name":"racunz2012","rank":"Gold
-        member"},"feature_details":{"feature_id":580760,"feature_type":"Movie","year":2013,"title":"Man
-        of Steel","movie_name":"2013 - Man of Steel","imdb_id":770828,"tmdb_id":49521},"url":"https://www.opensubtitles.com/en/subtitles/legacy/5225826","related_links":[{"label":"All
-        subtitles for man of steel","url":"https://www.opensubtitles.com/en/movies/2013-man-of-steel","img_url":"https://s9.opensubtitles.com/features/0/6/7/580760.jpg"}],"files":[{"file_id":959001,"cd_number":1,"file_name":"Man
-        Of Steel 2013 - Bluray.EN"}],"moviehash_match":true}},{"id":"876365","type":"subtitle","attributes":{"subtitle_id":"876365","language":"en","download_count":37923,"new_download_count":62,"hearing_impaired":true,"hd":true,"fps":23.976,"votes":0,"ratings":0.0,"from_trusted":true,"foreign_parts_only":false,"upload_date":"2013-10-16T00:37:20Z","ai_translated":false,"nb_cd":1,"machine_translated":false,"release":"720p.BluRay.x264-Felony
-        (COLOR Hearing Impaired)","comments":"Fix OCR, italics, overlapping, etc...
-        for all 720p/1080p BluRay","legacy_subtitle_id":5225494,"legacy_uploader_id":847082,"uploader":{"uploader_id":48068,"name":"cipry_master","rank":"Trusted
-        member"},"feature_details":{"feature_id":580760,"feature_type":"Movie","year":2013,"title":"Man
-        of Steel","movie_name":"2013 - Man of Steel","imdb_id":770828,"tmdb_id":49521},"url":"https://www.opensubtitles.com/en/subtitles/legacy/5225494","related_links":[{"label":"All
-        subtitles for man of steel","url":"https://www.opensubtitles.com/en/movies/2013-man-of-steel","img_url":"https://s9.opensubtitles.com/features/0/6/7/580760.jpg"}],"files":[{"file_id":957845,"cd_number":1,"file_name":"Man.Of.Steel.2013.720p.BluRay.x264-Felony"}],"moviehash_match":true}},{"id":"871951","type":"subtitle","attributes":{"subtitle_id":"871951","language":"en","download_count":22941,"new_download_count":112,"hearing_impaired":true,"hd":true,"fps":23.976,"votes":0,"ratings":0.0,"from_trusted":false,"foreign_parts_only":false,"upload_date":"2013-10-15T19:01:42Z","ai_translated":false,"nb_cd":1,"machine_translated":false,"release":"Man
-        Of Steel 2013 BDRip.x264-Larceny","comments":"","legacy_subtitle_id":5224904,"legacy_uploader_id":0,"uploader":{"uploader_id":3282,"name":"os-auto","rank":"Application
-        Developers"},"feature_details":{"feature_id":580760,"feature_type":"Movie","year":2013,"title":"Man
-        of Steel","movie_name":"2013 - Man of Steel","imdb_id":770828,"tmdb_id":49521},"url":"https://www.opensubtitles.com/en/subtitles/legacy/5224904","related_links":[{"label":"All
-        subtitles for man of steel","url":"https://www.opensubtitles.com/en/movies/2013-man-of-steel","img_url":"https://s9.opensubtitles.com/features/0/6/7/580760.jpg"}],"files":[{"file_id":953193,"cd_number":1,"file_name":"Man
-        Of Steel 2013 BDRip.x264-Larceny.Hi"}],"moviehash_match":true}},{"id":"874537","type":"subtitle","attributes":{"subtitle_id":"874537","language":"en","download_count":14558,"new_download_count":84,"hearing_impaired":false,"hd":true,"fps":0.0,"votes":0,"ratings":0.0,"from_trusted":false,"foreign_parts_only":false,"upload_date":"2013-10-15T23:33:54Z","ai_translated":false,"nb_cd":1,"machine_translated":false,"release":"Man.Of.Steel.2013.720p.BRRip.x264.AC3-UNDERCOVER","comments":"","legacy_subtitle_id":5225363,"legacy_uploader_id":1447693,"uploader":{"uploader_id":59646,"name":"Neomale","rank":"Read
-        Only Member"},"feature_details":{"feature_id":580760,"feature_type":"Movie","year":2013,"title":"Man
-        of Steel","movie_name":"2013 - Man of Steel","imdb_id":770828,"tmdb_id":49521},"url":"https://www.opensubtitles.com/en/subtitles/legacy/5225363","related_links":[{"label":"All
-        subtitles for man of steel","url":"https://www.opensubtitles.com/en/movies/2013-man-of-steel","img_url":"https://s9.opensubtitles.com/features/0/6/7/580760.jpg"}],"files":[{"file_id":955964,"cd_number":1,"file_name":"Man.Of.Steel.2013.720p.BRRip.x264.AC3-UNDERCOVER_eng"}],"moviehash_match":true}},{"id":"873226","type":"subtitle","attributes":{"subtitle_id":"873226","language":"en","download_count":12299,"new_download_count":32,"hearing_impaired":true,"hd":true,"fps":0.0,"votes":0,"ratings":0.0,"from_trusted":false,"foreign_parts_only":false,"upload_date":"2013-10-15T20:22:10Z","ai_translated":false,"nb_cd":1,"machine_translated":false,"release":"Man.Of.Steel.2013.BDRip.x264-Larceny[rarbg]","comments":"","legacy_subtitle_id":5225027,"legacy_uploader_id":121929,"uploader":{"uploader_id":35815,"name":"untukforum","rank":"Gold
-        member"},"feature_details":{"feature_id":580760,"feature_type":"Movie","year":2013,"title":"Man
-        of Steel","movie_name":"2013 - Man of Steel","imdb_id":770828,"tmdb_id":49521},"url":"https://www.opensubtitles.com/en/subtitles/legacy/5225027","related_links":[{"label":"All
-        subtitles for man of steel","url":"https://www.opensubtitles.com/en/movies/2013-man-of-steel","img_url":"https://s9.opensubtitles.com/features/0/6/7/580760.jpg"}],"files":[{"file_id":954566,"cd_number":1,"file_name":"l-manofsteel"}],"moviehash_match":true}},{"id":"882182","type":"subtitle","attributes":{"subtitle_id":"882182","language":"en","download_count":10566,"new_download_count":32,"hearing_impaired":false,"hd":true,"fps":23.98,"votes":0,"ratings":0.0,"from_trusted":false,"foreign_parts_only":false,"upload_date":"2013-10-28T01:20:44Z","ai_translated":false,"nb_cd":1,"machine_translated":false,"release":"Man
-        of Steel 2013 BRRip XvidHD 720p-NPW","comments":"","legacy_subtitle_id":5244413,"legacy_uploader_id":429031,"uploader":{"uploader_id":41158,"name":"willygeerts","rank":"VIP
-        Member"},"feature_details":{"feature_id":580760,"feature_type":"Movie","year":2013,"title":"Man
-        of Steel","movie_name":"2013 - Man of Steel","imdb_id":770828,"tmdb_id":49521},"url":"https://www.opensubtitles.com/en/subtitles/legacy/5244413","related_links":[{"label":"All
-        subtitles for man of steel","url":"https://www.opensubtitles.com/en/movies/2013-man-of-steel","img_url":"https://s9.opensubtitles.com/features/0/6/7/580760.jpg"}],"files":[{"file_id":963880,"cd_number":1,"file_name":"Man
-        of Steel 2013 BRRip XvidHD 720p-NPW"}],"moviehash_match":true}},{"id":"877376","type":"subtitle","attributes":{"subtitle_id":"877376","language":"en","download_count":9410,"new_download_count":15,"hearing_impaired":false,"hd":true,"fps":0.0,"votes":0,"ratings":0.0,"from_trusted":false,"foreign_parts_only":false,"upload_date":"2013-10-16T06:52:41Z","ai_translated":false,"nb_cd":1,"machine_translated":false,"release":"ManOf.Steel.(2013).BDRip.600MB.Ganool","comments":"","legacy_subtitle_id":5225752,"legacy_uploader_id":1548471,"uploader":{"uploader_id":62760,"name":"Drigerray","rank":"Bronze
-        Member"},"feature_details":{"feature_id":580760,"feature_type":"Movie","year":2013,"title":"Man
-        of Steel","movie_name":"2013 - Man of Steel","imdb_id":770828,"tmdb_id":49521},"url":"https://www.opensubtitles.com/en/subtitles/legacy/5225752","related_links":[{"label":"All
-        subtitles for man of steel","url":"https://www.opensubtitles.com/en/movies/2013-man-of-steel","img_url":"https://s9.opensubtitles.com/features/0/6/7/580760.jpg"}],"files":[{"file_id":958900,"cd_number":1,"file_name":"ManOf.Steel.(2013).BDRip.600MB.Ganool"}],"moviehash_match":true}}]}'
+      string: !!binary |
+        E6M1AORvr9r/1y9zbn8Py4dS/1Labnd8S9UQCztMEGiQnKy3/Pz+vkKaOCX/UoedSGK/99yh8N65
+        Ay/It8pG3TRtEfI6iXFTAJCkUKReQBXZ7O5CoRPyTLi1+wK/qH8u/RQOcQbP6Nzp24GWBc84hSm2
+        TvKB10jh3nHFKAxhCeD//gJpAA/WaGYRKCynKYKH+fiwpCVHoBAJUeC/PNlIr8oMqgQeYgEKPmPG
+        bFVhUUlDocSX/vn1piwihccYWiqHPo1TSC0O4Pchz5HC4wB+acdIYT/N4LnonNEUnqtVx0ZQaGFJ
+        5TCDZ9ghhX2rY7+047xE7eXXFtOh9FNoy9zXkk+D8DtO9hz7ISwRPHBkYsVwxfQW0Qvjkf8FFELq
+        f3Jhrzks1qWVh343BDybAEWww03ZYo5hjuDBcJy683zchFP3iWu5uo65lhP5O5SBnF9u0ofuj9/S
+        5epdvdl8+BcoxPs8wcN1+kTeX2wo+USCztzNlNTn2HKYplQOlMRl13Ud2ddGQs7EcJzWDC1OZJhb
+        CBRyPITdqY/DoopzJZ3ogIaHX2yukJUGLQ+kycYG/gt01DnSorYUShgjeNilqZ36McxLbEChhfIE
+        HrZxUY98F9ZE+EZh6hXP/hP2SLpiDxOzRrFoNHYKaXKN3tbnFIHCKYYGniMTFBLp2np4Gwqpe3K/
+        xJiBwlifU+wtmzKOTJAV6SwujcPDECsbg5ZbCsuD6yid4uwbhWPL4OFxWabZr9cvLy9dnWIJwHrz
+        /00QFcvaua9D0WMdqm4Q97MJSxz6nMrTPLJV/5GPRcHDWc6kbyTe3EdfyM08DCCe9ZvXybbwGMqq
+        7ld9GUIaD32fuja7BQR+uXmNa7026231HxZZ7tu/FPYpR+sD9inRbI5TxjBJYTf0X7eWwA7pBJJC
+        3rehdO/3XWhL0nFkokv6ZDAkvubwGObHfgzL7nFkj/j2jSLTdCyYsRaX1XRRe1vgDCXKgWO1Wlxx
+        XL4/2ArNFqWX1jOUJZ+1Vl+6e+RXqLrby+1vMdWHN+/fwNBk51PZUfLp5rvcbokDeTiRmIfYxlAg
+        xhTKCWklZkJwp5cypR1i9eEBvjCftbhii7WFtIJZia6mNNdhfSC+ieFwjKTuydk8h3lOZQYZEoLh
+        ZEXW3UCImhPoTEYwboVbzl9LJhyFOYa5ljErnlOI5jk9PB9FYQotlqXvY1HOnEDOnmS2E8PqwVPM
+        Aj8mSQFVqBFCI5Fx6aCPxDZPV2n7TO4f6wsxmYcFMB9kXrf4zZvd1l7gDX357JqtxTp5UNdsajMk
+        mCCS41lhqBsfUBtEwa7UgkuHKJbNPBuLsUAbZw3HVy2u9A9UUTBrGiYVOt0xwilEoQUAImf2952h
+        tsx55J4ZyXgbCnlPQdwILck4v9ykKaqmILRdLCfAFYeqpuDSobJdjhyFczJtBJObtY85fRpDW1JJ
+        yPoN6bzV8jmSt6TtFUU6VGIcISRDpk80lJizdkZypopzw4JSYC6yf7jUDugR3Se5zhm2phrGtPnN
+        /mPQrNBtmfAovGTSsasE+0DY6O5NenfVneXc/RbbnGrZn4Da1iVk4uwP5G6cWn2OA93E1f2p7OJA
+        76eYM7l4jLunONDr+ELepBJncjYMcejI/RR3KeR8ItvHUJ5mslTyDyyp1GWqeQjzP0D+OSJyTf6B
+        pc5x/AdIRwhtBY1zgtmq5g7R6tHSakfSobY25v5R6abmnCYNz/MU4DIOWsexIwN6b87GcZRMFUWA
+        xkVpbgVw3VuU3X2O9JYZL9DzHYdCAR4kyAiaGyepENYyCSR6hNNuFufh4ZRrSfnKd0z3KT/HxoBe
+        TTQ3Tia+RqNtkVWD7s884QAsJm2kYaCKcqaRqAxec4R8ZtB6rr1SUhtxnX5W5DwfW0ASIyjLtbRM
+        CckNLgfRXKis1C9kLeyO5TNHxhkJDdHzlGyUTjpEliIHQHf1DjRMWgutQBXFRIwijONN69wTLXmp
+        O8gAZe47Uvl2Z3OUcj9fvH/zfkNug0Ce3DXyCxs5Y6vfbixIuV6R8mBYqWSCW8Oc4jGgioIlU3Du
+        JLsfGXPLNtnTGFou/FJiXnIRgyaiqUyS4JZXsU2qzqtwXGpuaLPPpimnXVhSLeSnqjz6xDYzmkcV
+        6RBKRqBgTjiBxDkAutvEbUxaKmFAFVcuPAxSKVvC0oOsXhAGc2ajyGeGCy+EV1KE86+emxjbk3Rn
+        F2L167vLq83F+9+uNoUs/aKEbhYkLZPSaCdwJUs5LfUy7V2sY6gGgJLab02bGAbyvuRTKcujihK6
+        UZDOK6dFpdQR0MdyyDf5CZ7x5IovoIqrcxoGzp2b9Rgh8k1nw+65Qc95uyCBiBN4HZh+/m6hPRz+
+        RRatIDfDzJnjVdcyoSxTv6gdy3J82td2HMtcHlGQGzGyVFrnz6sxlLrHN3QRy4i2nNnqaaaKdMRo
+        Ybjg2Yzwirbn7xxut8g8Ry/JiFM2H1jjEcVmkybyx3Mabi+J4Tit3n34HS2GRUrJmiXbsuQOBVPD
+        mNqcl5Tz6RBjW2Ya8qj0292HKh4SoOcpzjjCWsSnTjzn0HEjDKiigKRfnGT1OtcSlp15Pektaq94
+        4xYnnljgZ45M/EI6djoa8e15dxNKrZltaMUoPs5KWmlApFfNTVOTfJctHWKrWYL5eVYTuVcUZRQX
+        N9vOXDyKYFOn2IPvv98A
     headers:
       Access-Control-Allow-Headers:
       - Origin, Authorization, Accept, Api-Key, Content-Type, X-User-Agent
@@ -77,32 +62,34 @@ interactions:
       - GET, HEAD, POST, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
+      Age:
+      - '48859'
       CF-Cache-Status:
-      - MISS
+      - HIT
       CF-RAY:
-      - 87c704470ba43d9a-LHR
+      - 883aac4e5f943c98-CDG
       Cache-Control:
       - public, max-age=86400
       Connection:
       - keep-alive
       Content-Encoding:
-      - gzip
+      - br
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 30 Apr 2024 10:58:27 GMT
+      - Tue, 14 May 2024 11:50:51 GMT
       Last-Modified:
-      - Tue, 30 Apr 2024 10:58:27 GMT
+      - Mon, 13 May 2024 22:16:32 GMT
       NEL:
       - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
       RateLimit-Limit:
       - '5'
       RateLimit-Remaining:
-      - '4'
+      - '3'
       RateLimit-Reset:
       - '1'
       Report-To:
-      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=ejLHso5ccpfjgD5eAQQHMLK0Ow0c1JRAdh8HsS30r1jPxRanmsyZEDl9M6y4HI0osBpPnCe%2Fw5u2dZnvkzWsUqWJs%2F0WxOCHk8lCkDyEEI7%2BQDH3utTh%2FNHYcrCGBdN41HZLJvLB1bY%3D"}],"group":"cf-nel","max_age":604800}'
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=3ks8EAYGCOP6KG0Ptp6P3k3vMWwnpeayvAK5tCxkExxjLnf0kQWw28SCRvOKlHsoG%2FjNrmq3P0G4jWN3EfKKjZx4kwUNOHKMJXv%2FCoGXtCOnt6YPXrzl%2B%2BSs%2Fcu%2FHnG2xtk1Baug9MM%3D"}],"group":"cf-nel","max_age":604800}'
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -112,7 +99,7 @@ interactions:
       Vary:
       - Accept-Encoding
       X-Cache-Backend:
-      - apigw1_8000 rb1
+      - apigw1_8000 rb7
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -120,19 +107,19 @@ interactions:
       X-Frame-Options:
       - SAMEORIGIN
       X-Kong-Proxy-Latency:
-      - '1'
+      - '0'
       X-Kong-Upstream-Latency:
-      - '60'
+      - '367'
       X-RateLimit-Limit-Second:
       - '5'
       X-RateLimit-Remaining-Second:
-      - '4'
+      - '3'
       X-Request-Id:
-      - df3a3099-da73-4321-85f1-04014dd9cc16
+      - 32ef2052-8163-4051-8e8d-bf6a84a600e7
       X-Runtime:
-      - '0.052825'
+      - '0.077865'
       X-StackifyID:
-      - V1|06493527-0c54-4c80-8985-5655283f0109|C98184|CD5
+      - V1|d0743b1d-1840-4f11-9278-d860964753d1|C98087|CD1
       X-Var-Cache:
       - MISS
       X-Via:
@@ -156,7 +143,7 @@ interactions:
       Accept:
       - '*/*'
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Api-Key:
       - mij33pjc3kOlup1qOKxnWWxvle2kFbMH
       Connection:
@@ -169,58 +156,43 @@ interactions:
     uri: https://api.opensubtitles.com/api/v1/subtitles?languages=en&moviehash=5b8f8f4e41ccb21e
   response:
     body:
-      string: '{"total_pages":1,"total_count":12,"per_page":60,"page":1,"data":[{"id":"876180","type":"subtitle","attributes":{"subtitle_id":"876180","language":"en","download_count":380547,"new_download_count":5603,"hearing_impaired":false,"hd":true,"fps":23.976,"votes":3,"ratings":10.0,"from_trusted":true,"foreign_parts_only":false,"upload_date":"2013-10-16T00:37:02Z","ai_translated":false,"nb_cd":1,"machine_translated":false,"release":"720p.BluRay.x264-Felony
-        [and BDRiP.XViD-NoGRP]","comments":"Fix OCR, italics, overlapping, etc...
-        for all 720p/1080p BluRay","legacy_subtitle_id":5225493,"legacy_uploader_id":847082,"uploader":{"uploader_id":48068,"name":"cipry_master","rank":"Trusted
-        member"},"feature_details":{"feature_id":580760,"feature_type":"Movie","year":2013,"title":"Man
-        of Steel","movie_name":"2013 - Man of Steel","imdb_id":770828,"tmdb_id":49521},"url":"https://www.opensubtitles.com/en/subtitles/legacy/5225493","related_links":[{"label":"All
-        subtitles for man of steel","url":"https://www.opensubtitles.com/en/movies/2013-man-of-steel","img_url":"https://s9.opensubtitles.com/features/0/6/7/580760.jpg"}],"files":[{"file_id":957714,"cd_number":1,"file_name":"Man.Of.Steel.2013.720p.BluRay.x264-Felony"}],"moviehash_match":true}},{"id":"3178800","type":"subtitle","attributes":{"subtitle_id":"3178800","language":"en","download_count":210404,"new_download_count":839,"hearing_impaired":false,"hd":true,"fps":23.976,"votes":2,"ratings":10.0,"from_trusted":true,"foreign_parts_only":false,"upload_date":"2013-11-07T04:48:10Z","ai_translated":false,"nb_cd":1,"machine_translated":false,"release":"Arrow.S02E05.HDTV.x264-LOL","comments":"sync,
-        corrected by elderman","legacy_subtitle_id":5259348,"legacy_uploader_id":1332962,"uploader":{"uploader_id":56900,"name":"elderman","rank":"translator"},"feature_details":{"feature_id":348318,"feature_type":"Episode","year":2013,"title":"League
-        of Assassins","movie_name":"Arrow - S02E05  League of Assassins","imdb_id":3128398,"tmdb_id":64139,"season_number":2,"episode_number":5,"parent_imdb_id":2193021,"parent_title":"Arrow","parent_tmdb_id":1412,"parent_feature_id":12491},"url":"https://www.opensubtitles.com/en/subtitles/legacy/5259348","related_links":[{"label":"All
-        subtitles for Tv Show Arrow","url":"https://www.opensubtitles.com/en/features/redirect/12491","img_url":"https://s9.opensubtitles.com/features/8/1/3/348318.jpg"},{"label":"All
-        subtitles for Episode league of assassins","url":"https://www.opensubtitles.com/en/features/redirect/348318"}],"files":[{"file_id":3249003,"cd_number":1,"file_name":"Arrow.S02E05.HDTV.x264-LOL"}],"moviehash_match":true}},{"id":"872093","type":"subtitle","attributes":{"subtitle_id":"872093","language":"en","download_count":145094,"new_download_count":705,"hearing_impaired":false,"hd":true,"fps":23.976,"votes":0,"ratings":0.0,"from_trusted":false,"foreign_parts_only":false,"upload_date":"2013-10-15T19:02:17Z","ai_translated":false,"nb_cd":1,"machine_translated":false,"release":"Man
-        Of Steel 2013 BDRip.x264-Larceny","comments":"","legacy_subtitle_id":5224905,"legacy_uploader_id":2020399,"uploader":{"uploader_id":67314,"name":"felixmartini","rank":"Bronze
-        Member"},"feature_details":{"feature_id":580760,"feature_type":"Movie","year":2013,"title":"Man
-        of Steel","movie_name":"2013 - Man of Steel","imdb_id":770828,"tmdb_id":49521},"url":"https://www.opensubtitles.com/en/subtitles/legacy/5224905","related_links":[{"label":"All
-        subtitles for man of steel","url":"https://www.opensubtitles.com/en/movies/2013-man-of-steel","img_url":"https://s9.opensubtitles.com/features/0/6/7/580760.jpg"}],"files":[{"file_id":953341,"cd_number":1,"file_name":"Man
-        Of Steel 2013 BDRip.x264-Larceny"}],"moviehash_match":true}},{"id":"869742","type":"subtitle","attributes":{"subtitle_id":"869742","language":"en","download_count":104307,"new_download_count":233,"hearing_impaired":false,"hd":false,"fps":29.97,"votes":1,"ratings":10.0,"from_trusted":false,"foreign_parts_only":false,"upload_date":"2013-07-09T13:03:41Z","ai_translated":false,"nb_cd":1,"machine_translated":false,"release":"Man.of.Steel.2013.R6.LiNE.All.Version","comments":"Total
-        98% Improved,Re-Synced,Spell Checked,Few Lines Added. Specially Thanks to
-        \"tinotpoldas\" \u0026 \"tosem\" .","legacy_subtitle_id":5079931,"legacy_uploader_id":1629008,"uploader":{"uploader_id":64860,"name":"igorrml_","rank":"Gold
-        member"},"feature_details":{"feature_id":580760,"feature_type":"Movie","year":2013,"title":"Man
-        of Steel","movie_name":"2013 - Man of Steel","imdb_id":770828,"tmdb_id":49521},"url":"https://www.opensubtitles.com/en/subtitles/legacy/5079931","related_links":[{"label":"All
-        subtitles for man of steel","url":"https://www.opensubtitles.com/en/movies/2013-man-of-steel","img_url":"https://s9.opensubtitles.com/features/0/6/7/580760.jpg"}],"files":[{"file_id":950892,"cd_number":1,"file_name":"Man.of.Steel.2013.R6.LiNE.All.Version"}],"moviehash_match":true}},{"id":"879204","type":"subtitle","attributes":{"subtitle_id":"879204","language":"en","download_count":56283,"new_download_count":248,"hearing_impaired":false,"hd":true,"fps":23.976,"votes":0,"ratings":0.0,"from_trusted":false,"foreign_parts_only":false,"upload_date":"2013-10-16T17:30:21Z","ai_translated":false,"nb_cd":1,"machine_translated":false,"release":"Man.Of.Steel.2013.720p.BluRay.x264-Felony","comments":"","legacy_subtitle_id":5226279,"legacy_uploader_id":338814,"uploader":{"uploader_id":39690,"name":"Babylonian","rank":"Silver
-        Member"},"feature_details":{"feature_id":580760,"feature_type":"Movie","year":2013,"title":"Man
-        of Steel","movie_name":"2013 - Man of Steel","imdb_id":770828,"tmdb_id":49521},"url":"https://www.opensubtitles.com/en/subtitles/legacy/5226279","related_links":[{"label":"All
-        subtitles for man of steel","url":"https://www.opensubtitles.com/en/movies/2013-man-of-steel","img_url":"https://s9.opensubtitles.com/features/0/6/7/580760.jpg"}],"files":[{"file_id":960768,"cd_number":1,"file_name":"Man.Of.Steel.2013.720p.BluRay.x264-Felony.English"}],"moviehash_match":true}},{"id":"877471","type":"subtitle","attributes":{"subtitle_id":"877471","language":"en","download_count":40570,"new_download_count":227,"hearing_impaired":false,"hd":true,"fps":23.976,"votes":0,"ratings":0.0,"from_trusted":false,"foreign_parts_only":false,"upload_date":"2013-10-16T08:26:55Z","ai_translated":false,"nb_cd":1,"machine_translated":false,"release":"Man
-        Of Steel 2013 - Bluray","comments":"","legacy_subtitle_id":5225826,"legacy_uploader_id":1534270,"uploader":{"uploader_id":62354,"name":"racunz2012","rank":"Gold
-        member"},"feature_details":{"feature_id":580760,"feature_type":"Movie","year":2013,"title":"Man
-        of Steel","movie_name":"2013 - Man of Steel","imdb_id":770828,"tmdb_id":49521},"url":"https://www.opensubtitles.com/en/subtitles/legacy/5225826","related_links":[{"label":"All
-        subtitles for man of steel","url":"https://www.opensubtitles.com/en/movies/2013-man-of-steel","img_url":"https://s9.opensubtitles.com/features/0/6/7/580760.jpg"}],"files":[{"file_id":959001,"cd_number":1,"file_name":"Man
-        Of Steel 2013 - Bluray.EN"}],"moviehash_match":true}},{"id":"876365","type":"subtitle","attributes":{"subtitle_id":"876365","language":"en","download_count":37923,"new_download_count":62,"hearing_impaired":true,"hd":true,"fps":23.976,"votes":0,"ratings":0.0,"from_trusted":true,"foreign_parts_only":false,"upload_date":"2013-10-16T00:37:20Z","ai_translated":false,"nb_cd":1,"machine_translated":false,"release":"720p.BluRay.x264-Felony
-        (COLOR Hearing Impaired)","comments":"Fix OCR, italics, overlapping, etc...
-        for all 720p/1080p BluRay","legacy_subtitle_id":5225494,"legacy_uploader_id":847082,"uploader":{"uploader_id":48068,"name":"cipry_master","rank":"Trusted
-        member"},"feature_details":{"feature_id":580760,"feature_type":"Movie","year":2013,"title":"Man
-        of Steel","movie_name":"2013 - Man of Steel","imdb_id":770828,"tmdb_id":49521},"url":"https://www.opensubtitles.com/en/subtitles/legacy/5225494","related_links":[{"label":"All
-        subtitles for man of steel","url":"https://www.opensubtitles.com/en/movies/2013-man-of-steel","img_url":"https://s9.opensubtitles.com/features/0/6/7/580760.jpg"}],"files":[{"file_id":957845,"cd_number":1,"file_name":"Man.Of.Steel.2013.720p.BluRay.x264-Felony"}],"moviehash_match":true}},{"id":"871951","type":"subtitle","attributes":{"subtitle_id":"871951","language":"en","download_count":22941,"new_download_count":112,"hearing_impaired":true,"hd":true,"fps":23.976,"votes":0,"ratings":0.0,"from_trusted":false,"foreign_parts_only":false,"upload_date":"2013-10-15T19:01:42Z","ai_translated":false,"nb_cd":1,"machine_translated":false,"release":"Man
-        Of Steel 2013 BDRip.x264-Larceny","comments":"","legacy_subtitle_id":5224904,"legacy_uploader_id":0,"uploader":{"uploader_id":3282,"name":"os-auto","rank":"Application
-        Developers"},"feature_details":{"feature_id":580760,"feature_type":"Movie","year":2013,"title":"Man
-        of Steel","movie_name":"2013 - Man of Steel","imdb_id":770828,"tmdb_id":49521},"url":"https://www.opensubtitles.com/en/subtitles/legacy/5224904","related_links":[{"label":"All
-        subtitles for man of steel","url":"https://www.opensubtitles.com/en/movies/2013-man-of-steel","img_url":"https://s9.opensubtitles.com/features/0/6/7/580760.jpg"}],"files":[{"file_id":953193,"cd_number":1,"file_name":"Man
-        Of Steel 2013 BDRip.x264-Larceny.Hi"}],"moviehash_match":true}},{"id":"874537","type":"subtitle","attributes":{"subtitle_id":"874537","language":"en","download_count":14558,"new_download_count":84,"hearing_impaired":false,"hd":true,"fps":0.0,"votes":0,"ratings":0.0,"from_trusted":false,"foreign_parts_only":false,"upload_date":"2013-10-15T23:33:54Z","ai_translated":false,"nb_cd":1,"machine_translated":false,"release":"Man.Of.Steel.2013.720p.BRRip.x264.AC3-UNDERCOVER","comments":"","legacy_subtitle_id":5225363,"legacy_uploader_id":1447693,"uploader":{"uploader_id":59646,"name":"Neomale","rank":"Read
-        Only Member"},"feature_details":{"feature_id":580760,"feature_type":"Movie","year":2013,"title":"Man
-        of Steel","movie_name":"2013 - Man of Steel","imdb_id":770828,"tmdb_id":49521},"url":"https://www.opensubtitles.com/en/subtitles/legacy/5225363","related_links":[{"label":"All
-        subtitles for man of steel","url":"https://www.opensubtitles.com/en/movies/2013-man-of-steel","img_url":"https://s9.opensubtitles.com/features/0/6/7/580760.jpg"}],"files":[{"file_id":955964,"cd_number":1,"file_name":"Man.Of.Steel.2013.720p.BRRip.x264.AC3-UNDERCOVER_eng"}],"moviehash_match":true}},{"id":"873226","type":"subtitle","attributes":{"subtitle_id":"873226","language":"en","download_count":12299,"new_download_count":32,"hearing_impaired":true,"hd":true,"fps":0.0,"votes":0,"ratings":0.0,"from_trusted":false,"foreign_parts_only":false,"upload_date":"2013-10-15T20:22:10Z","ai_translated":false,"nb_cd":1,"machine_translated":false,"release":"Man.Of.Steel.2013.BDRip.x264-Larceny[rarbg]","comments":"","legacy_subtitle_id":5225027,"legacy_uploader_id":121929,"uploader":{"uploader_id":35815,"name":"untukforum","rank":"Gold
-        member"},"feature_details":{"feature_id":580760,"feature_type":"Movie","year":2013,"title":"Man
-        of Steel","movie_name":"2013 - Man of Steel","imdb_id":770828,"tmdb_id":49521},"url":"https://www.opensubtitles.com/en/subtitles/legacy/5225027","related_links":[{"label":"All
-        subtitles for man of steel","url":"https://www.opensubtitles.com/en/movies/2013-man-of-steel","img_url":"https://s9.opensubtitles.com/features/0/6/7/580760.jpg"}],"files":[{"file_id":954566,"cd_number":1,"file_name":"l-manofsteel"}],"moviehash_match":true}},{"id":"882182","type":"subtitle","attributes":{"subtitle_id":"882182","language":"en","download_count":10566,"new_download_count":32,"hearing_impaired":false,"hd":true,"fps":23.98,"votes":0,"ratings":0.0,"from_trusted":false,"foreign_parts_only":false,"upload_date":"2013-10-28T01:20:44Z","ai_translated":false,"nb_cd":1,"machine_translated":false,"release":"Man
-        of Steel 2013 BRRip XvidHD 720p-NPW","comments":"","legacy_subtitle_id":5244413,"legacy_uploader_id":429031,"uploader":{"uploader_id":41158,"name":"willygeerts","rank":"VIP
-        Member"},"feature_details":{"feature_id":580760,"feature_type":"Movie","year":2013,"title":"Man
-        of Steel","movie_name":"2013 - Man of Steel","imdb_id":770828,"tmdb_id":49521},"url":"https://www.opensubtitles.com/en/subtitles/legacy/5244413","related_links":[{"label":"All
-        subtitles for man of steel","url":"https://www.opensubtitles.com/en/movies/2013-man-of-steel","img_url":"https://s9.opensubtitles.com/features/0/6/7/580760.jpg"}],"files":[{"file_id":963880,"cd_number":1,"file_name":"Man
-        of Steel 2013 BRRip XvidHD 720p-NPW"}],"moviehash_match":true}},{"id":"877376","type":"subtitle","attributes":{"subtitle_id":"877376","language":"en","download_count":9410,"new_download_count":15,"hearing_impaired":false,"hd":true,"fps":0.0,"votes":0,"ratings":0.0,"from_trusted":false,"foreign_parts_only":false,"upload_date":"2013-10-16T06:52:41Z","ai_translated":false,"nb_cd":1,"machine_translated":false,"release":"ManOf.Steel.(2013).BDRip.600MB.Ganool","comments":"","legacy_subtitle_id":5225752,"legacy_uploader_id":1548471,"uploader":{"uploader_id":62760,"name":"Drigerray","rank":"Bronze
-        Member"},"feature_details":{"feature_id":580760,"feature_type":"Movie","year":2013,"title":"Man
-        of Steel","movie_name":"2013 - Man of Steel","imdb_id":770828,"tmdb_id":49521},"url":"https://www.opensubtitles.com/en/subtitles/legacy/5225752","related_links":[{"label":"All
-        subtitles for man of steel","url":"https://www.opensubtitles.com/en/movies/2013-man-of-steel","img_url":"https://s9.opensubtitles.com/features/0/6/7/580760.jpg"}],"files":[{"file_id":958900,"cd_number":1,"file_name":"ManOf.Steel.(2013).BDRip.600MB.Ganool"}],"moviehash_match":true}}]}'
+      string: !!binary |
+        E6M1AORvr9r/1y9zbn8Py4dS/1Labnd8S9UQCztMEGiQnKy3/Pz+vkKaOCX/UoedSGK/99yh8N65
+        Ay/It8pG3TRtEfI6iXFTAJCkUKReQBXZ7O5CoRPyTLi1+wK/qH8u/RQOcQbP6Nzp24GWBc84hSm2
+        TvKB10jh3nHFKAxhCeD//gJpAA/WaGYRKCynKYKH+fiwpCVHoBAJUeC/PNlIr8oMqgQeYgEKPmPG
+        bFVhUUlDocSX/vn1piwihccYWiqHPo1TSC0O4Pchz5HC4wB+acdIYT/N4LnonNEUnqtVx0ZQaGFJ
+        5TCDZ9ghhX2rY7+047xE7eXXFtOh9FNoy9zXkk+D8DtO9hz7ISwRPHBkYsVwxfQW0Qvjkf8FFELq
+        f3Jhrzks1qWVh343BDybAEWww03ZYo5hjuDBcJy683zchFP3iWu5uo65lhP5O5SBnF9u0ofuj9/S
+        5epdvdl8+BcoxPs8wcN1+kTeX2wo+USCztzNlNTn2HKYplQOlMRl13Ud2ddGQs7EcJzWDC1OZJhb
+        CBRyPITdqY/DoopzJZ3ogIaHX2yukJUGLQ+kycYG/gt01DnSorYUShgjeNilqZ36McxLbEChhfIE
+        HrZxUY98F9ZE+EZh6hXP/hP2SLpiDxOzRrFoNHYKaXKN3tbnFIHCKYYGniMTFBLp2np4Gwqpe3K/
+        xJiBwlifU+wtmzKOTJAV6SwujcPDECsbg5ZbCsuD6yid4uwbhWPL4OFxWabZr9cvLy9dnWIJwHrz
+        /00QFcvaua9D0WMdqm4Q97MJSxz6nMrTPLJV/5GPRcHDWc6kbyTe3EdfyM08DCCe9ZvXybbwGMqq
+        7ld9GUIaD32fuja7BQR+uXmNa7026231HxZZ7tu/FPYpR+sD9inRbI5TxjBJYTf0X7eWwA7pBJJC
+        3rehdO/3XWhL0nFkokv6ZDAkvubwGObHfgzL7nFkj/j2jSLTdCyYsRaX1XRRe1vgDCXKgWO1Wlxx
+        XL4/2ArNFqWX1jOUJZ+1Vl+6e+RXqLrby+1vMdWHN+/fwNBk51PZUfLp5rvcbokDeTiRmIfYxlAg
+        xhTKCWklZkJwp5cypR1i9eEBvjCftbhii7WFtIJZia6mNNdhfSC+ieFwjKTuydk8h3lOZQYZEoLh
+        ZEXW3UCImhPoTEYwboVbzl9LJhyFOYa5ljErnlOI5jk9PB9FYQotlqXvY1HOnEDOnmS2E8PqwVPM
+        Aj8mSQFVqBFCI5Fx6aCPxDZPV2n7TO4f6wsxmYcFMB9kXrf4zZvd1l7gDX357JqtxTp5UNdsajMk
+        mCCS41lhqBsfUBtEwa7UgkuHKJbNPBuLsUAbZw3HVy2u9A9UUTBrGiYVOt0xwilEoQUAImf2952h
+        tsx55J4ZyXgbCnlPQdwILck4v9ykKaqmILRdLCfAFYeqpuDSobJdjhyFczJtBJObtY85fRpDW1JJ
+        yPoN6bzV8jmSt6TtFUU6VGIcISRDpk80lJizdkZypopzw4JSYC6yf7jUDugR3Se5zhm2phrGtPnN
+        /mPQrNBtmfAovGTSsasE+0DY6O5NenfVneXc/RbbnGrZn4Da1iVk4uwP5G6cWn2OA93E1f2p7OJA
+        76eYM7l4jLunONDr+ELepBJncjYMcejI/RR3KeR8ItvHUJ5mslTyDyyp1GWqeQjzP0D+OSJyTf6B
+        pc5x/AdIRwhtBY1zgtmq5g7R6tHSakfSobY25v5R6abmnCYNz/MU4DIOWsexIwN6b87GcZRMFUWA
+        xkVpbgVw3VuU3X2O9JYZL9DzHYdCAR4kyAiaGyepENYyCSR6hNNuFufh4ZRrSfnKd0z3KT/HxoBe
+        TTQ3Tia+RqNtkVWD7s884QAsJm2kYaCKcqaRqAxec4R8ZtB6rr1SUhtxnX5W5DwfW0ASIyjLtbRM
+        CckNLgfRXKis1C9kLeyO5TNHxhkJDdHzlGyUTjpEliIHQHf1DjRMWgutQBXFRIwijONN69wTLXmp
+        O8gAZe47Uvl2Z3OUcj9fvH/zfkNug0Ce3DXyCxs5Y6vfbixIuV6R8mBYqWSCW8Oc4jGgioIlU3Du
+        JLsfGXPLNtnTGFou/FJiXnIRgyaiqUyS4JZXsU2qzqtwXGpuaLPPpimnXVhSLeSnqjz6xDYzmkcV
+        6RBKRqBgTjiBxDkAutvEbUxaKmFAFVcuPAxSKVvC0oOsXhAGc2ajyGeGCy+EV1KE86+emxjbk3Rn
+        F2L167vLq83F+9+uNoUs/aKEbhYkLZPSaCdwJUs5LfUy7V2sY6gGgJLab02bGAbyvuRTKcujihK6
+        UZDOK6dFpdQR0MdyyDf5CZ7x5IovoIqrcxoGzp2b9Rgh8k1nw+65Qc95uyCBiBN4HZh+/m6hPRz+
+        RRatIDfDzJnjVdcyoSxTv6gdy3J82td2HMtcHlGQGzGyVFrnz6sxlLrHN3QRy4i2nNnqaaaKdMRo
+        Ybjg2Yzwirbn7xxut8g8Ry/JiFM2H1jjEcVmkybyx3Mabi+J4Tit3n34HS2GRUrJmiXbsuQOBVPD
+        mNqcl5Tz6RBjW2Ya8qj0292HKh4SoOcpzjjCWsSnTjzn0HEjDKiigKRfnGT1OtcSlp15Pektaq94
+        4xYnnljgZ45M/EI6djoa8e15dxNKrZltaMUoPs5KWmlApFfNTVOTfJctHWKrWYL5eVYTuVcUZRQX
+        N9vOXDyKYFOn2IPvv98A
     headers:
       Access-Control-Allow-Headers:
       - Origin, Authorization, Accept, Api-Key, Content-Type, X-User-Agent
@@ -229,33 +201,33 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '0'
+      - '48859'
       CF-Cache-Status:
       - HIT
       CF-RAY:
-      - 87c70449193c406b-LHR
+      - 883aac4eafda3c98-CDG
       Cache-Control:
       - public, max-age=86400
       Connection:
       - keep-alive
       Content-Encoding:
-      - gzip
+      - br
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 30 Apr 2024 10:58:27 GMT
+      - Tue, 14 May 2024 11:50:51 GMT
       Last-Modified:
-      - Tue, 30 Apr 2024 10:58:27 GMT
+      - Mon, 13 May 2024 22:16:32 GMT
       NEL:
       - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
       RateLimit-Limit:
       - '5'
       RateLimit-Remaining:
-      - '4'
+      - '3'
       RateLimit-Reset:
       - '1'
       Report-To:
-      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=8jOLOfLPhrkvQQeDsMhVJ3Rfl7iH6%2FIAMNHFgdT9Sd0YApTZAOLPe4fqsVQjFlFrW63PYs9gNz99fCUUksnTxPchb05XFR6HsJNxanE0Q8pCiW9wD%2FOKFExxDUiR1ai6zTgsxEqJxio%3D"}],"group":"cf-nel","max_age":604800}'
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=G3%2BhDtkb2KxFQN9oy%2FfrPAGtVtM4gZwpQKxgOvewtrfatdjWlFP58gSv5EvNoGUT%2BshCxfWBRALApm8L2AeFetoEhvmhKlk%2FbW00FgPkeu2uujHcvNwwl5tdgS0wKa5uTZoMp7r3eaQ%3D"}],"group":"cf-nel","max_age":604800}'
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -265,7 +237,7 @@ interactions:
       Vary:
       - Accept-Encoding
       X-Cache-Backend:
-      - apigw1_8000 rb1
+      - apigw1_8000 rb7
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -273,19 +245,19 @@ interactions:
       X-Frame-Options:
       - SAMEORIGIN
       X-Kong-Proxy-Latency:
-      - '1'
+      - '0'
       X-Kong-Upstream-Latency:
-      - '60'
+      - '367'
       X-RateLimit-Limit-Second:
       - '5'
       X-RateLimit-Remaining-Second:
-      - '4'
+      - '3'
       X-Request-Id:
-      - df3a3099-da73-4321-85f1-04014dd9cc16
+      - 32ef2052-8163-4051-8e8d-bf6a84a600e7
       X-Runtime:
-      - '0.052825'
+      - '0.077865'
       X-StackifyID:
-      - V1|06493527-0c54-4c80-8985-5655283f0109|C98184|CD5
+      - V1|d0743b1d-1840-4f11-9278-d860964753d1|C98087|CD1
       X-Var-Cache:
       - MISS
       X-Via:

--- a/tests/cassettes/opensubtitlescom/test_query_imdb_id.yaml
+++ b/tests/cassettes/opensubtitlescom/test_query_imdb_id.yaml
@@ -5,7 +5,7 @@ interactions:
       Accept:
       - '*/*'
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Api-Key:
       - mij33pjc3kOlup1qOKxnWWxvle2kFbMH
       Connection:
@@ -18,36 +18,34 @@ interactions:
     uri: https://api.opensubtitles.com/api/v1/subtitles?imdb_id=770828&languages=de
   response:
     body:
-      string: "{\"total_pages\":1,\"total_count\":6,\"per_page\":60,\"page\":1,\"data\":[{\"id\":\"880332\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"880332\",\"language\":\"de\",\"download_count\":7182,\"new_download_count\":216,\"hearing_impaired\":true,\"hd\":true,\"fps\":23.976,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2013-10-17T13:26:46Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Man.of.Steel.German.DL.1080p.BluRay.x264-EXQUiSiTE\",\"comments\":\"\",\"legacy_subtitle_id\":5227599,\"legacy_uploader_id\":0,\"uploader\":{\"uploader_id\":3282,\"name\":\"os-auto\",\"rank\":\"Application
-        Developers\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/de/subtitles/legacy/5227599\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/de/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":961964,\"cd_number\":1,\"file_name\":\"Man.of.Steel.German.DL.1080p.BluRay.x264-EXQUiSiTE\"}]}},{\"id\":\"883552\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"883552\",\"language\":\"de\",\"download_count\":4283,\"new_download_count\":10,\"hearing_impaired\":false,\"hd\":true,\"fps\":25.0,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2016-07-31T14:29:17Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Man
-        of Steel (2013) Dtv 2h07min\",\"comments\":\"\",\"legacy_subtitle_id\":6698593,\"legacy_uploader_id\":2563175,\"uploader\":{\"uploader_id\":69315,\"name\":\"bergert_\",\"rank\":\"Trusted
-        member\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/de/subtitles/legacy/6698593\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/de/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":965287,\"cd_number\":1,\"file_name\":\"Man
-        of Steel (DT-2013)\"}]}},{\"id\":\"880717\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"880717\",\"language\":\"de\",\"download_count\":2670,\"new_download_count\":194,\"hearing_impaired\":false,\"hd\":true,\"fps\":23.976,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2013-10-19T00:53:25Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Man.of.Steel.German.720p.BluRay.x264-EXQUiSiTE\",\"comments\":\"\",\"legacy_subtitle_id\":5229998,\"legacy_uploader_id\":0,\"uploader\":{\"uploader_id\":3282,\"name\":\"os-auto\",\"rank\":\"Application
-        Developers\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/de/subtitles/legacy/5229998\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/de/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":962352,\"cd_number\":1,\"file_name\":\"Man.of.Steel.German.720p.BluRay.x264-EXQUiSiTE\"}]}},{\"id\":\"5166256\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"5166256\",\"language\":\"de\",\"download_count\":1794,\"new_download_count\":14,\"hearing_impaired\":false,\"hd\":true,\"fps\":23.976,\"votes\":1,\"ratings\":10.0,\"from_trusted\":true,\"foreign_parts_only\":false,\"upload_date\":\"2020-03-29T11:40:37Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Man.of.Steel.2013.720p.german.srt\",\"comments\":\"--\\u003e
-        HI-Items entfernt, Timing teilweise korrigiert, Kursivsetzung korrigiert\\r\\n--\\u003e
-        passend f\xFCr Versionen mit Laufzeit 2h 23min 2s 688ms\",\"legacy_subtitle_id\":8148911,\"legacy_uploader_id\":1189705,\"uploader\":{\"uploader_id\":54111,\"name\":\"arcchancellor\",\"rank\":\"translator\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/de/subtitles/legacy/8148911\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/de/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":5276290,\"cd_number\":1,\"file_name\":\"Man.of.Steel.2013.720p.german\"}]}},{\"id\":\"883560\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"883560\",\"language\":\"de\",\"download_count\":938,\"new_download_count\":9,\"hearing_impaired\":true,\"hd\":true,\"fps\":23.976,\"votes\":2,\"ratings\":10.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2016-08-01T19:13:17Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Man
-        of Steel German DL 1080p BluRay x264-EXQUiSiTE\",\"comments\":\"Duration:
-        2:23:03\\r\\nvia SubTools from idx to srt\\r\\nFull German\\r\\nHandmade corrected\",\"legacy_subtitle_id\":6699712,\"legacy_uploader_id\":1471910,\"uploader\":{\"uploader_id\":60439,\"name\":\"PissPott\",\"rank\":\"Silver
-        Member\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/de/subtitles/legacy/6699712\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/de/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":965292,\"cd_number\":1,\"file_name\":\"exq-manofsteel-1080p.idx.mkv\"}]}},{\"id\":\"6632511\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"6632511\",\"language\":\"de\",\"download_count\":61,\"new_download_count\":7,\"hearing_impaired\":false,\"hd\":true,\"fps\":23.976,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2022-06-26T19:32:54Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Should
-        work with 4k BD rips\",\"comments\":\"Source German Retail 4k BD\\r\\nRetail
-        PGS to SSA + improvements\\r\\n\\r\\ncoloured parts\\r\\n\\r\\nIf the timing
-        is off, just correct it with SubtitleEdit.\\r\\n-\\u003e Synchronization \\r\\n-\\u003e
-        Adjust all times \\r\\n-\\u003e all lines\\r\\n\\r\\nWorks best with MPC-BE
-        + XySubFilter + madvr\\r\\nbecause there the font is not in the image,\\r\\nbut
-        at the bottom in the black bars.\",\"legacy_subtitle_id\":9150443,\"legacy_uploader_id\":9372469,\"uploader\":{\"uploader_id\":null,\"name\":\"Anonymous\",\"rank\":\"anonymous\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/de/subtitles/legacy/9150443\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/de/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":7601680,\"cd_number\":1,\"file_name\":\"Man
-        of Steel.Full - German\"}]}}]}"
+      string: !!binary |
+        E5MbAOSa5r9Vu7PVT4JkDgkJun+edm6/0WAL2cQIFEDvHNdduvz/9ypIIpTjEQ1QMPQToA/2/n1Z
+        mzr2ev93jmltqFpurVrQtFRcg3K8CzADC1JPxeoS/GaLGVT8hwfLbKhcuBZPuKN+B8NiTjajZuSo
+        1A60CGpJcLEpRjbUkhJ0uRQjOJpiUP/9hG5EjX1PheBIsDwsFjXm9VBc8RYJ9kEY6qfAOoakmJ5S
+        qHG0SLBimJYr7LhQBIO9G0LPyAUjeLYmuXAa3LwYl+yIuqTVEjy7jpuWjJqLWnWS4G2k6MIowWSK
+        C6eMmtaU4JTiPJS05mJH1JPx2RKcYrLuFIbFpJKHGPxDsHVdqHn50RSLGjllomK0Yt2OCc2lbuRf
+        SNC4YbeFrbzJOSkchuPY5vi7J+VGvGvJemuyRY2fTajjVG+Ltb7+8YdzqF99qhnt6VK/8OsP81Df
+        c9lUr//4/qvbut1rJNjtl0eNSNDbkzk+DJ2Qt+W8a5WKwFTKapM10EquahPqJ3y4sOA9JxjMbFFj
+        zJVZS0SCyYQLany+LN4dTXExgJaquW3KeCX41RPD8Ofx0KjA3oimGT3tJI0KI+pEn+Ots0jwwZqE
+        mlMmCA4x1DoiiBOURIJzvHV2IG5tnDIBFUSLcvN4KLF019Ge9wSL5ykb1XJ2JbgmjxrPpSxZbzZ3
+        d3d1XGxovRr5n0UQNtqN1W2aUL9pUi323iGm2HHwLlzyVCF36JgXNT73HnLLBlNMMJMozFVBAKqs
+        NW8GXu7ZhCpOVS5juPk05NReVido/GJ5Qzdy023u5K4gi11vCE7OW+rtkxsxzijJlGwIHsdBV1rE
+        M1AUaPSqHqpp15vrlXASmYu2haSVshQa3ov62QmmIufzt7Y1vfAaWdGuEmzHGs2VZp1RToXHHJ5x
+        ysRP8KrcAj/TbnaBadAhpepbJQ6Qt1KwriWsI00qwdrzDgebTjaV4azbtV0N0HzXx2Ea0KQ+ipWn
+        5X1HjsugV7vqzsUYFE071kHSSsELClx2dKiYUpzBA54BrtpRqluheWu6tePY4q9AKdUbP0Up1RuF
+        ctHyig5TFq7Yui2TkreShxBpK/WkwjrVNE9zkmT1MQuSTRVhC37IaUVFxdWOMd1QLbpjNKdMXHSn
+        ruojp4Iuvsmq2q+UCgvv3lfvi50z2FAmm0IhsHOzCyco1vk767KFS0zJnZxNhcDHNWV3m215XMMp
+        NG6f9iHj98licrZhhOn//xL8ZlN2MdgAsyvwyazTo3UF+Bm4mF0AnkH2/ZwlJDp61vSKsQ1mrFcd
+        BTzitmGMOWfS8Xg24Wi9j4mt4db96UTEA23qk9it0/JOckV5WV18unCLQ9KXFCWtFOMagBL9qVnU
+        ikpj+KvpJ3EowOwrynZMaSYMI6uK4NUnEECDYUkl6NWakMiNa+CaC03FPu3DrTOwXQ+7GL2K88Xc
+        eA8lQuZToW9WX2CZfdqHdyaMeuez9T2ZyLHYkRXRI6VSHeMLbjqmGKwKkrRZP2MOO3xzOX+LpQCr
+        f6St87c2wWexy29RHeOm4QpPFbX3/1azCXGCdrpqfWZ1N97X8+V2RSZJSsFbll2F6IlIWynbAcku
+        zdOf3GtJhn9wXlFZcbljSguu28a8he05rn6Eu5gucOfKGZoLvHgFyS0ZNOXaxjUdLavS/lgMYRLE
+        7NM++N2Fb2+3UCJst8/hF3DzkuKtQmFReZ/2LKfoMfq4JjsCXsQhLd9P21zXFezl2GWI00TgnzUX
+        YE3B4AqJ+m1HJ70eXalxF5yO2D6E4znF4B6lM1a49fmYX5zxHvakwH6WMd6Dd8HSuYbfY7pk0LIM
+        FfvmPn97Wb14Db/AHw/b9fDG+WIT/AKzGW/TPu3DLxwp/67rtcvZwhRDAZchxAJbX8jiZnOyJEmf
+        a4HvPWKtLHA0cj/wGwIHk3INBzdEsZY2zdoXvUp0vJEqLqzes+GdnocYHua4ZuHWaLx9G3kWWtMn
+        WfbaKp2kTPb0rK2Bgb7CIZnxenO93lwB
     headers:
       Access-Control-Allow-Headers:
       - Origin, Authorization, Accept, Api-Key, Content-Type, X-User-Agent
@@ -55,22 +53,24 @@ interactions:
       - GET, HEAD, POST, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
+      Age:
+      - '48860'
       CF-Cache-Status:
-      - MISS
+      - HIT
       CF-RAY:
-      - 87c7044168fe532c-LHR
+      - 883aac4d1e0e229d-CDG
       Cache-Control:
       - public, max-age=86400
       Connection:
       - keep-alive
       Content-Encoding:
-      - gzip
+      - br
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 30 Apr 2024 10:58:26 GMT
+      - Tue, 14 May 2024 11:50:51 GMT
       Last-Modified:
-      - Tue, 30 Apr 2024 10:58:26 GMT
+      - Mon, 13 May 2024 22:16:31 GMT
       NEL:
       - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
       RateLimit-Limit:
@@ -80,7 +80,7 @@ interactions:
       RateLimit-Reset:
       - '1'
       Report-To:
-      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=tb375khS32Wrgo2818DrYgihpgrZ09ouDBgjKtjbi19qQEOTn134Wd%2B7T7bM%2FY%2BwUWk2rQEFvX4woJ2NGhf9B5hQcj11eN8%2BGnGOoIFtQw7eZjJsAbz84sEQVRipwe13sFqx67JMtTw%3D"}],"group":"cf-nel","max_age":604800}'
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=HbpMTEncxpkhD4DML0DAbECncHJHyejVu%2BGh51YS1XRKdj4jTHuSwS2bwoU2KQUSTCuKJwkbSdhsIuL8f8OFYgMg34frwbGtnWEF8zNbhCdDyiggLmzBr5WM0TXUyFYjoucpyetKCqY%3D"}],"group":"cf-nel","max_age":604800}'
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -90,7 +90,7 @@ interactions:
       Vary:
       - Accept-Encoding
       X-Cache-Backend:
-      - apigw1_8000 rb1
+      - apigw1_8000 rb7
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -98,19 +98,19 @@ interactions:
       X-Frame-Options:
       - SAMEORIGIN
       X-Kong-Proxy-Latency:
-      - '1'
+      - '0'
       X-Kong-Upstream-Latency:
-      - '438'
+      - '208'
       X-RateLimit-Limit-Second:
       - '5'
       X-RateLimit-Remaining-Second:
       - '4'
       X-Request-Id:
-      - e9997384-351c-48ab-b614-708c0d06f97c
+      - 30a4a3f7-ed8c-4f76-8071-900c99162faa
       X-Runtime:
-      - '0.263838'
+      - '0.044903'
       X-StackifyID:
-      - V1|aff90fee-934c-4f29-819f-ed60e5fc8c75|C98184|CD5
+      - V1|57d97910-3604-48f0-b9d8-bb48c1f474e8|C98087|CD1
       X-Var-Cache:
       - MISS
       X-Via:
@@ -134,7 +134,7 @@ interactions:
       Accept:
       - '*/*'
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Api-Key:
       - mij33pjc3kOlup1qOKxnWWxvle2kFbMH
       Connection:
@@ -147,36 +147,34 @@ interactions:
     uri: https://api.opensubtitles.com/api/v1/subtitles?imdb_id=770828&languages=de
   response:
     body:
-      string: "{\"total_pages\":1,\"total_count\":6,\"per_page\":60,\"page\":1,\"data\":[{\"id\":\"880332\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"880332\",\"language\":\"de\",\"download_count\":7182,\"new_download_count\":216,\"hearing_impaired\":true,\"hd\":true,\"fps\":23.976,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2013-10-17T13:26:46Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Man.of.Steel.German.DL.1080p.BluRay.x264-EXQUiSiTE\",\"comments\":\"\",\"legacy_subtitle_id\":5227599,\"legacy_uploader_id\":0,\"uploader\":{\"uploader_id\":3282,\"name\":\"os-auto\",\"rank\":\"Application
-        Developers\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/de/subtitles/legacy/5227599\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/de/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":961964,\"cd_number\":1,\"file_name\":\"Man.of.Steel.German.DL.1080p.BluRay.x264-EXQUiSiTE\"}]}},{\"id\":\"883552\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"883552\",\"language\":\"de\",\"download_count\":4283,\"new_download_count\":10,\"hearing_impaired\":false,\"hd\":true,\"fps\":25.0,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2016-07-31T14:29:17Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Man
-        of Steel (2013) Dtv 2h07min\",\"comments\":\"\",\"legacy_subtitle_id\":6698593,\"legacy_uploader_id\":2563175,\"uploader\":{\"uploader_id\":69315,\"name\":\"bergert_\",\"rank\":\"Trusted
-        member\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/de/subtitles/legacy/6698593\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/de/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":965287,\"cd_number\":1,\"file_name\":\"Man
-        of Steel (DT-2013)\"}]}},{\"id\":\"880717\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"880717\",\"language\":\"de\",\"download_count\":2670,\"new_download_count\":194,\"hearing_impaired\":false,\"hd\":true,\"fps\":23.976,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2013-10-19T00:53:25Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Man.of.Steel.German.720p.BluRay.x264-EXQUiSiTE\",\"comments\":\"\",\"legacy_subtitle_id\":5229998,\"legacy_uploader_id\":0,\"uploader\":{\"uploader_id\":3282,\"name\":\"os-auto\",\"rank\":\"Application
-        Developers\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/de/subtitles/legacy/5229998\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/de/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":962352,\"cd_number\":1,\"file_name\":\"Man.of.Steel.German.720p.BluRay.x264-EXQUiSiTE\"}]}},{\"id\":\"5166256\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"5166256\",\"language\":\"de\",\"download_count\":1794,\"new_download_count\":14,\"hearing_impaired\":false,\"hd\":true,\"fps\":23.976,\"votes\":1,\"ratings\":10.0,\"from_trusted\":true,\"foreign_parts_only\":false,\"upload_date\":\"2020-03-29T11:40:37Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Man.of.Steel.2013.720p.german.srt\",\"comments\":\"--\\u003e
-        HI-Items entfernt, Timing teilweise korrigiert, Kursivsetzung korrigiert\\r\\n--\\u003e
-        passend f\xFCr Versionen mit Laufzeit 2h 23min 2s 688ms\",\"legacy_subtitle_id\":8148911,\"legacy_uploader_id\":1189705,\"uploader\":{\"uploader_id\":54111,\"name\":\"arcchancellor\",\"rank\":\"translator\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/de/subtitles/legacy/8148911\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/de/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":5276290,\"cd_number\":1,\"file_name\":\"Man.of.Steel.2013.720p.german\"}]}},{\"id\":\"883560\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"883560\",\"language\":\"de\",\"download_count\":938,\"new_download_count\":9,\"hearing_impaired\":true,\"hd\":true,\"fps\":23.976,\"votes\":2,\"ratings\":10.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2016-08-01T19:13:17Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Man
-        of Steel German DL 1080p BluRay x264-EXQUiSiTE\",\"comments\":\"Duration:
-        2:23:03\\r\\nvia SubTools from idx to srt\\r\\nFull German\\r\\nHandmade corrected\",\"legacy_subtitle_id\":6699712,\"legacy_uploader_id\":1471910,\"uploader\":{\"uploader_id\":60439,\"name\":\"PissPott\",\"rank\":\"Silver
-        Member\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/de/subtitles/legacy/6699712\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/de/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":965292,\"cd_number\":1,\"file_name\":\"exq-manofsteel-1080p.idx.mkv\"}]}},{\"id\":\"6632511\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"6632511\",\"language\":\"de\",\"download_count\":61,\"new_download_count\":7,\"hearing_impaired\":false,\"hd\":true,\"fps\":23.976,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2022-06-26T19:32:54Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Should
-        work with 4k BD rips\",\"comments\":\"Source German Retail 4k BD\\r\\nRetail
-        PGS to SSA + improvements\\r\\n\\r\\ncoloured parts\\r\\n\\r\\nIf the timing
-        is off, just correct it with SubtitleEdit.\\r\\n-\\u003e Synchronization \\r\\n-\\u003e
-        Adjust all times \\r\\n-\\u003e all lines\\r\\n\\r\\nWorks best with MPC-BE
-        + XySubFilter + madvr\\r\\nbecause there the font is not in the image,\\r\\nbut
-        at the bottom in the black bars.\",\"legacy_subtitle_id\":9150443,\"legacy_uploader_id\":9372469,\"uploader\":{\"uploader_id\":null,\"name\":\"Anonymous\",\"rank\":\"anonymous\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/de/subtitles/legacy/9150443\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/de/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":7601680,\"cd_number\":1,\"file_name\":\"Man
-        of Steel.Full - German\"}]}}]}"
+      string: !!binary |
+        E5MbAOSa5r9Vu7PVT4JkDgkJun+edm6/0WAL2cQIFEDvHNdduvz/9ypIIpTjEQ1QMPQToA/2/n1Z
+        mzr2ev93jmltqFpurVrQtFRcg3K8CzADC1JPxeoS/GaLGVT8hwfLbKhcuBZPuKN+B8NiTjajZuSo
+        1A60CGpJcLEpRjbUkhJ0uRQjOJpiUP/9hG5EjX1PheBIsDwsFjXm9VBc8RYJ9kEY6qfAOoakmJ5S
+        qHG0SLBimJYr7LhQBIO9G0LPyAUjeLYmuXAa3LwYl+yIuqTVEjy7jpuWjJqLWnWS4G2k6MIowWSK
+        C6eMmtaU4JTiPJS05mJH1JPx2RKcYrLuFIbFpJKHGPxDsHVdqHn50RSLGjllomK0Yt2OCc2lbuRf
+        SNC4YbeFrbzJOSkchuPY5vi7J+VGvGvJemuyRY2fTajjVG+Ltb7+8YdzqF99qhnt6VK/8OsP81Df
+        c9lUr//4/qvbut1rJNjtl0eNSNDbkzk+DJ2Qt+W8a5WKwFTKapM10EquahPqJ3y4sOA9JxjMbFFj
+        zJVZS0SCyYQLany+LN4dTXExgJaquW3KeCX41RPD8Ofx0KjA3oimGT3tJI0KI+pEn+Ots0jwwZqE
+        mlMmCA4x1DoiiBOURIJzvHV2IG5tnDIBFUSLcvN4KLF019Ge9wSL5ykb1XJ2JbgmjxrPpSxZbzZ3
+        d3d1XGxovRr5n0UQNtqN1W2aUL9pUi323iGm2HHwLlzyVCF36JgXNT73HnLLBlNMMJMozFVBAKqs
+        NW8GXu7ZhCpOVS5juPk05NReVido/GJ5Qzdy023u5K4gi11vCE7OW+rtkxsxzijJlGwIHsdBV1rE
+        M1AUaPSqHqpp15vrlXASmYu2haSVshQa3ov62QmmIufzt7Y1vfAaWdGuEmzHGs2VZp1RToXHHJ5x
+        ysRP8KrcAj/TbnaBadAhpepbJQ6Qt1KwriWsI00qwdrzDgebTjaV4azbtV0N0HzXx2Ea0KQ+ipWn
+        5X1HjsugV7vqzsUYFE071kHSSsELClx2dKiYUpzBA54BrtpRqluheWu6tePY4q9AKdUbP0Up1RuF
+        ctHyig5TFq7Yui2TkreShxBpK/WkwjrVNE9zkmT1MQuSTRVhC37IaUVFxdWOMd1QLbpjNKdMXHSn
+        ruojp4Iuvsmq2q+UCgvv3lfvi50z2FAmm0IhsHOzCyco1vk767KFS0zJnZxNhcDHNWV3m215XMMp
+        NG6f9iHj98licrZhhOn//xL8ZlN2MdgAsyvwyazTo3UF+Bm4mF0AnkH2/ZwlJDp61vSKsQ1mrFcd
+        BTzitmGMOWfS8Xg24Wi9j4mt4db96UTEA23qk9it0/JOckV5WV18unCLQ9KXFCWtFOMagBL9qVnU
+        ikpj+KvpJ3EowOwrynZMaSYMI6uK4NUnEECDYUkl6NWakMiNa+CaC03FPu3DrTOwXQ+7GL2K88Xc
+        eA8lQuZToW9WX2CZfdqHdyaMeuez9T2ZyLHYkRXRI6VSHeMLbjqmGKwKkrRZP2MOO3xzOX+LpQCr
+        f6St87c2wWexy29RHeOm4QpPFbX3/1azCXGCdrpqfWZ1N97X8+V2RSZJSsFbll2F6IlIWynbAcku
+        zdOf3GtJhn9wXlFZcbljSguu28a8he05rn6Eu5gucOfKGZoLvHgFyS0ZNOXaxjUdLavS/lgMYRLE
+        7NM++N2Fb2+3UCJst8/hF3DzkuKtQmFReZ/2LKfoMfq4JjsCXsQhLd9P21zXFezl2GWI00TgnzUX
+        YE3B4AqJ+m1HJ70eXalxF5yO2D6E4znF4B6lM1a49fmYX5zxHvakwH6WMd6Dd8HSuYbfY7pk0LIM
+        FfvmPn97Wb14Db/AHw/b9fDG+WIT/AKzGW/TPu3DLxwp/67rtcvZwhRDAZchxAJbX8jiZnOyJEmf
+        a4HvPWKtLHA0cj/wGwIHk3INBzdEsZY2zdoXvUp0vJEqLqzes+GdnocYHua4ZuHWaLx9G3kWWtMn
+        WfbaKp2kTPb0rK2Bgb7CIZnxenO93lwB
     headers:
       Access-Control-Allow-Headers:
       - Origin, Authorization, Accept, Api-Key, Content-Type, X-User-Agent
@@ -185,23 +183,23 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '0'
+      - '48860'
       CF-Cache-Status:
       - HIT
       CF-RAY:
-      - 87c70445fa564999-LHR
+      - 883aac4d5e89229d-CDG
       Cache-Control:
       - public, max-age=86400
       Connection:
       - keep-alive
       Content-Encoding:
-      - gzip
+      - br
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 30 Apr 2024 10:58:26 GMT
+      - Tue, 14 May 2024 11:50:51 GMT
       Last-Modified:
-      - Tue, 30 Apr 2024 10:58:26 GMT
+      - Mon, 13 May 2024 22:16:31 GMT
       NEL:
       - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
       RateLimit-Limit:
@@ -211,7 +209,7 @@ interactions:
       RateLimit-Reset:
       - '1'
       Report-To:
-      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=h5StGPlDJjDmZ3QHVWzhDphUCWmYm%2B9XOMrouOtEKL9bC5Zy2Fiw5ICKItGHlCmX6ANKTXYwv1KOtql8cF%2BfUDgcndG1IVg1Pz41NZOkFYWep0IRnNgP8%2FdAD5%2B3VZuv7RxrBC7gyno%3D"}],"group":"cf-nel","max_age":604800}'
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=llbTzuGTqF5nDc8a2xkwO%2FH5M2oGUiebcoOzULefsTDfjSj0dpgBj8X8XAioeLwcvTMmuAQuKQ8wEjVeyy4ycJrhTITbiu8KnrVfqXv2E1W9zdtZa7JIkU6cmvT%2BUIX9JDxdr9DJQeQ%3D"}],"group":"cf-nel","max_age":604800}'
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -221,7 +219,7 @@ interactions:
       Vary:
       - Accept-Encoding
       X-Cache-Backend:
-      - apigw1_8000 rb1
+      - apigw1_8000 rb7
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -229,19 +227,19 @@ interactions:
       X-Frame-Options:
       - SAMEORIGIN
       X-Kong-Proxy-Latency:
-      - '1'
+      - '0'
       X-Kong-Upstream-Latency:
-      - '438'
+      - '208'
       X-RateLimit-Limit-Second:
       - '5'
       X-RateLimit-Remaining-Second:
       - '4'
       X-Request-Id:
-      - e9997384-351c-48ab-b614-708c0d06f97c
+      - 30a4a3f7-ed8c-4f76-8071-900c99162faa
       X-Runtime:
-      - '0.263838'
+      - '0.044903'
       X-StackifyID:
-      - V1|aff90fee-934c-4f29-819f-ed60e5fc8c75|C98184|CD5
+      - V1|57d97910-3604-48f0-b9d8-bb48c1f474e8|C98087|CD1
       X-Var-Cache:
       - MISS
       X-Via:

--- a/tests/cassettes/opensubtitlescom/test_query_query_episode.yaml
+++ b/tests/cassettes/opensubtitlescom/test_query_query_episode.yaml
@@ -5,7 +5,7 @@ interactions:
       Accept:
       - '*/*'
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Api-Key:
       - mij33pjc3kOlup1qOKxnWWxvle2kFbMH
       Connection:
@@ -18,41 +18,31 @@ interactions:
     uri: https://api.opensubtitles.com/api/v1/subtitles?episode_number=3&languages=fr&query=dallas&season_number=1
   response:
     body:
-      string: "{\"total_pages\":1,\"total_count\":4,\"per_page\":60,\"page\":1,\"data\":[{\"id\":\"3359298\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"3359298\",\"language\":\"fr\",\"download_count\":938,\"new_download_count\":9,\"hearing_impaired\":false,\"hd\":true,\"fps\":23.976,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2010-10-07T03:56:07Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"The
-        Event - 1x03 - Protect Them from the Truth.HDTV.The Event - 01x03 - Protect
-        Them From the Truth\",\"comments\":\"\",\"legacy_subtitle_id\":3870905,\"legacy_uploader_id\":1168246,\"uploader\":{\"uploader_id\":53768,\"name\":\"nicocha\",\"rank\":\"bronze
-        member\"},\"feature_details\":{\"feature_id\":271191,\"feature_type\":\"Episode\",\"year\":2010,\"title\":\"Protect
-        Them from the Truth\",\"movie_name\":\"The Event - S1E3 \\\"The Event\\\"
-        Protect Them from the Truth\",\"imdb_id\":1653551,\"tmdb_id\":769867,\"season_number\":1,\"episode_number\":3,\"parent_imdb_id\":1582459,\"parent_title\":\"The
-        Event\",\"parent_tmdb_id\":32730,\"parent_feature_id\":10757},\"url\":\"https://www.opensubtitles.com/fr/subtitles/legacy/3870905\",\"related_links\":[{\"label\":\"All
-        subtitles for Tv Show The Event\",\"url\":\"https://www.opensubtitles.com/fr/features/redirect/10757\",\"img_url\":\"https://s9.opensubtitles.com/features/1/9/1/271191.jpg\"},{\"label\":\"All
-        subtitles for Episode protect them from the truth\",\"url\":\"https://www.opensubtitles.com/fr/features/redirect/271191\"}],\"files\":[{\"file_id\":3426643,\"cd_number\":1,\"file_name\":\"The
-        Event - 1x03 - Protect Them from the Truth.HDTV.The Event - 01x03 - Protect
-        Them From the Truth\"}]}},{\"id\":\"3829531\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"3829531\",\"language\":\"fr\",\"download_count\":545,\"new_download_count\":11,\"hearing_impaired\":false,\"hd\":false,\"fps\":23.976,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2012-06-21T14:43:26Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Dallas
-        (2012) - 01x03 - The Price You Pay.x264-LOL.French.C.updated.Addic7ed.com\",\"comments\":\"\",\"legacy_subtitle_id\":4581134,\"legacy_uploader_id\":0,\"uploader\":{\"uploader_id\":3282,\"name\":\"os-auto\",\"rank\":\"Application
-        Developers\"},\"feature_details\":{\"feature_id\":333010,\"feature_type\":\"Episode\",\"year\":2012,\"title\":\"The
-        Price You Pay\",\"movie_name\":\"Dallas - S1E3 \\\"Dallas\\\" The Price You
-        Pay\",\"imdb_id\":2205526,\"tmdb_id\":851353,\"season_number\":1,\"episode_number\":3,\"parent_imdb_id\":1723760,\"parent_title\":\"Dallas\",\"parent_tmdb_id\":37759,\"parent_feature_id\":12129},\"url\":\"https://www.opensubtitles.com/fr/subtitles/legacy/4581134\",\"related_links\":[{\"label\":\"All
-        subtitles for Tv Show Dallas\",\"url\":\"https://www.opensubtitles.com/fr/features/redirect/12129\",\"img_url\":\"https://s9.opensubtitles.com/features/0/1/0/333010.jpg\"},{\"label\":\"All
-        subtitles for Episode the price you pay\",\"url\":\"https://www.opensubtitles.com/fr/features/redirect/333010\"}],\"files\":[{\"file_id\":3904804,\"cd_number\":1,\"file_name\":\"Dallas
-        (2012) - 01x03 - The Price You Pay.x264-LOL.French.C.updated.Addic7ed.com\"}]}},{\"id\":\"3359569\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"3359569\",\"language\":\"fr\",\"download_count\":146,\"new_download_count\":4,\"hearing_impaired\":false,\"hd\":true,\"fps\":23.976,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2012-02-27T07:35:01Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"The
-        Event S01E03 Protect Them from the Truth 720p BluRay\",\"comments\":\"\",\"legacy_subtitle_id\":4478723,\"legacy_uploader_id\":1253306,\"uploader\":{\"uploader_id\":55203,\"name\":\"Pb8SOWOA\",\"rank\":\"bronze
-        member\"},\"feature_details\":{\"feature_id\":271191,\"feature_type\":\"Episode\",\"year\":2010,\"title\":\"Protect
-        Them from the Truth\",\"movie_name\":\"The Event - S1E3 \\\"The Event\\\"
-        Protect Them from the Truth\",\"imdb_id\":1653551,\"tmdb_id\":769867,\"season_number\":1,\"episode_number\":3,\"parent_imdb_id\":1582459,\"parent_title\":\"The
-        Event\",\"parent_tmdb_id\":32730,\"parent_feature_id\":10757},\"url\":\"https://www.opensubtitles.com/fr/subtitles/legacy/4478723\",\"related_links\":[{\"label\":\"All
-        subtitles for Tv Show The Event\",\"url\":\"https://www.opensubtitles.com/fr/features/redirect/10757\",\"img_url\":\"https://s9.opensubtitles.com/features/1/9/1/271191.jpg\"},{\"label\":\"All
-        subtitles for Episode protect them from the truth\",\"url\":\"https://www.opensubtitles.com/fr/features/redirect/271191\"}],\"files\":[{\"file_id\":3426918,\"cd_number\":1,\"file_name\":\"The
-        Event S01E03 Protect Them from the Truth 720p BluRay\"}]}},{\"id\":\"6915085\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"6915085\",\"language\":\"fr\",\"download_count\":34,\"new_download_count\":7,\"hearing_impaired\":false,\"hd\":true,\"fps\":0.0,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2022-07-05T13:19:24Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Space
-        Battleship Yamato 2199 (2012) - 03 VOSTFR BDrip 1080p FLAC x265-GundamGuy\",\"comments\":\"Sous-titres
-        officiels \xE9diteur.\",\"legacy_subtitle_id\":9159327,\"legacy_uploader_id\":8338908,\"uploader\":{\"uploader_id\":285788,\"name\":\"sonkun02\",\"rank\":\"Platinum
-        Member\"},\"feature_details\":{\"feature_id\":1388271,\"feature_type\":\"Episode\",\"year\":2012,\"title\":\"Escape
-        from the Jupiter Sphere\",\"movie_name\":\"Star Blazers [Space Battleship
-        Yamato] 2199 - S01E03  Escape from the Jupiter Sphere\",\"imdb_id\":3626220,\"tmdb_id\":1404349,\"season_number\":1,\"episode_number\":3,\"parent_imdb_id\":2496120,\"parent_title\":\"Star
-        Blazers [Space Battleship Yamato] 2199\",\"parent_tmdb_id\":45844,\"parent_feature_id\":13449},\"url\":\"https://www.opensubtitles.com/fr/subtitles/legacy/9159327\",\"related_links\":[{\"label\":\"All
-        subtitles for Tv Show Star Blazers [Space Battleship Yamato] 2199\",\"url\":\"https://www.opensubtitles.com/fr/features/redirect/13449\",\"img_url\":\"https://s9.opensubtitles.com/features/1/7/2/1388271.jpg\"},{\"label\":\"All
-        subtitles for Episode escape from the jupiter sphere\",\"url\":\"https://www.opensubtitles.com/fr/features/redirect/1388271\"}],\"files\":[{\"file_id\":7869617,\"cd_number\":1,\"file_name\":\"Space
-        Battleship Yamato 2199 (2012) - 03 VOSTFR BDrip 1080p FLAC x265-GundamGuy\"}]}}]}"
+      string: !!binary |
+        E8oXAORPZ71Vq3nVty1AIXc/xt0fIqMD7SEfC5rA5S0LN7Wnv18B7YomyTbQzgJF/Rh/tZdV710l
+        NZ5VaQGVHciJVI4v7pwfeNIhHwB8ldHyXYEKIdc5bNwdjKj/iD7581DAUbwkvQNtAU5gSCGnqAVO
+        EQzPAotiGH314H7eQRzBAefSMmsAQ71JARyU7azGOgfAUAkZ4O7eHKzPizVqBw4OGTCYhrXZv+UG
+        wxKu+sWlYJiCz3E57+Mx+ZjDCO7g5xIwTCO4mreA4ZAKOMZbqxWGy/XqT4Ih+xqX8wKOtATDIa/H
+        vuat1HLOcVhziOdLn3yupV+X+UZEzJaU8f/oawAHjFDSUNIQvSfcSeWI/gEYfOxHWzhh9iWXLGf9
+        MPoc/+xJjwmfmMMcfAngYD8FNJrG86IG0WvCUYM+5LWGoaL9FI4ImNfZ561O7Ysn+y9tviHJWvdZ
+        OmDAyfXBAWCYw7kfbvpKa8iNJpbIBNALMSHP61OqDBPKN2uGDO4OUgWI5FoZDIs/BnCwxGEdJg8Y
+        sl8uwMFZXpfbgPq9mg8nDD+pEt7/NT2AIfzyFeIIjmlKLU2K8HfCpymWdQyA4Sb4DI4RSjBAcroO
+        fNcWMBzXyxh6Jbt4fpUdfcrRr8qYxy9ApeXG43jmmvZKcikphvrqU7SyRmkMJfiyLn3HY0EDDA3q
+        k5evwDEkn8NS+yIbSMOEtG9i2whM+sHbOF8FZ5qT4rq48YKUaKlPGLY8g4Op1lRc111dXbVrCkv9
+        9yv/H4OMQ+5eDO1AENaBIgQAe4CvYeznuFwUdug8KMmG4ODhPKPM10OHNaP9JdpN6xXSm4YWqL6X
+        lC6HbvOGdGYAp09y3hc0ZbErvKtFO9vRDkedB0M57RPWGyErDiUM6VZZHZPNEqhLazj9xnCIc/Bi
+        /CG2vWsIppTgGIYRMiBNT4D9lDRRfvp9OmHaF7BhVnJK8vZpboEUciaUrdHTL3CUHKwhqmF0T4UT
+        3DE1u/oTP8++oAeMUPZXLX3Y91NAH3IcAvq+buiDv2mvmRLNm/dv2mc5LMPUPm63NPoaxvbhOMZB
+        h7Ed1iPLcyGkoZSLcOKCnvi9gDPDVq7W0vitrld+mNIcB1/juqCOC8835MLzKZxzCsdJe7nQYt17
+        qVt2R+4lF/jarL8A5Sb0uzpjREqm2FwkRlIuuceaca0IVKjHy3ityb+Lp1aKMsrsAtU8izlRmg0D
+        Ahto83gt0tGOdDihNe+mLy2gpjU364YSG/2hBr1jb44tEYaIz9XWu1K1gLm0UlmSt0/RuQVUqL9C
+        zCQbawhrmN4T7bh0hM42eUfoU8InvAcgzUhCj+btE+r6SsgcCG0045tOmeSchNwKyQj/d/fhzOze
+        f33/cI1Q8esxt4Klhmbj7xJIC1dZKomRnfL2iaGnwcXKTBqw8Ke8SA/GGqIbIveUO2odE7MGu+SH
+        gP7s3pPLFBP67o++rohRawPr94qjL+93+2ef0KMnOSZEiSEJPXvz8DG6Zko2z7dl9MfnG2kfu1u3
+        0tRYcyiozwB3J8wF/f/fGGvYcsvpXFgqLWeaW8O5scQsY0Zq8zmUXcq6XGwLYesH5MPsa1y2I3pL
+        69uTcmOYpjH2Kk/L4FNokS/4akuxhox2aQo5BNxvZFd9Ro9mfxtyQT+rJvT3OrxpUSNDckho7por
+        phgjO4MKIriway+YsIoyWrb0NF2wQUgjxKJxIQJ4hCwWn4ehaBkbzgWG0o7y69BOd6yDKq1P1QwW
+        YCr7V17YTD2QPr0K+rnWRllFdW8cPSaInaqdfp9Ov08=
     headers:
       Access-Control-Allow-Headers:
       - Origin, Authorization, Accept, Api-Key, Content-Type, X-User-Agent
@@ -60,22 +50,24 @@ interactions:
       - GET, HEAD, POST, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
+      Age:
+      - '48861'
       CF-Cache-Status:
-      - MISS
+      - HIT
       CF-RAY:
-      - 87c7043b8909070a-LHR
+      - 883aac49e8f9f170-CDG
       Cache-Control:
       - public, max-age=86400
       Connection:
       - keep-alive
       Content-Encoding:
-      - gzip
+      - br
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 30 Apr 2024 10:58:25 GMT
+      - Tue, 14 May 2024 11:50:51 GMT
       Last-Modified:
-      - Tue, 30 Apr 2024 10:58:25 GMT
+      - Mon, 13 May 2024 22:16:30 GMT
       NEL:
       - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
       RateLimit-Limit:
@@ -85,7 +77,7 @@ interactions:
       RateLimit-Reset:
       - '1'
       Report-To:
-      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=G2aAZx51xhNPDTWMbm0vxspMCKcqeeuVg7RQxeUmmyUtaeQyxu%2Fl1jMFzIfHDoqnw3AVxUu0I8vXnsHvnQrNJjCQilSaWQCKPreX1%2FiVJQ7DAOd5KFMiaEd%2FyGQh4muVFxpoTO6clFg%3D"}],"group":"cf-nel","max_age":604800}'
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=5QzKgIcGPjEayIk%2Bi7rWbvqClzozrSGahxzGTVZV7aPullO1vwWJyEVvy9GCSFY0kZg0%2B0ISTxgsRdJ2dPux38erR6CeL5TYHoHW29alk%2FotjIUHd3nNQKDNfvPfZ%2FxY3QPnQjSkNU8%3D"}],"group":"cf-nel","max_age":604800}'
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -95,7 +87,7 @@ interactions:
       Vary:
       - Accept-Encoding
       X-Cache-Backend:
-      - apigw1_8000 rb11
+      - apigw1_8000 rb7
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -103,17 +95,19 @@ interactions:
       X-Frame-Options:
       - SAMEORIGIN
       X-Kong-Proxy-Latency:
-      - '0'
+      - '1'
       X-Kong-Upstream-Latency:
-      - '43'
+      - '267'
       X-RateLimit-Limit-Second:
       - '5'
       X-RateLimit-Remaining-Second:
       - '4'
       X-Request-Id:
-      - 079e018e-43c6-4b42-b83f-cd4c8f7fd025
+      - d4f90665-f95f-4288-8da6-d18abd6541de
       X-Runtime:
-      - '0.041305'
+      - '0.095390'
+      X-StackifyID:
+      - V1|ab24cafa-85d2-41db-9956-127164f946d6|C98087|CD1
       X-Var-Cache:
       - MISS
       X-Via:
@@ -137,7 +131,7 @@ interactions:
       Accept:
       - '*/*'
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Api-Key:
       - mij33pjc3kOlup1qOKxnWWxvle2kFbMH
       Connection:
@@ -150,41 +144,31 @@ interactions:
     uri: https://api.opensubtitles.com/api/v1/subtitles?episode_number=3&languages=fr&query=dallas&season_number=1
   response:
     body:
-      string: "{\"total_pages\":1,\"total_count\":4,\"per_page\":60,\"page\":1,\"data\":[{\"id\":\"3359298\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"3359298\",\"language\":\"fr\",\"download_count\":938,\"new_download_count\":9,\"hearing_impaired\":false,\"hd\":true,\"fps\":23.976,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2010-10-07T03:56:07Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"The
-        Event - 1x03 - Protect Them from the Truth.HDTV.The Event - 01x03 - Protect
-        Them From the Truth\",\"comments\":\"\",\"legacy_subtitle_id\":3870905,\"legacy_uploader_id\":1168246,\"uploader\":{\"uploader_id\":53768,\"name\":\"nicocha\",\"rank\":\"bronze
-        member\"},\"feature_details\":{\"feature_id\":271191,\"feature_type\":\"Episode\",\"year\":2010,\"title\":\"Protect
-        Them from the Truth\",\"movie_name\":\"The Event - S1E3 \\\"The Event\\\"
-        Protect Them from the Truth\",\"imdb_id\":1653551,\"tmdb_id\":769867,\"season_number\":1,\"episode_number\":3,\"parent_imdb_id\":1582459,\"parent_title\":\"The
-        Event\",\"parent_tmdb_id\":32730,\"parent_feature_id\":10757},\"url\":\"https://www.opensubtitles.com/fr/subtitles/legacy/3870905\",\"related_links\":[{\"label\":\"All
-        subtitles for Tv Show The Event\",\"url\":\"https://www.opensubtitles.com/fr/features/redirect/10757\",\"img_url\":\"https://s9.opensubtitles.com/features/1/9/1/271191.jpg\"},{\"label\":\"All
-        subtitles for Episode protect them from the truth\",\"url\":\"https://www.opensubtitles.com/fr/features/redirect/271191\"}],\"files\":[{\"file_id\":3426643,\"cd_number\":1,\"file_name\":\"The
-        Event - 1x03 - Protect Them from the Truth.HDTV.The Event - 01x03 - Protect
-        Them From the Truth\"}]}},{\"id\":\"3829531\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"3829531\",\"language\":\"fr\",\"download_count\":545,\"new_download_count\":11,\"hearing_impaired\":false,\"hd\":false,\"fps\":23.976,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2012-06-21T14:43:26Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Dallas
-        (2012) - 01x03 - The Price You Pay.x264-LOL.French.C.updated.Addic7ed.com\",\"comments\":\"\",\"legacy_subtitle_id\":4581134,\"legacy_uploader_id\":0,\"uploader\":{\"uploader_id\":3282,\"name\":\"os-auto\",\"rank\":\"Application
-        Developers\"},\"feature_details\":{\"feature_id\":333010,\"feature_type\":\"Episode\",\"year\":2012,\"title\":\"The
-        Price You Pay\",\"movie_name\":\"Dallas - S1E3 \\\"Dallas\\\" The Price You
-        Pay\",\"imdb_id\":2205526,\"tmdb_id\":851353,\"season_number\":1,\"episode_number\":3,\"parent_imdb_id\":1723760,\"parent_title\":\"Dallas\",\"parent_tmdb_id\":37759,\"parent_feature_id\":12129},\"url\":\"https://www.opensubtitles.com/fr/subtitles/legacy/4581134\",\"related_links\":[{\"label\":\"All
-        subtitles for Tv Show Dallas\",\"url\":\"https://www.opensubtitles.com/fr/features/redirect/12129\",\"img_url\":\"https://s9.opensubtitles.com/features/0/1/0/333010.jpg\"},{\"label\":\"All
-        subtitles for Episode the price you pay\",\"url\":\"https://www.opensubtitles.com/fr/features/redirect/333010\"}],\"files\":[{\"file_id\":3904804,\"cd_number\":1,\"file_name\":\"Dallas
-        (2012) - 01x03 - The Price You Pay.x264-LOL.French.C.updated.Addic7ed.com\"}]}},{\"id\":\"3359569\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"3359569\",\"language\":\"fr\",\"download_count\":146,\"new_download_count\":4,\"hearing_impaired\":false,\"hd\":true,\"fps\":23.976,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2012-02-27T07:35:01Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"The
-        Event S01E03 Protect Them from the Truth 720p BluRay\",\"comments\":\"\",\"legacy_subtitle_id\":4478723,\"legacy_uploader_id\":1253306,\"uploader\":{\"uploader_id\":55203,\"name\":\"Pb8SOWOA\",\"rank\":\"bronze
-        member\"},\"feature_details\":{\"feature_id\":271191,\"feature_type\":\"Episode\",\"year\":2010,\"title\":\"Protect
-        Them from the Truth\",\"movie_name\":\"The Event - S1E3 \\\"The Event\\\"
-        Protect Them from the Truth\",\"imdb_id\":1653551,\"tmdb_id\":769867,\"season_number\":1,\"episode_number\":3,\"parent_imdb_id\":1582459,\"parent_title\":\"The
-        Event\",\"parent_tmdb_id\":32730,\"parent_feature_id\":10757},\"url\":\"https://www.opensubtitles.com/fr/subtitles/legacy/4478723\",\"related_links\":[{\"label\":\"All
-        subtitles for Tv Show The Event\",\"url\":\"https://www.opensubtitles.com/fr/features/redirect/10757\",\"img_url\":\"https://s9.opensubtitles.com/features/1/9/1/271191.jpg\"},{\"label\":\"All
-        subtitles for Episode protect them from the truth\",\"url\":\"https://www.opensubtitles.com/fr/features/redirect/271191\"}],\"files\":[{\"file_id\":3426918,\"cd_number\":1,\"file_name\":\"The
-        Event S01E03 Protect Them from the Truth 720p BluRay\"}]}},{\"id\":\"6915085\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"6915085\",\"language\":\"fr\",\"download_count\":34,\"new_download_count\":7,\"hearing_impaired\":false,\"hd\":true,\"fps\":0.0,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2022-07-05T13:19:24Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Space
-        Battleship Yamato 2199 (2012) - 03 VOSTFR BDrip 1080p FLAC x265-GundamGuy\",\"comments\":\"Sous-titres
-        officiels \xE9diteur.\",\"legacy_subtitle_id\":9159327,\"legacy_uploader_id\":8338908,\"uploader\":{\"uploader_id\":285788,\"name\":\"sonkun02\",\"rank\":\"Platinum
-        Member\"},\"feature_details\":{\"feature_id\":1388271,\"feature_type\":\"Episode\",\"year\":2012,\"title\":\"Escape
-        from the Jupiter Sphere\",\"movie_name\":\"Star Blazers [Space Battleship
-        Yamato] 2199 - S01E03  Escape from the Jupiter Sphere\",\"imdb_id\":3626220,\"tmdb_id\":1404349,\"season_number\":1,\"episode_number\":3,\"parent_imdb_id\":2496120,\"parent_title\":\"Star
-        Blazers [Space Battleship Yamato] 2199\",\"parent_tmdb_id\":45844,\"parent_feature_id\":13449},\"url\":\"https://www.opensubtitles.com/fr/subtitles/legacy/9159327\",\"related_links\":[{\"label\":\"All
-        subtitles for Tv Show Star Blazers [Space Battleship Yamato] 2199\",\"url\":\"https://www.opensubtitles.com/fr/features/redirect/13449\",\"img_url\":\"https://s9.opensubtitles.com/features/1/7/2/1388271.jpg\"},{\"label\":\"All
-        subtitles for Episode escape from the jupiter sphere\",\"url\":\"https://www.opensubtitles.com/fr/features/redirect/1388271\"}],\"files\":[{\"file_id\":7869617,\"cd_number\":1,\"file_name\":\"Space
-        Battleship Yamato 2199 (2012) - 03 VOSTFR BDrip 1080p FLAC x265-GundamGuy\"}]}}]}"
+      string: !!binary |
+        E8oXAORPZ71Vq3nVty1AIXc/xt0fIqMD7SEfC5rA5S0LN7Wnv18B7YomyTbQzgJF/Rh/tZdV710l
+        NZ5VaQGVHciJVI4v7pwfeNIhHwB8ldHyXYEKIdc5bNwdjKj/iD7581DAUbwkvQNtAU5gSCGnqAVO
+        EQzPAotiGH314H7eQRzBAefSMmsAQ71JARyU7azGOgfAUAkZ4O7eHKzPizVqBw4OGTCYhrXZv+UG
+        wxKu+sWlYJiCz3E57+Mx+ZjDCO7g5xIwTCO4mreA4ZAKOMZbqxWGy/XqT4Ih+xqX8wKOtATDIa/H
+        vuat1HLOcVhziOdLn3yupV+X+UZEzJaU8f/oawAHjFDSUNIQvSfcSeWI/gEYfOxHWzhh9iWXLGf9
+        MPoc/+xJjwmfmMMcfAngYD8FNJrG86IG0WvCUYM+5LWGoaL9FI4ImNfZ561O7Ysn+y9tviHJWvdZ
+        OmDAyfXBAWCYw7kfbvpKa8iNJpbIBNALMSHP61OqDBPKN2uGDO4OUgWI5FoZDIs/BnCwxGEdJg8Y
+        sl8uwMFZXpfbgPq9mg8nDD+pEt7/NT2AIfzyFeIIjmlKLU2K8HfCpymWdQyA4Sb4DI4RSjBAcroO
+        fNcWMBzXyxh6Jbt4fpUdfcrRr8qYxy9ApeXG43jmmvZKcikphvrqU7SyRmkMJfiyLn3HY0EDDA3q
+        k5evwDEkn8NS+yIbSMOEtG9i2whM+sHbOF8FZ5qT4rq48YKUaKlPGLY8g4Op1lRc111dXbVrCkv9
+        9yv/H4OMQ+5eDO1AENaBIgQAe4CvYeznuFwUdug8KMmG4ODhPKPM10OHNaP9JdpN6xXSm4YWqL6X
+        lC6HbvOGdGYAp09y3hc0ZbErvKtFO9vRDkedB0M57RPWGyErDiUM6VZZHZPNEqhLazj9xnCIc/Bi
+        /CG2vWsIppTgGIYRMiBNT4D9lDRRfvp9OmHaF7BhVnJK8vZpboEUciaUrdHTL3CUHKwhqmF0T4UT
+        3DE1u/oTP8++oAeMUPZXLX3Y91NAH3IcAvq+buiDv2mvmRLNm/dv2mc5LMPUPm63NPoaxvbhOMZB
+        h7Ed1iPLcyGkoZSLcOKCnvi9gDPDVq7W0vitrld+mNIcB1/juqCOC8835MLzKZxzCsdJe7nQYt17
+        qVt2R+4lF/jarL8A5Sb0uzpjREqm2FwkRlIuuceaca0IVKjHy3ityb+Lp1aKMsrsAtU8izlRmg0D
+        Ahto83gt0tGOdDihNe+mLy2gpjU364YSG/2hBr1jb44tEYaIz9XWu1K1gLm0UlmSt0/RuQVUqL9C
+        zCQbawhrmN4T7bh0hM42eUfoU8InvAcgzUhCj+btE+r6SsgcCG0045tOmeSchNwKyQj/d/fhzOze
+        f33/cI1Q8esxt4Klhmbj7xJIC1dZKomRnfL2iaGnwcXKTBqw8Ke8SA/GGqIbIveUO2odE7MGu+SH
+        gP7s3pPLFBP67o++rohRawPr94qjL+93+2ef0KMnOSZEiSEJPXvz8DG6Zko2z7dl9MfnG2kfu1u3
+        0tRYcyiozwB3J8wF/f/fGGvYcsvpXFgqLWeaW8O5scQsY0Zq8zmUXcq6XGwLYesH5MPsa1y2I3pL
+        69uTcmOYpjH2Kk/L4FNokS/4akuxhox2aQo5BNxvZFd9Ro9mfxtyQT+rJvT3OrxpUSNDckho7por
+        phgjO4MKIriway+YsIoyWrb0NF2wQUgjxKJxIQJ4hCwWn4ehaBkbzgWG0o7y69BOd6yDKq1P1QwW
+        YCr7V17YTD2QPr0K+rnWRllFdW8cPSaInaqdfp9Ov08=
     headers:
       Access-Control-Allow-Headers:
       - Origin, Authorization, Accept, Api-Key, Content-Type, X-User-Agent
@@ -193,23 +177,23 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '0'
+      - '48861'
       CF-Cache-Status:
       - HIT
       CF-RAY:
-      - 87c7043ce88f0692-LHR
+      - 883aac4a39bef170-CDG
       Cache-Control:
       - public, max-age=86400
       Connection:
       - keep-alive
       Content-Encoding:
-      - gzip
+      - br
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 30 Apr 2024 10:58:25 GMT
+      - Tue, 14 May 2024 11:50:51 GMT
       Last-Modified:
-      - Tue, 30 Apr 2024 10:58:25 GMT
+      - Mon, 13 May 2024 22:16:30 GMT
       NEL:
       - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
       RateLimit-Limit:
@@ -219,7 +203,7 @@ interactions:
       RateLimit-Reset:
       - '1'
       Report-To:
-      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=Ufm79DlyhDO1j2BpnNriXys3cr%2B2LOzLdyFHS7737PnOTcFZD9lwFCVwsqA2VhJDEmqQkgeLwHaOq5YYxnOhLpdUii4W3Ybl7vvED600c%2FvE268tcHNUP7gmq0SSfvP5wMUqB9PPsd4%3D"}],"group":"cf-nel","max_age":604800}'
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=%2Fp67lxiyoVha01J1EcLS%2F28jm5qcUthrB%2F8DC%2FwMV1lrYBzDyaD53Nt%2B%2FrBD4VDDN%2BnS9M3wW9ZV0AIZyxxOcXkAGYl3i5ZOREPrsV%2Fym9uJ7Y1Zs2zQpIpzFy01YUkl6uWnr%2FoTDik%3D"}],"group":"cf-nel","max_age":604800}'
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -229,7 +213,7 @@ interactions:
       Vary:
       - Accept-Encoding
       X-Cache-Backend:
-      - apigw1_8000 rb11
+      - apigw1_8000 rb7
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -237,17 +221,19 @@ interactions:
       X-Frame-Options:
       - SAMEORIGIN
       X-Kong-Proxy-Latency:
-      - '0'
+      - '1'
       X-Kong-Upstream-Latency:
-      - '43'
+      - '267'
       X-RateLimit-Limit-Second:
       - '5'
       X-RateLimit-Remaining-Second:
       - '4'
       X-Request-Id:
-      - 079e018e-43c6-4b42-b83f-cd4c8f7fd025
+      - d4f90665-f95f-4288-8da6-d18abd6541de
       X-Runtime:
-      - '0.041305'
+      - '0.095390'
+      X-StackifyID:
+      - V1|ab24cafa-85d2-41db-9956-127164f946d6|C98087|CD1
       X-Var-Cache:
       - MISS
       X-Via:

--- a/tests/cassettes/opensubtitlescom/test_query_query_movie.yaml
+++ b/tests/cassettes/opensubtitlescom/test_query_query_movie.yaml
@@ -5,7 +5,7 @@ interactions:
       Accept:
       - '*/*'
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Api-Key:
       - mij33pjc3kOlup1qOKxnWWxvle2kFbMH
       Connection:
@@ -18,26 +18,31 @@ interactions:
     uri: https://api.opensubtitles.com/api/v1/subtitles?languages=fr&query=man+of+steel
   response:
     body:
-      string: "{\"total_pages\":1,\"total_count\":6,\"per_page\":60,\"page\":1,\"data\":[{\"id\":\"880511\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"880511\",\"language\":\"fr\",\"download_count\":35322,\"new_download_count\":264,\"hearing_impaired\":false,\"hd\":true,\"fps\":0.0,\"votes\":0,\"ratings\":0.0,\"from_trusted\":true,\"foreign_parts_only\":false,\"upload_date\":\"2013-10-18T14:26:47Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"man.of.steel.2013.720p.bluray.x264-felony.www.subsynchro.com\",\"comments\":\"\",\"legacy_subtitle_id\":5229112,\"legacy_uploader_id\":1430515,\"uploader\":{\"uploader_id\":59162,\"name\":\"smailpouri\",\"rank\":\"Trusted
-        member\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/fr/subtitles/legacy/5229112\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/fr/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":962144,\"cd_number\":1,\"file_name\":\"man.of.steel.2013.720p.bluray.x264-felony.www.subsynchro.com\"}]}},{\"id\":\"870964\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"870964\",\"language\":\"fr\",\"download_count\":22032,\"new_download_count\":89,\"hearing_impaired\":false,\"hd\":true,\"fps\":0.0,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2013-07-26T08:47:00Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Man.of.Steel.2013.720p.R6.LiNE.x264.AAC-DiGiTAL\",\"comments\":\"\",\"legacy_subtitle_id\":5105960,\"legacy_uploader_id\":0,\"uploader\":{\"uploader_id\":3282,\"name\":\"os-auto\",\"rank\":\"Application
-        Developers\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/fr/subtitles/legacy/5105960\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/fr/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":952177,\"cd_number\":1,\"file_name\":\"Man.of.Steel.2013.R6.LiNE.All.Version-fr\"}]}},{\"id\":\"879122\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"879122\",\"language\":\"fr\",\"download_count\":20172,\"new_download_count\":203,\"hearing_impaired\":false,\"hd\":true,\"fps\":23.976,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2013-10-16T16:56:06Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"man.of.steel.2013.720p.bluray.x264-felony\",\"comments\":\"\",\"legacy_subtitle_id\":5226251,\"legacy_uploader_id\":0,\"uploader\":{\"uploader_id\":3282,\"name\":\"os-auto\",\"rank\":\"Application
-        Developers\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/fr/subtitles/legacy/5226251\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/fr/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":960683,\"cd_number\":1,\"file_name\":\"man.of.steel.2013.720p.bluray.x264-felony.www.subsynchro.com\"}]}},{\"id\":\"877697\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"877697\",\"language\":\"fr\",\"download_count\":17037,\"new_download_count\":130,\"hearing_impaired\":false,\"hd\":true,\"fps\":0.0,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2013-10-16T09:35:02Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"man.of.steel.2013.1080p.bluray.x264-sector7\",\"comments\":\"\",\"legacy_subtitle_id\":5225852,\"legacy_uploader_id\":0,\"uploader\":{\"uploader_id\":3282,\"name\":\"os-auto\",\"rank\":\"Application
-        Developers\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/fr/subtitles/legacy/5225852\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/fr/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":959227,\"cd_number\":1,\"file_name\":\"man.of.steel.2013.1080p.bluray.x264-sector7\"}]}},{\"id\":\"4614499\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"4614499\",\"language\":\"fr\",\"download_count\":4213,\"new_download_count\":98,\"hearing_impaired\":false,\"hd\":true,\"fps\":23.976,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2018-11-01T17:26:02Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Supergirl.S04E03.720p.HDTV.x264-AVS\",\"comments\":\"\",\"legacy_subtitle_id\":7528072,\"legacy_uploader_id\":2592971,\"uploader\":{\"uploader_id\":69404,\"name\":\"maxoudela\",\"rank\":\"Gold
-        member\"},\"feature_details\":{\"feature_id\":429415,\"feature_type\":\"Episode\",\"year\":2015,\"title\":\"Man
-        of Steel\",\"movie_name\":\"Supergirl - S04E03  L'\xE2ge de l'acier\",\"imdb_id\":8685330,\"tmdb_id\":1593206,\"season_number\":4,\"episode_number\":3,\"parent_imdb_id\":4016454,\"parent_title\":\"Supergirl\",\"parent_tmdb_id\":62688,\"parent_feature_id\":15301},\"url\":\"https://www.opensubtitles.com/fr/subtitles/legacy/7528072\",\"related_links\":[{\"label\":\"All
-        subtitles for Tv Show Supergirl\",\"url\":\"https://www.opensubtitles.com/fr/features/redirect/15301\",\"img_url\":\"https://s9.opensubtitles.com/features/5/1/4/429415.jpg\"},{\"label\":\"All
-        subtitles for Episode man of steel\",\"url\":\"https://www.opensubtitles.com/fr/features/redirect/429415\"}],\"files\":[{\"file_id\":4737481,\"cd_number\":1,\"file_name\":\"Supergirl.S04E03.720p.HDTV.x264-AVS\"}]}},{\"id\":\"1546744\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"1546744\",\"language\":\"fr\",\"download_count\":87,\"new_download_count\":3,\"hearing_impaired\":false,\"hd\":true,\"fps\":0.0,\"votes\":0,\"ratings\":0.0,\"from_trusted\":true,\"foreign_parts_only\":false,\"upload_date\":\"2012-05-11T12:51:44Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Standoff[1].S01E07.hdtv.xvid-xor.VF\",\"comments\":\"\",\"legacy_subtitle_id\":4545822,\"legacy_uploader_id\":1465168,\"uploader\":{\"uploader_id\":60242,\"name\":\"subth1ck\",\"rank\":\"trusted\"},\"feature_details\":{\"feature_id\":116746,\"feature_type\":\"Episode\",\"year\":2006,\"title\":\"Man
-        of Steele\",\"movie_name\":\"Standoff - S1E7 \\\"Standoff\\\" Man of Steele\",\"imdb_id\":852891,\"tmdb_id\":1210425,\"season_number\":1,\"episode_number\":7,\"parent_imdb_id\":756582,\"parent_title\":\"Standoff\",\"parent_tmdb_id\":630,\"parent_feature_id\":8050},\"url\":\"https://www.opensubtitles.com/fr/subtitles/legacy/4545822\",\"related_links\":[{\"label\":\"All
-        subtitles for Tv Show Standoff\",\"url\":\"https://www.opensubtitles.com/fr/features/redirect/8050\",\"img_url\":\"https://s9.opensubtitles.com/features/6/4/7/116746.jpg\"},{\"label\":\"All
-        subtitles for Episode man of steele\",\"url\":\"https://www.opensubtitles.com/fr/features/redirect/116746\"}],\"files\":[{\"file_id\":1638900,\"cd_number\":1,\"file_name\":\"Standoff[1].S01E07.hdtv.xvid-xor.VF\"}]}}]}"
+      string: !!binary |
+        0VDeACCXLqsopXrvfgHdQh/K9n3te15KNsJWLSBKgvG4ppwlF6U3/X4ulC3lla5pcXlpw0N7hoq8
+        j4m0iWYsiVZCoZNNEpHoKa2ROCJLyHUiIcSPymgGE31Rekvlgmze7gGeUf8y3eJOPoMltiSPDrQE
+        WMVg8alELrAKGfx2r4hB71YH9q8HCD1YMAYlETBYr4sHC3k7rGEdPTDwQQTYh3820oliPOXAwpCA
+        gWIYy0k2SknJYPaX7t8HwrVkcPYuhfnUhWlxIfke7ODG7Bmce7Br2jyDYclgsUIGdxFQeWSQ3Brm
+        08dRhhSnbk1bXr3kxjH5cJq7xaU1d3Eer5P32RYod9+71YMFjtSUhCWZPQnLlRX6T2DgQvdcC/uP
+        bkWWMh+6Y29xfM2TKgsenuRH77IHC5ObqzhUefV+rDhSU2mOS3UYt+Su1T1Xohz8GOdrdblcqrwd
+        8nU+nlOsjnECBu4/PlgABqM/ueO1c0ZByXlLxAtA9Xx8yvlJNChJKq3SJ7APUGoR2ZLiDGY3+X9X
+        kwvjErcUgEFy81ewsLdsveIhrcbDjcGVUNy7O8oD8YH/DCY7z6BWWBTF1o7ex7vggcHVuwSWIzUM
+        YmrPYOG9m4s4FLvV+xEYTPEu+A6XehypKcqiWEyY+oMS5bVGww2D9Y/7FK3kdGOwpREsnNd1ybau
+        L5dLFRc/B3K9/LIRRAypzq61Ed1qo7qAJxdxq++7Mcxf80xDP1fHgmDh8TgWwrmKIaZigsjNtQEA
+        KOuT6yDMP7m5jEM5lUnCdOqm1GVuV9DQpXKNtap1bX/6+UGWuv3DYAijR+83hJn3KK3iJASDY989
+        alrAHqAIMnrdhW367Z/bjbGLFWtslcCiNcpycI4Nf3strRAP1OKRZaAuudqjsUJbxMR5z2+X84uq
+        3oUPz9cXQvX48dPyWXgZ9o/fEYoDEMpWYXORSvo13KyUxVy6bY27Iz9eljEc3RriXDz0XUvHp0wn
+        0KTmSZZbctK6ijjFIXpDj8ex+tWnHOJcDok6ZN0S50i0ZlkaJD1KHJtGya/Lm6rVij7+YYQlqT0p
+        K5VF1TCplVbIz4DikogDmtRMaYN8BlSmSbLWqtVItEZZDtLY6A+CGrmGTPKnYmsbaZGnwQiNs/Ql
+        ++Mak37/KZBG8mShSCP7MlYoW851NWOU0QbRX6FIiLblDkq2RsdpCE7N6r1oTRuEpZiSqETak7Zc
+        2fe1dtvi0ymksdqheI4kH/vq2f7XUZGRP/511/rQipbcoB7/cFguW95q4qlWoDA2ufu49X50fZfR
+        ehnHsQ87C94KkiqfLyHHfikGSUwVWpTF9laL4t33//938kXvi/F7dww+AY8oN8rIpsEGyUYk24aj
+        YpC9y3GudmMFA4+N1MSrNAwWl/y8drxUUCApIcU/MXACrh78G3NZhuLKmH8xbDRnJBskNeTx2swm
+        9nfF7hwvBe7aYDbCS+2Sf5j/LrUatd1AyiVrqkUdJJDYms1wo7Cpi4YdOWUCHX5Wi021LXSjhaE1
+        icbqzrQMGtVjkkJpMfxDydao/dUcs3sNmkFl1sFLlCXRnriVZIVIL/Hd6uY+DsNf9E+1Q3qOujr3
+        6111fxf68j6m6tcXPTetCCmk4fzp0CSUJGX6IRcdOCN5O6xnOn4d9sHmq+E4j06JlBaKOiVA1bhf
+        IzNVLMpiR8918bfhBv0bCmmKQBdIblpa2ZkTCi4FkACtREslDedI1NvEaKpkz4AGRRhGmiuDEtuC
+        yNl1Qp0U5rqhoNk2KJE4c6la1LoOkbrIbecJH5x6tdqg2ifVmBaROZH9qj27Zrv9c7v9cwM=
     headers:
       Access-Control-Allow-Headers:
       - Origin, Authorization, Accept, Api-Key, Content-Type, X-User-Agent
@@ -45,32 +50,34 @@ interactions:
       - GET, HEAD, POST, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
+      Age:
+      - '48860'
       CF-Cache-Status:
-      - MISS
+      - HIT
       CF-RAY:
-      - 87c7043829fa527a-LHR
+      - 883aac489fcf3cb9-CDG
       Cache-Control:
       - public, max-age=86400
       Connection:
       - keep-alive
       Content-Encoding:
-      - gzip
+      - br
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 30 Apr 2024 10:58:24 GMT
+      - Tue, 14 May 2024 11:50:50 GMT
       Last-Modified:
-      - Tue, 30 Apr 2024 10:58:24 GMT
+      - Mon, 13 May 2024 22:16:30 GMT
       NEL:
       - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
       RateLimit-Limit:
       - '5'
       RateLimit-Remaining:
-      - '2'
+      - '4'
       RateLimit-Reset:
       - '1'
       Report-To:
-      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=FPC1gARU3W6zQKdeI9Mxh%2BrYpHCuVz%2BnsMe%2Bu3VmOuHaiqh61jVIalYx%2BQmaKiZ7mOz9OxrS8oR3U3mkNQTcJI6MY1qiX0XQdN9tvl%2FW1XKKz2YVG6fCEyAhodISZytNiRpn3jRBddg%3D"}],"group":"cf-nel","max_age":604800}'
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=WNBLGkxYQCdpjgJhNezupVA%2FQQJn6g2MLlsNex44Npa63TT6zDgOkqclYgSybW7DdcRHld1KWxAFUEpkTGSOh0wmdMdMeulH6U20w7ErfGLI24U8wFOW8Z%2FJ5I9YF9oxUu7anpz5Xuw%3D"}],"group":"cf-nel","max_age":604800}'
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -80,7 +87,7 @@ interactions:
       Vary:
       - Accept-Encoding
       X-Cache-Backend:
-      - apigw1_8000 rb1-temp
+      - apigw1_8000 rb11
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -90,15 +97,15 @@ interactions:
       X-Kong-Proxy-Latency:
       - '0'
       X-Kong-Upstream-Latency:
-      - '69'
+      - '347'
       X-RateLimit-Limit-Second:
       - '5'
       X-RateLimit-Remaining-Second:
-      - '2'
+      - '4'
       X-Request-Id:
-      - 2aea613e-c1a6-465f-a838-b4064e1337af
+      - 18208fa7-8bdb-4594-8c6b-4e0369ccf613
       X-Runtime:
-      - '0.066170'
+      - '0.185281'
       X-Var-Cache:
       - MISS
       X-Via:
@@ -122,7 +129,7 @@ interactions:
       Accept:
       - '*/*'
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Api-Key:
       - mij33pjc3kOlup1qOKxnWWxvle2kFbMH
       Connection:
@@ -135,26 +142,31 @@ interactions:
     uri: https://api.opensubtitles.com/api/v1/subtitles?languages=fr&query=man+of+steel
   response:
     body:
-      string: "{\"total_pages\":1,\"total_count\":6,\"per_page\":60,\"page\":1,\"data\":[{\"id\":\"880511\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"880511\",\"language\":\"fr\",\"download_count\":35322,\"new_download_count\":264,\"hearing_impaired\":false,\"hd\":true,\"fps\":0.0,\"votes\":0,\"ratings\":0.0,\"from_trusted\":true,\"foreign_parts_only\":false,\"upload_date\":\"2013-10-18T14:26:47Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"man.of.steel.2013.720p.bluray.x264-felony.www.subsynchro.com\",\"comments\":\"\",\"legacy_subtitle_id\":5229112,\"legacy_uploader_id\":1430515,\"uploader\":{\"uploader_id\":59162,\"name\":\"smailpouri\",\"rank\":\"Trusted
-        member\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/fr/subtitles/legacy/5229112\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/fr/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":962144,\"cd_number\":1,\"file_name\":\"man.of.steel.2013.720p.bluray.x264-felony.www.subsynchro.com\"}]}},{\"id\":\"870964\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"870964\",\"language\":\"fr\",\"download_count\":22032,\"new_download_count\":89,\"hearing_impaired\":false,\"hd\":true,\"fps\":0.0,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2013-07-26T08:47:00Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Man.of.Steel.2013.720p.R6.LiNE.x264.AAC-DiGiTAL\",\"comments\":\"\",\"legacy_subtitle_id\":5105960,\"legacy_uploader_id\":0,\"uploader\":{\"uploader_id\":3282,\"name\":\"os-auto\",\"rank\":\"Application
-        Developers\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/fr/subtitles/legacy/5105960\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/fr/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":952177,\"cd_number\":1,\"file_name\":\"Man.of.Steel.2013.R6.LiNE.All.Version-fr\"}]}},{\"id\":\"879122\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"879122\",\"language\":\"fr\",\"download_count\":20172,\"new_download_count\":203,\"hearing_impaired\":false,\"hd\":true,\"fps\":23.976,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2013-10-16T16:56:06Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"man.of.steel.2013.720p.bluray.x264-felony\",\"comments\":\"\",\"legacy_subtitle_id\":5226251,\"legacy_uploader_id\":0,\"uploader\":{\"uploader_id\":3282,\"name\":\"os-auto\",\"rank\":\"Application
-        Developers\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/fr/subtitles/legacy/5226251\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/fr/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":960683,\"cd_number\":1,\"file_name\":\"man.of.steel.2013.720p.bluray.x264-felony.www.subsynchro.com\"}]}},{\"id\":\"877697\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"877697\",\"language\":\"fr\",\"download_count\":17037,\"new_download_count\":130,\"hearing_impaired\":false,\"hd\":true,\"fps\":0.0,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2013-10-16T09:35:02Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"man.of.steel.2013.1080p.bluray.x264-sector7\",\"comments\":\"\",\"legacy_subtitle_id\":5225852,\"legacy_uploader_id\":0,\"uploader\":{\"uploader_id\":3282,\"name\":\"os-auto\",\"rank\":\"Application
-        Developers\"},\"feature_details\":{\"feature_id\":580760,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Man
-        of Steel\",\"movie_name\":\"2013 - Man of Steel\",\"imdb_id\":770828,\"tmdb_id\":49521},\"url\":\"https://www.opensubtitles.com/fr/subtitles/legacy/5225852\",\"related_links\":[{\"label\":\"All
-        subtitles for man of steel\",\"url\":\"https://www.opensubtitles.com/fr/movies/2013-man-of-steel\",\"img_url\":\"https://s9.opensubtitles.com/features/0/6/7/580760.jpg\"}],\"files\":[{\"file_id\":959227,\"cd_number\":1,\"file_name\":\"man.of.steel.2013.1080p.bluray.x264-sector7\"}]}},{\"id\":\"4614499\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"4614499\",\"language\":\"fr\",\"download_count\":4213,\"new_download_count\":98,\"hearing_impaired\":false,\"hd\":true,\"fps\":23.976,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2018-11-01T17:26:02Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Supergirl.S04E03.720p.HDTV.x264-AVS\",\"comments\":\"\",\"legacy_subtitle_id\":7528072,\"legacy_uploader_id\":2592971,\"uploader\":{\"uploader_id\":69404,\"name\":\"maxoudela\",\"rank\":\"Gold
-        member\"},\"feature_details\":{\"feature_id\":429415,\"feature_type\":\"Episode\",\"year\":2015,\"title\":\"Man
-        of Steel\",\"movie_name\":\"Supergirl - S04E03  L'\xE2ge de l'acier\",\"imdb_id\":8685330,\"tmdb_id\":1593206,\"season_number\":4,\"episode_number\":3,\"parent_imdb_id\":4016454,\"parent_title\":\"Supergirl\",\"parent_tmdb_id\":62688,\"parent_feature_id\":15301},\"url\":\"https://www.opensubtitles.com/fr/subtitles/legacy/7528072\",\"related_links\":[{\"label\":\"All
-        subtitles for Tv Show Supergirl\",\"url\":\"https://www.opensubtitles.com/fr/features/redirect/15301\",\"img_url\":\"https://s9.opensubtitles.com/features/5/1/4/429415.jpg\"},{\"label\":\"All
-        subtitles for Episode man of steel\",\"url\":\"https://www.opensubtitles.com/fr/features/redirect/429415\"}],\"files\":[{\"file_id\":4737481,\"cd_number\":1,\"file_name\":\"Supergirl.S04E03.720p.HDTV.x264-AVS\"}]}},{\"id\":\"1546744\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"1546744\",\"language\":\"fr\",\"download_count\":87,\"new_download_count\":3,\"hearing_impaired\":false,\"hd\":true,\"fps\":0.0,\"votes\":0,\"ratings\":0.0,\"from_trusted\":true,\"foreign_parts_only\":false,\"upload_date\":\"2012-05-11T12:51:44Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Standoff[1].S01E07.hdtv.xvid-xor.VF\",\"comments\":\"\",\"legacy_subtitle_id\":4545822,\"legacy_uploader_id\":1465168,\"uploader\":{\"uploader_id\":60242,\"name\":\"subth1ck\",\"rank\":\"trusted\"},\"feature_details\":{\"feature_id\":116746,\"feature_type\":\"Episode\",\"year\":2006,\"title\":\"Man
-        of Steele\",\"movie_name\":\"Standoff - S1E7 \\\"Standoff\\\" Man of Steele\",\"imdb_id\":852891,\"tmdb_id\":1210425,\"season_number\":1,\"episode_number\":7,\"parent_imdb_id\":756582,\"parent_title\":\"Standoff\",\"parent_tmdb_id\":630,\"parent_feature_id\":8050},\"url\":\"https://www.opensubtitles.com/fr/subtitles/legacy/4545822\",\"related_links\":[{\"label\":\"All
-        subtitles for Tv Show Standoff\",\"url\":\"https://www.opensubtitles.com/fr/features/redirect/8050\",\"img_url\":\"https://s9.opensubtitles.com/features/6/4/7/116746.jpg\"},{\"label\":\"All
-        subtitles for Episode man of steele\",\"url\":\"https://www.opensubtitles.com/fr/features/redirect/116746\"}],\"files\":[{\"file_id\":1638900,\"cd_number\":1,\"file_name\":\"Standoff[1].S01E07.hdtv.xvid-xor.VF\"}]}}]}"
+      string: !!binary |
+        0VDeACCXLqsopXrvfgHdQh/K9n3te15KNsJWLSBKgvG4ppwlF6U3/X4ulC3lla5pcXlpw0N7hoq8
+        j4m0iWYsiVZCoZNNEpHoKa2ROCJLyHUiIcSPymgGE31Rekvlgmze7gGeUf8y3eJOPoMltiSPDrQE
+        WMVg8alELrAKGfx2r4hB71YH9q8HCD1YMAYlETBYr4sHC3k7rGEdPTDwQQTYh3820oliPOXAwpCA
+        gWIYy0k2SknJYPaX7t8HwrVkcPYuhfnUhWlxIfke7ODG7Bmce7Br2jyDYclgsUIGdxFQeWSQ3Brm
+        08dRhhSnbk1bXr3kxjH5cJq7xaU1d3Eer5P32RYod9+71YMFjtSUhCWZPQnLlRX6T2DgQvdcC/uP
+        bkWWMh+6Y29xfM2TKgsenuRH77IHC5ObqzhUefV+rDhSU2mOS3UYt+Su1T1Xohz8GOdrdblcqrwd
+        8nU+nlOsjnECBu4/PlgABqM/ueO1c0ZByXlLxAtA9Xx8yvlJNChJKq3SJ7APUGoR2ZLiDGY3+X9X
+        kwvjErcUgEFy81ewsLdsveIhrcbDjcGVUNy7O8oD8YH/DCY7z6BWWBTF1o7ex7vggcHVuwSWIzUM
+        YmrPYOG9m4s4FLvV+xEYTPEu+A6XehypKcqiWEyY+oMS5bVGww2D9Y/7FK3kdGOwpREsnNd1ybau
+        L5dLFRc/B3K9/LIRRAypzq61Ed1qo7qAJxdxq++7Mcxf80xDP1fHgmDh8TgWwrmKIaZigsjNtQEA
+        KOuT6yDMP7m5jEM5lUnCdOqm1GVuV9DQpXKNtap1bX/6+UGWuv3DYAijR+83hJn3KK3iJASDY989
+        alrAHqAIMnrdhW367Z/bjbGLFWtslcCiNcpycI4Nf3strRAP1OKRZaAuudqjsUJbxMR5z2+X84uq
+        3oUPz9cXQvX48dPyWXgZ9o/fEYoDEMpWYXORSvo13KyUxVy6bY27Iz9eljEc3RriXDz0XUvHp0wn
+        0KTmSZZbctK6ijjFIXpDj8ex+tWnHOJcDok6ZN0S50i0ZlkaJD1KHJtGya/Lm6rVij7+YYQlqT0p
+        K5VF1TCplVbIz4DikogDmtRMaYN8BlSmSbLWqtVItEZZDtLY6A+CGrmGTPKnYmsbaZGnwQiNs/Ql
+        ++Mak37/KZBG8mShSCP7MlYoW851NWOU0QbRX6FIiLblDkq2RsdpCE7N6r1oTRuEpZiSqETak7Zc
+        2fe1dtvi0ymksdqheI4kH/vq2f7XUZGRP/511/rQipbcoB7/cFguW95q4qlWoDA2ufu49X50fZfR
+        ehnHsQ87C94KkiqfLyHHfikGSUwVWpTF9laL4t33//938kXvi/F7dww+AY8oN8rIpsEGyUYk24aj
+        YpC9y3GudmMFA4+N1MSrNAwWl/y8drxUUCApIcU/MXACrh78G3NZhuLKmH8xbDRnJBskNeTx2swm
+        9nfF7hwvBe7aYDbCS+2Sf5j/LrUatd1AyiVrqkUdJJDYms1wo7Cpi4YdOWUCHX5Wi021LXSjhaE1
+        icbqzrQMGtVjkkJpMfxDydao/dUcs3sNmkFl1sFLlCXRnriVZIVIL/Hd6uY+DsNf9E+1Q3qOujr3
+        6111fxf68j6m6tcXPTetCCmk4fzp0CSUJGX6IRcdOCN5O6xnOn4d9sHmq+E4j06JlBaKOiVA1bhf
+        IzNVLMpiR8918bfhBv0bCmmKQBdIblpa2ZkTCi4FkACtREslDedI1NvEaKpkz4AGRRhGmiuDEtuC
+        yNl1Qp0U5rqhoNk2KJE4c6la1LoOkbrIbecJH5x6tdqg2ifVmBaROZH9qj27Zrv9c7v9cwM=
     headers:
       Access-Control-Allow-Headers:
       - Origin, Authorization, Accept, Api-Key, Content-Type, X-User-Agent
@@ -163,33 +175,33 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '1'
+      - '48861'
       CF-Cache-Status:
       - HIT
       CF-RAY:
-      - 87c7043a8bda0666-LHR
+      - 883aac48e82a3cb9-CDG
       Cache-Control:
       - public, max-age=86400
       Connection:
       - keep-alive
       Content-Encoding:
-      - gzip
+      - br
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 30 Apr 2024 10:58:25 GMT
+      - Tue, 14 May 2024 11:50:51 GMT
       Last-Modified:
-      - Tue, 30 Apr 2024 10:58:24 GMT
+      - Mon, 13 May 2024 22:16:30 GMT
       NEL:
       - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
       RateLimit-Limit:
       - '5'
       RateLimit-Remaining:
-      - '2'
+      - '4'
       RateLimit-Reset:
       - '1'
       Report-To:
-      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=3afkawid%2BUzYoppedmwWR8%2FxQPqgRVaa9ponHrmHcKDRlv%2FMPbUYFGo7xE8Gv0ulbEbfvN76d79t6RN8wcE%2Faxxgs8bGXPUL6PVctoewhAuTaoi8hII99Fvgr3fwZrGNhSuJClI8GZc%3D"}],"group":"cf-nel","max_age":604800}'
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=%2BQpz1Tmnr%2F3c86Yzfwib4jBkfXKn5SB9fh3rtRsDHb4tB9crgDKgZ1prv8tJscq%2BVVZWsi8GYmhBYrJOVlf%2B73r4N5NQ46g5S3r6ers3BUbDufaIeWursac0zLGWUwhYOweQgqdfu%2F0%3D"}],"group":"cf-nel","max_age":604800}'
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -199,7 +211,7 @@ interactions:
       Vary:
       - Accept-Encoding
       X-Cache-Backend:
-      - apigw1_8000 rb1-temp
+      - apigw1_8000 rb11
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -209,15 +221,15 @@ interactions:
       X-Kong-Proxy-Latency:
       - '0'
       X-Kong-Upstream-Latency:
-      - '69'
+      - '347'
       X-RateLimit-Limit-Second:
       - '5'
       X-RateLimit-Remaining-Second:
-      - '2'
+      - '4'
       X-Request-Id:
-      - 2aea613e-c1a6-465f-a838-b4064e1337af
+      - 18208fa7-8bdb-4594-8c6b-4e0369ccf613
       X-Runtime:
-      - '0.066170'
+      - '0.185281'
       X-Var-Cache:
       - MISS
       X-Via:

--- a/tests/cassettes/opensubtitlescom/test_query_query_season_episode.yaml
+++ b/tests/cassettes/opensubtitlescom/test_query_query_season_episode.yaml
@@ -5,7 +5,7 @@ interactions:
       Accept:
       - '*/*'
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Api-Key:
       - mij33pjc3kOlup1qOKxnWWxvle2kFbMH
       Connection:
@@ -18,19 +18,22 @@ interactions:
     uri: https://api.opensubtitles.com/api/v1/subtitles?episode_number=5&languages=de&query=the+big+bang+theory&season_number=7
   response:
     body:
-      string: '{"total_pages":1,"total_count":2,"per_page":60,"page":1,"data":[{"id":"2748964","type":"subtitle","attributes":{"subtitle_id":"2748964","language":"de","download_count":17595,"new_download_count":108,"hearing_impaired":false,"hd":true,"fps":23.976,"votes":0,"ratings":0.0,"from_trusted":false,"foreign_parts_only":false,"upload_date":"2013-10-19T09:58:22Z","ai_translated":false,"nb_cd":1,"machine_translated":false,"release":"The.Big.Bang.Theory.S07E05.720p.HDTV.X264-DIMENSION.de-SC+TV4U","comments":"","legacy_subtitle_id":5230500,"legacy_uploader_id":0,"uploader":{"uploader_id":3282,"name":"os-auto","rank":"Application
-        Developers"},"feature_details":{"feature_id":160627,"feature_type":"Episode","year":2013,"title":"The
-        Workplace Proximity","movie_name":"The Big Bang Theory - S7E5 \"The Big Bang
-        Theory\" The Workplace Proximity","imdb_id":3229392,"tmdb_id":64782,"season_number":7,"episode_number":5,"parent_imdb_id":898266,"parent_title":"The
-        Big Bang Theory","parent_tmdb_id":1418,"parent_feature_id":8620},"url":"https://www.opensubtitles.com/de/subtitles/legacy/5230500","related_links":[{"label":"All
-        subtitles for Tv Show The Big Bang Theory","url":"https://www.opensubtitles.com/de/features/redirect/8620","img_url":"https://s9.opensubtitles.com/features/7/2/6/160627.jpg"},{"label":"All
-        subtitles for Episode the workplace proximity","url":"https://www.opensubtitles.com/de/features/redirect/160627"}],"files":[{"file_id":2822058,"cd_number":1,"file_name":"The.Big.Bang.Theory.S07E05.720p.HDTV.X264-DIMENSION.de-SC+TV4U"}]}},{"id":"4662161","type":"subtitle","attributes":{"subtitle_id":"4662161","language":"de","download_count":315,"new_download_count":143,"hearing_impaired":true,"hd":true,"fps":23.976,"votes":0,"ratings":0.0,"from_trusted":false,"foreign_parts_only":false,"upload_date":"2018-12-31T06:00:27Z","ai_translated":false,"nb_cd":1,"machine_translated":false,"release":"The.Big.Bang.Theory.S07E05.German.DL.1080p.BluRay.x264","comments":"","legacy_subtitle_id":7593069,"legacy_uploader_id":0,"uploader":{"uploader_id":3282,"name":"os-auto","rank":"Application
-        Developers"},"feature_details":{"feature_id":160627,"feature_type":"Episode","year":2013,"title":"The
-        Workplace Proximity","movie_name":"The Big Bang Theory - S07E05  The Workplace
-        Proximity","imdb_id":3229392,"tmdb_id":64782,"season_number":7,"episode_number":5,"parent_imdb_id":898266,"parent_title":"The
-        Big Bang Theory","parent_tmdb_id":1418,"parent_feature_id":8620},"url":"https://www.opensubtitles.com/de/subtitles/legacy/7593069","related_links":[{"label":"All
-        subtitles for Tv Show The Big Bang Theory","url":"https://www.opensubtitles.com/de/features/redirect/8620","img_url":"https://s9.opensubtitles.com/features/7/2/6/160627.jpg"},{"label":"All
-        subtitles for Episode the workplace proximity","url":"https://www.opensubtitles.com/de/features/redirect/160627"}],"files":[{"file_id":4785161,"cd_number":1,"file_name":"The.Big.Bang.Theory.S07E05.German.DL.1080p.BluRay.x264-iND"}]}}]}'
+      string: !!binary |
+        wUBdACD22dQ/XZm9fgGSMAJ0SyntN0Yxz1gT2khynMbENV3fn/z/vIOffmuLCEpM0PGsz5M2kPk4
+        EvDxSRc2w4HIbOrIauKgoy0lBz1x0i9f9Y2M+ifUk2nJQwu2EbMDjYKWDBM5CR9oxRmurCUYGhMM
+        9J9v2AYasliUlVqAIXxOBA2/eQ02dASGQdChvxsr1X1xRAnQaAgMpuFoTi2KvMoZBtrWzTsSnGFN
+        xtmhrW0/GeuogV6ZzhPDuoEObkMMq8lDyyypCsXwPoIykzM4E+zQemiecIaVG/s6uI0PetZYjY5s
+        O9STccHX49B9rspmgmN+YwJBQ3KRxYLHorrnlc5LLeVvMBhbZ1xY0xnN7uG1XjZ+x98/ySq4T446
+        Mp6gcb+mZNe2ya4Z2uR+TaP7TO54ccDzpJB8So737x+TZ6kW8f7JxcHl3cnVZdJQfLf36/5x8QAG
+        GhwPDTB01JrlZz0mwbnMeM65AGqgQq7w3OC+5KC/cVg4k6VkGExP0Bh9bDZhBIMzwxs0dqaps0sT
+        7DhEs1YNJOcxM7yKwtc/l4eQBK8+wDbQQnElC1GMYAseTNaPDYHhk4yDllxkDJxDfLVZ9DS6t6kz
+        S4qu3fhhexs+wdCP75ZqpOPv1xTt2jbaNUMbuXTQKI7uioM8+ivQ4l9E2g3bN6/OSJBVVkmGUPuA
+        WhSlZPBk/DjUk4z1gS4YyBLinJEzTMbREGqNQWVVSqXa0qzMhLAEgjgcu1iIsnuaZ7crleQzw8Z1
+        0FiHMHmdptvtNhknGjhR4v8SA72htJJNicGlRGHAzxEmUFN3dnjzASE1D8lgaOx0XdT5MqLV6KL7
+        9+huPW4j/IXAg3Ghx6eO5szrTksl+RjUaWs9jXxlEqHDp0hlqlKKpSZC2fTMDMBIl5oSqLAlAXAq
+        jhEojljM/xhWtiNXait7U86SpZQ8LxmWDVdYIZ3K5aKFBu/8b55ZJIfuQikplEjpm1dpKhM7aC7R
+        4P1Ux19fxkLGmbjnSnOuZbFk+qLPPMn+eSJ4yadkt9vcms/kQz4h8wzfv7YirzKuqgVx5jcYRWqM
+        E5+PAo9FUeZCiVzv/mGxvdzH/G+e/80=
     headers:
       Access-Control-Allow-Headers:
       - Origin, Authorization, Accept, Api-Key, Content-Type, X-User-Agent
@@ -38,22 +41,24 @@ interactions:
       - GET, HEAD, POST, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
+      Age:
+      - '48859'
       CF-Cache-Status:
-      - MISS
+      - HIT
       CF-RAY:
-      - 87c7044ccf9d0716-LHR
+      - 883aac50e8f9f0f0-CDG
       Cache-Control:
       - public, max-age=86400
       Connection:
       - keep-alive
       Content-Encoding:
-      - gzip
+      - br
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 30 Apr 2024 10:58:28 GMT
+      - Tue, 14 May 2024 11:50:52 GMT
       Last-Modified:
-      - Tue, 30 Apr 2024 10:58:28 GMT
+      - Mon, 13 May 2024 22:16:33 GMT
       NEL:
       - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
       RateLimit-Limit:
@@ -63,7 +68,7 @@ interactions:
       RateLimit-Reset:
       - '1'
       Report-To:
-      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=fbPQgc3nyQt4lpm8i2PytaMULYEQCy7LXz%2BR2ZIt0VvVGe67y5uQoz4qupYKGYRxjg6dehS%2BDM6oxg%2Fzynqoy9xOm8FK1gLiiDUY8F2UbCnve%2FOrmHKeYxo4JHDdCTXSz7O618bxMqI%3D"}],"group":"cf-nel","max_age":604800}'
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=dcjvVmJIz3PtcYZnWgjTVDDLPQklRVjzoPKavDtK4Aaku59fsY91AY2AadQb5BsSVUKu%2BC6RwgGiqkUxHWe9oTwqDK0LbKBri1NvTnmdPiZVbFdTmQpA7LqsqAyP%2BXg3nZJvbLlpJBU%3D"}],"group":"cf-nel","max_age":604800}'
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -73,7 +78,7 @@ interactions:
       Vary:
       - Accept-Encoding
       X-Cache-Backend:
-      - apigw1_8000 rb1-temp
+      - apigw1_8000 rb7
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -81,17 +86,19 @@ interactions:
       X-Frame-Options:
       - SAMEORIGIN
       X-Kong-Proxy-Latency:
-      - '0'
+      - '1'
       X-Kong-Upstream-Latency:
-      - '57'
+      - '322'
       X-RateLimit-Limit-Second:
       - '5'
       X-RateLimit-Remaining-Second:
       - '4'
       X-Request-Id:
-      - d85ca766-2aa4-4050-b262-332d7efd3dd4
+      - dae03172-ed45-4024-ae27-50ac1d5d5cf5
       X-Runtime:
-      - '0.053608'
+      - '0.075396'
+      X-StackifyID:
+      - V1|34fc9055-8702-45ae-a3eb-e890971cdc37|C98087|CD1
       X-Var-Cache:
       - MISS
       X-Via:
@@ -115,7 +122,7 @@ interactions:
       Accept:
       - '*/*'
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Api-Key:
       - mij33pjc3kOlup1qOKxnWWxvle2kFbMH
       Connection:
@@ -128,19 +135,22 @@ interactions:
     uri: https://api.opensubtitles.com/api/v1/subtitles?episode_number=5&languages=de&query=the+big+bang+theory&season_number=7
   response:
     body:
-      string: '{"total_pages":1,"total_count":2,"per_page":60,"page":1,"data":[{"id":"2748964","type":"subtitle","attributes":{"subtitle_id":"2748964","language":"de","download_count":17595,"new_download_count":108,"hearing_impaired":false,"hd":true,"fps":23.976,"votes":0,"ratings":0.0,"from_trusted":false,"foreign_parts_only":false,"upload_date":"2013-10-19T09:58:22Z","ai_translated":false,"nb_cd":1,"machine_translated":false,"release":"The.Big.Bang.Theory.S07E05.720p.HDTV.X264-DIMENSION.de-SC+TV4U","comments":"","legacy_subtitle_id":5230500,"legacy_uploader_id":0,"uploader":{"uploader_id":3282,"name":"os-auto","rank":"Application
-        Developers"},"feature_details":{"feature_id":160627,"feature_type":"Episode","year":2013,"title":"The
-        Workplace Proximity","movie_name":"The Big Bang Theory - S7E5 \"The Big Bang
-        Theory\" The Workplace Proximity","imdb_id":3229392,"tmdb_id":64782,"season_number":7,"episode_number":5,"parent_imdb_id":898266,"parent_title":"The
-        Big Bang Theory","parent_tmdb_id":1418,"parent_feature_id":8620},"url":"https://www.opensubtitles.com/de/subtitles/legacy/5230500","related_links":[{"label":"All
-        subtitles for Tv Show The Big Bang Theory","url":"https://www.opensubtitles.com/de/features/redirect/8620","img_url":"https://s9.opensubtitles.com/features/7/2/6/160627.jpg"},{"label":"All
-        subtitles for Episode the workplace proximity","url":"https://www.opensubtitles.com/de/features/redirect/160627"}],"files":[{"file_id":2822058,"cd_number":1,"file_name":"The.Big.Bang.Theory.S07E05.720p.HDTV.X264-DIMENSION.de-SC+TV4U"}]}},{"id":"4662161","type":"subtitle","attributes":{"subtitle_id":"4662161","language":"de","download_count":315,"new_download_count":143,"hearing_impaired":true,"hd":true,"fps":23.976,"votes":0,"ratings":0.0,"from_trusted":false,"foreign_parts_only":false,"upload_date":"2018-12-31T06:00:27Z","ai_translated":false,"nb_cd":1,"machine_translated":false,"release":"The.Big.Bang.Theory.S07E05.German.DL.1080p.BluRay.x264","comments":"","legacy_subtitle_id":7593069,"legacy_uploader_id":0,"uploader":{"uploader_id":3282,"name":"os-auto","rank":"Application
-        Developers"},"feature_details":{"feature_id":160627,"feature_type":"Episode","year":2013,"title":"The
-        Workplace Proximity","movie_name":"The Big Bang Theory - S07E05  The Workplace
-        Proximity","imdb_id":3229392,"tmdb_id":64782,"season_number":7,"episode_number":5,"parent_imdb_id":898266,"parent_title":"The
-        Big Bang Theory","parent_tmdb_id":1418,"parent_feature_id":8620},"url":"https://www.opensubtitles.com/de/subtitles/legacy/7593069","related_links":[{"label":"All
-        subtitles for Tv Show The Big Bang Theory","url":"https://www.opensubtitles.com/de/features/redirect/8620","img_url":"https://s9.opensubtitles.com/features/7/2/6/160627.jpg"},{"label":"All
-        subtitles for Episode the workplace proximity","url":"https://www.opensubtitles.com/de/features/redirect/160627"}],"files":[{"file_id":4785161,"cd_number":1,"file_name":"The.Big.Bang.Theory.S07E05.German.DL.1080p.BluRay.x264-iND"}]}}]}'
+      string: !!binary |
+        wUBdACD22dQ/XZm9fgGSMAJ0SyntN0Yxz1gT2khynMbENV3fn/z/vIOffmuLCEpM0PGsz5M2kPk4
+        EvDxSRc2w4HIbOrIauKgoy0lBz1x0i9f9Y2M+ifUk2nJQwu2EbMDjYKWDBM5CR9oxRmurCUYGhMM
+        9J9v2AYasliUlVqAIXxOBA2/eQ02dASGQdChvxsr1X1xRAnQaAgMpuFoTi2KvMoZBtrWzTsSnGFN
+        xtmhrW0/GeuogV6ZzhPDuoEObkMMq8lDyyypCsXwPoIykzM4E+zQemiecIaVG/s6uI0PetZYjY5s
+        O9STccHX49B9rspmgmN+YwJBQ3KRxYLHorrnlc5LLeVvMBhbZ1xY0xnN7uG1XjZ+x98/ySq4T446
+        Mp6gcb+mZNe2ya4Z2uR+TaP7TO54ccDzpJB8So737x+TZ6kW8f7JxcHl3cnVZdJQfLf36/5x8QAG
+        GhwPDTB01JrlZz0mwbnMeM65AGqgQq7w3OC+5KC/cVg4k6VkGExP0Bh9bDZhBIMzwxs0dqaps0sT
+        7DhEs1YNJOcxM7yKwtc/l4eQBK8+wDbQQnElC1GMYAseTNaPDYHhk4yDllxkDJxDfLVZ9DS6t6kz
+        S4qu3fhhexs+wdCP75ZqpOPv1xTt2jbaNUMbuXTQKI7uioM8+ivQ4l9E2g3bN6/OSJBVVkmGUPuA
+        WhSlZPBk/DjUk4z1gS4YyBLinJEzTMbREGqNQWVVSqXa0qzMhLAEgjgcu1iIsnuaZ7crleQzw8Z1
+        0FiHMHmdptvtNhknGjhR4v8SA72htJJNicGlRGHAzxEmUFN3dnjzASE1D8lgaOx0XdT5MqLV6KL7
+        9+huPW4j/IXAg3Ghx6eO5szrTksl+RjUaWs9jXxlEqHDp0hlqlKKpSZC2fTMDMBIl5oSqLAlAXAq
+        jhEojljM/xhWtiNXait7U86SpZQ8LxmWDVdYIZ3K5aKFBu/8b55ZJIfuQikplEjpm1dpKhM7aC7R
+        4P1Ux19fxkLGmbjnSnOuZbFk+qLPPMn+eSJ4yadkt9vcms/kQz4h8wzfv7YirzKuqgVx5jcYRWqM
+        E5+PAo9FUeZCiVzv/mGxvdzH/G+e/80=
     headers:
       Access-Control-Allow-Headers:
       - Origin, Authorization, Accept, Api-Key, Content-Type, X-User-Agent
@@ -149,23 +159,23 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '0'
+      - '48859'
       CF-Cache-Status:
       - HIT
       CF-RAY:
-      - 87c7044ecda9527a-LHR
+      - 883aac51292cf0f0-CDG
       Cache-Control:
       - public, max-age=86400
       Connection:
       - keep-alive
       Content-Encoding:
-      - gzip
+      - br
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 30 Apr 2024 10:58:28 GMT
+      - Tue, 14 May 2024 11:50:52 GMT
       Last-Modified:
-      - Tue, 30 Apr 2024 10:58:28 GMT
+      - Mon, 13 May 2024 22:16:33 GMT
       NEL:
       - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
       RateLimit-Limit:
@@ -175,7 +185,7 @@ interactions:
       RateLimit-Reset:
       - '1'
       Report-To:
-      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=x0N3jdQP4mO8NiFQeyCaa31VVQ5BOIMDr76XxNvRhnOQB7jzypvbYCNDBPWfYhgRlwGNUyWz1HGt4WIjkITIpRVk9oGCeIwsIl%2BBtM%2Ftk1%2F07JWuPbyQo7VfGPXKCPrp894D5VRZ9bU%3D"}],"group":"cf-nel","max_age":604800}'
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=EF3IhaEQw0F6dNxTRcaSkMa6GYt%2F7nOTVouV241NJrdbZFzggHSMkrUksAgBulVaOeJRb0F7urdaBKRj3e48T6BjsHYZF6HSZd3RXweL2jPzwQSR6Dc4Mr9g%2BD5XvT6HBLGBNYAItwU%3D"}],"group":"cf-nel","max_age":604800}'
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -185,7 +195,7 @@ interactions:
       Vary:
       - Accept-Encoding
       X-Cache-Backend:
-      - apigw1_8000 rb1-temp
+      - apigw1_8000 rb7
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -193,17 +203,19 @@ interactions:
       X-Frame-Options:
       - SAMEORIGIN
       X-Kong-Proxy-Latency:
-      - '0'
+      - '1'
       X-Kong-Upstream-Latency:
-      - '57'
+      - '322'
       X-RateLimit-Limit-Second:
       - '5'
       X-RateLimit-Remaining-Second:
       - '4'
       X-Request-Id:
-      - d85ca766-2aa4-4050-b262-332d7efd3dd4
+      - dae03172-ed45-4024-ae27-50ac1d5d5cf5
       X-Runtime:
-      - '0.053608'
+      - '0.075396'
+      X-StackifyID:
+      - V1|34fc9055-8702-45ae-a3eb-e890971cdc37|C98087|CD1
       X-Var-Cache:
       - MISS
       X-Via:

--- a/tests/cassettes/opensubtitlescom/test_query_tag_movie.yaml
+++ b/tests/cassettes/opensubtitlescom/test_query_tag_movie.yaml
@@ -5,7 +5,7 @@ interactions:
       Accept:
       - '*/*'
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Api-Key:
       - mij33pjc3kOlup1qOKxnWWxvle2kFbMH
       Connection:
@@ -18,15 +18,21 @@ interactions:
     uri: https://api.opensubtitles.com/api/v1/subtitles?languages=fr&query=enders.game.2013.720p.bluray.x264-sparks.mkv
   response:
     body:
-      string: "{\"total_pages\":1,\"total_count\":2,\"per_page\":60,\"page\":1,\"data\":[{\"id\":\"938965\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"938965\",\"language\":\"fr\",\"download_count\":21081,\"new_download_count\":653,\"hearing_impaired\":false,\"hd\":true,\"fps\":23.976,\"votes\":1,\"ratings\":10.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2014-02-09T15:28:46Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Enders.Game.2013.BDRip.X264-SPARKS\",\"comments\":\"\",\"legacy_subtitle_id\":5532921,\"legacy_uploader_id\":1656162,\"uploader\":{\"uploader_id\":65416,\"name\":\"dumbojet\",\"rank\":\"Bronze
-        Member\"},\"feature_details\":{\"feature_id\":586791,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Ender's
-        Game\",\"movie_name\":\"2013 - La Strat\xE9gie Ender\",\"imdb_id\":1731141,\"tmdb_id\":80274},\"url\":\"https://www.opensubtitles.com/fr/subtitles/legacy/5532921\",\"related_links\":[{\"label\":\"All
-        subtitles for ender's game\",\"url\":\"https://www.opensubtitles.com/fr/movies/2013-ender-s-game\",\"img_url\":\"https://s9.opensubtitles.com/features/1/9/7/586791.jpg\"}],\"files\":[{\"file_id\":1023065,\"cd_number\":1,\"file_name\":\"Enders.Game.2013.BDRip.X264-SPARKS\"}]}},{\"id\":\"940630\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"940630\",\"language\":\"fr\",\"download_count\":1713,\"new_download_count\":23,\"hearing_impaired\":false,\"hd\":false,\"fps\":0.0,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2014-12-29T03:32:34Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Ender's
-        Game 2013 KORSUB HDRip XViD NO1KNOWS\",\"comments\":\"\",\"legacy_subtitle_id\":5982036,\"legacy_uploader_id\":0,\"uploader\":{\"uploader_id\":3282,\"name\":\"os-auto\",\"rank\":\"Application
-        Developers\"},\"feature_details\":{\"feature_id\":586791,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Ender's
-        Game\",\"movie_name\":\"2013 - Ender's Game\",\"imdb_id\":1731141,\"tmdb_id\":80274},\"url\":\"https://www.opensubtitles.com/fr/subtitles/legacy/5982036\",\"related_links\":[{\"label\":\"All
-        subtitles for ender's game\",\"url\":\"https://www.opensubtitles.com/fr/movies/2013-ender-s-game\",\"img_url\":\"https://s9.opensubtitles.com/features/1/9/7/586791.jpg\"}],\"files\":[{\"file_id\":1024868,\"cd_number\":1,\"file_name\":\"Enders
-        Game 2013 KORSUB HDRip XViD NO1KNOWS-fre\"}]}}]}"
+      string: !!binary |
+        wXBFACD+p6pOK++lNFBEoSASm0spqTzI/JSRsB0A2WkchyxzJi4HEmjmkaRRYD83h2sOkDYW6LRo
+        WpgFPoDCqItwCQVoPdfKxSu3PioSl/xaUs0fZNS/oBrtigKMYCeyO9AgGMkwksdwgdGcofVUgqG2
+        0cJ8/gNXw6BURannYIi/RoJBWC+jiy2BwQYamD+DBaqpMD8RMGg8GARDeLmi4IVg6Om5Gj6Z1oLh
+        kax3/apy3WidpxqmsW0ghscaJvo1MTRjgJFqVi40w9MQRb69t9H1qwAj+IwzNH7oqujXIRLaoxk8
+        uVVfjdbHUA19++sZwnrk5/61jQQDyUWecpny8lrMjSxMrj+Bwboq4cK61lI29svqoVY7/PpJUsRj
+        e2rJBoLBTl+TD7M929FMcqFmm9uXbpzdS52nV+cbl0dXYLD05TAAQ0sr+/Crqt7zuZKlFAigEAL5
+        4in0XAstRZtIHuYPsI6v57nQDL3tCAb1ulsO3ymCwdv+Bww2/dD/puSEuiV5TAwvm9DVB/EAP4C7
+        AZZGCr0oBSrkQxudDE+OwPCLrIeRXCgGp4KUsfJNSPZsR2DohidHFVPrSS5UkibHNrmK3sb//1aO
+        Eu05g8F19VKQJWKhhMgFQ+w9sOBykU8Ma9/C4DHGMZgse35+ng0j9UrMCb+JQNP47CIzTVKZZgkY
+        bYaNVFet63+ERRKbm6M3DDbaNqGWm6QbCUkjW2WCAUBo55BJLlRKRZ6GtIPrVhWlpqGUArRLSMhE
+        VmaLzA6x+UCGTF8ZGtcS91LjHOcswaXies7wUFfbpAV8F8CBtJ+ui1qmr9PEgoaKc64Vh6emVXoQ
+        C6GgHakAagIViAvQrchfAv4gIVNZXnNllDQqP6Bl8mgkkguVHJ1dXt1sJvvbl25M7m/ddnJ6Jo5O
+        z+4ihxrKQnKlS+UxQ6tkIWHcEFK7jgOcvTGOrXuw0Q19sp3d3yQfQkcitJeNGaBOv5WiZF7oIn0v
+        nZY2njB9naavEw==
     headers:
       Access-Control-Allow-Headers:
       - Origin, Authorization, Accept, Api-Key, Content-Type, X-User-Agent
@@ -37,29 +43,29 @@ interactions:
       CF-Cache-Status:
       - MISS
       CF-RAY:
-      - 87c7043e09a45280-LHR
+      - 883aac4b4d3e2294-CDG
       Cache-Control:
       - public, max-age=86400
       Connection:
       - keep-alive
       Content-Encoding:
-      - gzip
+      - br
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 30 Apr 2024 10:58:25 GMT
+      - Tue, 14 May 2024 11:50:51 GMT
       Last-Modified:
-      - Tue, 30 Apr 2024 10:58:25 GMT
+      - Tue, 14 May 2024 11:50:51 GMT
       NEL:
       - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
       RateLimit-Limit:
       - '5'
       RateLimit-Remaining:
-      - '3'
+      - '4'
       RateLimit-Reset:
       - '1'
       Report-To:
-      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=oyzq6f8gRUJMSCBiTSrmOf9sDUlO1fqnhKlAt%2B4iwzSxfSDvr5uRHCPFbQbckQe7HJs2%2BofxAmI33m463I3IYbXgh18AO6587Th9NlGjQazayX%2FVEI%2Bsq1W0R8%2FHAPzkiFmyAgRRWrk%3D"}],"group":"cf-nel","max_age":604800}'
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=yfwkL4SfmrQlbJz9uSLYO4dZhNI8RTiC19LPlJlIedl6TUER3mPAPETuAsLgQf1x%2BJMaC1RziOKCXOciVxUQkKNsjfz5TRdX7YNtYSAzK18XLsdl2IriaQRRD%2BFUpuCu2TTiORA7pxM%3D"}],"group":"cf-nel","max_age":604800}'
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -69,7 +75,7 @@ interactions:
       Vary:
       - Accept-Encoding
       X-Cache-Backend:
-      - apigw1_8000 rb1-temp
+      - apigw1_8000 rb8
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -77,17 +83,19 @@ interactions:
       X-Frame-Options:
       - SAMEORIGIN
       X-Kong-Proxy-Latency:
-      - '0'
+      - '1'
       X-Kong-Upstream-Latency:
-      - '50'
+      - '27'
       X-RateLimit-Limit-Second:
       - '5'
       X-RateLimit-Remaining-Second:
-      - '3'
+      - '4'
       X-Request-Id:
-      - 19d58ba0-03a8-4cfa-8c8e-af99e77b47e8
+      - 5d21a066-d15a-4b76-9ee2-be0d34b51d03
       X-Runtime:
-      - '0.045539'
+      - '0.025066'
+      X-StackifyID:
+      - V1|0f155088-2fce-47ef-81d8-d4f821cf3874|C98087|CD1
       X-Var-Cache:
       - MISS
       X-Via:
@@ -111,7 +119,7 @@ interactions:
       Accept:
       - '*/*'
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Api-Key:
       - mij33pjc3kOlup1qOKxnWWxvle2kFbMH
       Connection:
@@ -124,15 +132,21 @@ interactions:
     uri: https://api.opensubtitles.com/api/v1/subtitles?languages=fr&query=enders.game.2013.720p.bluray.x264-sparks.mkv
   response:
     body:
-      string: "{\"total_pages\":1,\"total_count\":2,\"per_page\":60,\"page\":1,\"data\":[{\"id\":\"938965\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"938965\",\"language\":\"fr\",\"download_count\":21081,\"new_download_count\":653,\"hearing_impaired\":false,\"hd\":true,\"fps\":23.976,\"votes\":1,\"ratings\":10.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2014-02-09T15:28:46Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Enders.Game.2013.BDRip.X264-SPARKS\",\"comments\":\"\",\"legacy_subtitle_id\":5532921,\"legacy_uploader_id\":1656162,\"uploader\":{\"uploader_id\":65416,\"name\":\"dumbojet\",\"rank\":\"Bronze
-        Member\"},\"feature_details\":{\"feature_id\":586791,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Ender's
-        Game\",\"movie_name\":\"2013 - La Strat\xE9gie Ender\",\"imdb_id\":1731141,\"tmdb_id\":80274},\"url\":\"https://www.opensubtitles.com/fr/subtitles/legacy/5532921\",\"related_links\":[{\"label\":\"All
-        subtitles for ender's game\",\"url\":\"https://www.opensubtitles.com/fr/movies/2013-ender-s-game\",\"img_url\":\"https://s9.opensubtitles.com/features/1/9/7/586791.jpg\"}],\"files\":[{\"file_id\":1023065,\"cd_number\":1,\"file_name\":\"Enders.Game.2013.BDRip.X264-SPARKS\"}]}},{\"id\":\"940630\",\"type\":\"subtitle\",\"attributes\":{\"subtitle_id\":\"940630\",\"language\":\"fr\",\"download_count\":1713,\"new_download_count\":23,\"hearing_impaired\":false,\"hd\":false,\"fps\":0.0,\"votes\":0,\"ratings\":0.0,\"from_trusted\":false,\"foreign_parts_only\":false,\"upload_date\":\"2014-12-29T03:32:34Z\",\"ai_translated\":false,\"nb_cd\":1,\"machine_translated\":false,\"release\":\"Ender's
-        Game 2013 KORSUB HDRip XViD NO1KNOWS\",\"comments\":\"\",\"legacy_subtitle_id\":5982036,\"legacy_uploader_id\":0,\"uploader\":{\"uploader_id\":3282,\"name\":\"os-auto\",\"rank\":\"Application
-        Developers\"},\"feature_details\":{\"feature_id\":586791,\"feature_type\":\"Movie\",\"year\":2013,\"title\":\"Ender's
-        Game\",\"movie_name\":\"2013 - Ender's Game\",\"imdb_id\":1731141,\"tmdb_id\":80274},\"url\":\"https://www.opensubtitles.com/fr/subtitles/legacy/5982036\",\"related_links\":[{\"label\":\"All
-        subtitles for ender's game\",\"url\":\"https://www.opensubtitles.com/fr/movies/2013-ender-s-game\",\"img_url\":\"https://s9.opensubtitles.com/features/1/9/7/586791.jpg\"}],\"files\":[{\"file_id\":1024868,\"cd_number\":1,\"file_name\":\"Enders
-        Game 2013 KORSUB HDRip XViD NO1KNOWS-fre\"}]}}]}"
+      string: !!binary |
+        wXBFACD+p6pOK++lNFBEoSASm0spqTzI/JSRsB0A2WkchyxzJi4HEmjmkaRRYD83h2sOkDYW6LRo
+        WpgFPoDCqItwCQVoPdfKxSu3PioSl/xaUs0fZNS/oBrtigKMYCeyO9AgGMkwksdwgdGcofVUgqG2
+        0cJ8/gNXw6BURannYIi/RoJBWC+jiy2BwQYamD+DBaqpMD8RMGg8GARDeLmi4IVg6Om5Gj6Z1oLh
+        kax3/apy3WidpxqmsW0ghscaJvo1MTRjgJFqVi40w9MQRb69t9H1qwAj+IwzNH7oqujXIRLaoxk8
+        uVVfjdbHUA19++sZwnrk5/61jQQDyUWecpny8lrMjSxMrj+Bwboq4cK61lI29svqoVY7/PpJUsRj
+        e2rJBoLBTl+TD7M929FMcqFmm9uXbpzdS52nV+cbl0dXYLD05TAAQ0sr+/Crqt7zuZKlFAigEAL5
+        4in0XAstRZtIHuYPsI6v57nQDL3tCAb1ulsO3ymCwdv+Bww2/dD/puSEuiV5TAwvm9DVB/EAP4C7
+        AZZGCr0oBSrkQxudDE+OwPCLrIeRXCgGp4KUsfJNSPZsR2DohidHFVPrSS5UkibHNrmK3sb//1aO
+        Eu05g8F19VKQJWKhhMgFQ+w9sOBykU8Ma9/C4DHGMZgse35+ng0j9UrMCb+JQNP47CIzTVKZZgkY
+        bYaNVFet63+ERRKbm6M3DDbaNqGWm6QbCUkjW2WCAUBo55BJLlRKRZ6GtIPrVhWlpqGUArRLSMhE
+        VmaLzA6x+UCGTF8ZGtcS91LjHOcswaXies7wUFfbpAV8F8CBtJ+ui1qmr9PEgoaKc64Vh6emVXoQ
+        C6GgHakAagIViAvQrchfAv4gIVNZXnNllDQqP6Bl8mgkkguVHJ1dXt1sJvvbl25M7m/ddnJ6Jo5O
+        z+4ihxrKQnKlS+UxQ6tkIWHcEFK7jgOcvTGOrXuw0Q19sp3d3yQfQkcitJeNGaBOv5WiZF7oIn0v
+        nZY2njB9naavEw==
     headers:
       Access-Control-Allow-Headers:
       - Origin, Authorization, Accept, Api-Key, Content-Type, X-User-Agent
@@ -145,29 +159,29 @@ interactions:
       CF-Cache-Status:
       - HIT
       CF-RAY:
-      - 87c704404b3252d0-LHR
+      - 883aac4c1e0b2294-CDG
       Cache-Control:
       - public, max-age=86400
       Connection:
       - keep-alive
       Content-Encoding:
-      - gzip
+      - br
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 30 Apr 2024 10:58:25 GMT
+      - Tue, 14 May 2024 11:50:51 GMT
       Last-Modified:
-      - Tue, 30 Apr 2024 10:58:25 GMT
+      - Tue, 14 May 2024 11:50:51 GMT
       NEL:
       - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
       RateLimit-Limit:
       - '5'
       RateLimit-Remaining:
-      - '3'
+      - '4'
       RateLimit-Reset:
       - '1'
       Report-To:
-      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=sLTQU%2BINU%2FzCvhiHwZFB%2BRCyAfILupMt9BZ5kMuLbGiNMNDwr4AZiZhMLuDb0AmDLRUpMMqW%2BJhuJisZbgnbyBJtY8wInLYXwrODXE49OHVWCAgITD7dg530SYEqITKp6lPlwQe4RiE%3D"}],"group":"cf-nel","max_age":604800}'
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=C4C7dYicDVs%2B1UozSwWr%2BUBnf2R%2Fl5ofInihNepi5sVQFCDszqKcyeN4topj1%2BBBdbkVtxHDYyht79XVX9%2BAm8y%2B8xZ5cw6RywZFmVUTt5jtDKZuCePiprB%2FoNPH6%2FObCxrgpSZqHPc%3D"}],"group":"cf-nel","max_age":604800}'
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -177,7 +191,7 @@ interactions:
       Vary:
       - Accept-Encoding
       X-Cache-Backend:
-      - apigw1_8000 rb1-temp
+      - apigw1_8000 rb8
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -185,17 +199,19 @@ interactions:
       X-Frame-Options:
       - SAMEORIGIN
       X-Kong-Proxy-Latency:
-      - '0'
+      - '1'
       X-Kong-Upstream-Latency:
-      - '50'
+      - '27'
       X-RateLimit-Limit-Second:
       - '5'
       X-RateLimit-Remaining-Second:
-      - '3'
+      - '4'
       X-Request-Id:
-      - 19d58ba0-03a8-4cfa-8c8e-af99e77b47e8
+      - 5d21a066-d15a-4b76-9ee2-be0d34b51d03
       X-Runtime:
-      - '0.045539'
+      - '0.025066'
+      X-StackifyID:
+      - V1|0f155088-2fce-47ef-81d8-d4f821cf3874|C98087|CD1
       X-Var-Cache:
       - MISS
       X-Via:

--- a/tests/cassettes/opensubtitlescom/test_query_wrong_hash_wrong_size.yaml
+++ b/tests/cassettes/opensubtitlescom/test_query_wrong_hash_wrong_size.yaml
@@ -5,63 +5,7 @@ interactions:
       Accept:
       - '*/*'
       Accept-Encoding:
-      - gzip, deflate
-      Api-Key:
-      - mij33pjc3kOlup1qOKxnWWxvle2kFbMH
-      Connection:
-      - keep-alive
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Subliminal v2.1
-    method: GET
-    uri: https://api.opensubtitles.com/api/v1/subtitles?languages=en&moviehash=123456787654321
-  response:
-    body:
-      string: ''
-    headers:
-      Access-Control-Allow-Origin:
-      - '*'
-      CF-Cache-Status:
-      - MISS
-      CF-RAY:
-      - 87c7044a3d3e48ca-LHR
-      Cache-Control:
-      - public, max-age=86400
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      Date:
-      - Tue, 30 Apr 2024 10:58:27 GMT
-      NEL:
-      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
-      Report-To:
-      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=zKZBICuY4IWfGTA4LKfgKw9lqG3mpufoAhQE2cYWWC6K1DdRGKEUg0sJltF6xwbo0N1UcMRYFDnT%2FxGUY5BEUdXnsxz7Vx8ANeO0H9irH%2FMrAUbKvGPZ1PwShGjY1PGc0tIdFD2KD7A%3D"}],"group":"cf-nel","max_age":604800}'
-      Server:
-      - cloudflare
-      Strict-Transport-Security:
-      - max-age=15552000; includeSubDomains; preload
-      Vary:
-      - Accept-Encoding
-      X-Content-Type-Options:
-      - nosniff
-      X-Reason:
-      - Request parameters does not make sense, moviehash is wrong
-      X-Varnish:
-      - '167903389'
-      alt-svc:
-      - h3=":443"; ma=86400
-    status:
-      code: 400
-      message: Bad Request
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Api-Key:
       - mij33pjc3kOlup1qOKxnWWxvle2kFbMH
       Connection:
@@ -79,11 +23,11 @@ interactions:
       Access-Control-Allow-Origin:
       - '*'
       Age:
-      - '0'
+      - '48860'
       CF-Cache-Status:
       - HIT
       CF-RAY:
-      - 87c7044b6fcb073a-LHR
+      - 883aac4fafbb3cad-CDG
       Cache-Control:
       - public, max-age=86400
       Connection:
@@ -91,11 +35,11 @@ interactions:
       Content-Length:
       - '0'
       Date:
-      - Tue, 30 Apr 2024 10:58:27 GMT
+      - Tue, 14 May 2024 11:50:52 GMT
       NEL:
       - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
       Report-To:
-      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=nlmHZjCsvHKFtlNqrOGLLCLR5a4gsURp%2BJ9dI%2FysXUI2q9X2eCz9leNDT2iWWWnbfoNdGc2A2i7%2FTOhSSSC1qM%2FxeVpsImjzjkOXKZjdyecDnyzHM9mN1VcUOB66iOgpENi%2B05cqrw8%3D"}],"group":"cf-nel","max_age":604800}'
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=CqiykDB2mvzFut%2FOrrpDc5QZHdEqD296XJXBAZju1NFCr7elUt1OUCBf%2BJPG9IIPn6nXGMRPPdOH2jZUgsmrgmxW9wULI6jOutI7cXkBfYjtuAaL7Ek45JSXo8ygPmjZAv0A%2FkEmHvo%3D"}],"group":"cf-nel","max_age":604800}'
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -107,7 +51,65 @@ interactions:
       X-Reason:
       - Request parameters does not make sense, moviehash is wrong
       X-Varnish:
-      - '167903389'
+      - '5104067'
+      alt-svc:
+      - h3=":443"; ma=86400
+    status:
+      code: 400
+      message: Bad Request
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, br
+      Api-Key:
+      - mij33pjc3kOlup1qOKxnWWxvle2kFbMH
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Subliminal v2.1
+    method: GET
+    uri: https://api.opensubtitles.com/api/v1/subtitles?languages=en&moviehash=123456787654321
+  response:
+    body:
+      string: ''
+    headers:
+      Access-Control-Allow-Origin:
+      - '*'
+      Age:
+      - '48860'
+      CF-Cache-Status:
+      - HIT
+      CF-RAY:
+      - 883aac4fffff3cad-CDG
+      Cache-Control:
+      - public, max-age=86400
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '0'
+      Date:
+      - Tue, 14 May 2024 11:50:52 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=7ORzJp2vZ%2FlBWaM8d9hQhB2a2%2FIAcnRxNQVvKBj1ihyL2yn3M%2Fk2CS5ToUNcL%2FV3bmLedgosFRLz8d4dVlJ3s8gBhah9F7D%2FISNGL2rnkZpj0tLTQf8zKtR%2BZkdE9jJqCA8%2Bq3DMwJ8%3D"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Reason:
+      - Request parameters does not make sense, moviehash is wrong
+      X-Varnish:
+      - '5104067'
       alt-svc:
       - h3=":443"; ma=86400
     status:

--- a/tests/cassettes/opensubtitlescom/test_tag_match.yaml
+++ b/tests/cassettes/opensubtitlescom/test_tag_match.yaml
@@ -5,7 +5,7 @@ interactions:
       Accept:
       - '*/*'
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Api-Key:
       - mij33pjc3kOlup1qOKxnWWxvle2kFbMH
       Connection:
@@ -18,7 +18,9 @@ interactions:
     uri: https://api.opensubtitles.com/api/v1/subtitles?episode_number=1&imdb_id=4516230&languages=pt-br&query=the+fall&season_number=3
   response:
     body:
-      string: '{"total_pages":0,"total_count":0,"per_page":60,"page":1,"data":[]}'
+      string: !!binary |
+        oQgCACDqttSXF24xLFUROXisR20iOOTg4JBAohGE3BZM5CDAtgT+enjUf0b6igMZ0TpQnLGLgKoR
+        Ngsx/TrU+gc=
     headers:
       Access-Control-Allow-Headers:
       - Origin, Authorization, Accept, Api-Key, Content-Type, X-User-Agent
@@ -26,32 +28,34 @@ interactions:
       - GET, HEAD, POST, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
+      Age:
+      - '48856'
       CF-Cache-Status:
-      - MISS
+      - HIT
       CF-RAY:
-      - 87c704709bbb4913-LHR
+      - 883aac5d8ce822b6-CDG
       Cache-Control:
       - public, max-age=86400
       Connection:
       - keep-alive
       Content-Encoding:
-      - gzip
+      - br
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 30 Apr 2024 10:58:33 GMT
+      - Tue, 14 May 2024 11:50:54 GMT
       Last-Modified:
-      - Tue, 30 Apr 2024 10:58:33 GMT
+      - Mon, 13 May 2024 22:16:38 GMT
       NEL:
       - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
       RateLimit-Limit:
       - '5'
       RateLimit-Remaining:
-      - '3'
+      - '4'
       RateLimit-Reset:
       - '1'
       Report-To:
-      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=JyooNchtoHo0BbCSWHZF4o8Q0%2FROFwY%2FQxiEa6Lh4ZiBIvVFoU3y1cOeKQhEo2iUi2gpVaEbAHMkfPbaeLuBAreUSjfCDuIpjjb6QnJAfi%2BvBHIgSBDIAhbTrNxKhxxtXCxXWjuzC9M%3D"}],"group":"cf-nel","max_age":604800}'
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=Ov3Q4dbftMNnz3C4OXmsPCsvRfGD%2FR26fsQhxoLb8EZ85ROrHaFt4qKoXeka%2F1wEcsEPlyOSd6U9o%2FA1iZxQE9ET0K24226FNfxApUYXM1yFLqW7VcKTdD%2F66G50LX1dowTCxpEfhuw%3D"}],"group":"cf-nel","max_age":604800}'
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -61,7 +65,7 @@ interactions:
       Vary:
       - Accept-Encoding
       X-Cache-Backend:
-      - apigw1_8000 rb1
+      - apigw1_8000 rb11
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -69,19 +73,17 @@ interactions:
       X-Frame-Options:
       - SAMEORIGIN
       X-Kong-Proxy-Latency:
-      - '1'
+      - '0'
       X-Kong-Upstream-Latency:
-      - '39'
+      - '60'
       X-RateLimit-Limit-Second:
       - '5'
       X-RateLimit-Remaining-Second:
-      - '3'
+      - '4'
       X-Request-Id:
-      - 525f3da6-96b9-4661-a7db-873d85d8c15e
+      - 0b4ce46e-cc0a-4432-a3a4-3561b36f8284
       X-Runtime:
-      - '0.034994'
-      X-StackifyID:
-      - V1|d47e51ed-ee75-4d56-ac9a-61a2009bd936|C98184|CD5
+      - '0.058552'
       X-Var-Cache:
       - MISS
       X-Via:
@@ -105,7 +107,7 @@ interactions:
       Accept:
       - '*/*'
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Api-Key:
       - mij33pjc3kOlup1qOKxnWWxvle2kFbMH
       Connection:
@@ -118,17 +120,22 @@ interactions:
     uri: https://api.opensubtitles.com/api/v1/subtitles?imdb_id=4516230&languages=pt-br
   response:
     body:
-      string: '{"total_pages":1,"total_count":2,"per_page":60,"page":1,"data":[{"id":"3936502","type":"subtitle","attributes":{"subtitle_id":"3936502","language":"pt-BR","download_count":2817,"new_download_count":32,"hearing_impaired":false,"hd":true,"fps":50.0,"votes":0,"ratings":0.0,"from_trusted":false,"foreign_parts_only":false,"upload_date":"2016-10-03T21:13:57Z","ai_translated":false,"nb_cd":1,"machine_translated":false,"release":"The.Fall.S03E01.720p.HDTV.x264-FoV[eztv]","comments":"","legacy_subtitle_id":6753582,"legacy_uploader_id":0,"uploader":{"uploader_id":3282,"name":"os-auto","rank":"Application
-        Developers"},"feature_details":{"feature_id":374751,"feature_type":"Episode","year":2016,"title":"Episode
-        One","movie_name":"The Fall - S03E01  Episode One","imdb_id":4516230,"tmdb_id":1223686,"season_number":3,"episode_number":1,"parent_imdb_id":2294189,"parent_title":"The
-        Fall","parent_tmdb_id":49010,"parent_feature_id":13091},"url":"https://www.opensubtitles.com/pt-BR/subtitles/legacy/6753582","related_links":[{"label":"All
-        subtitles for Tv Show The Fall","url":"https://www.opensubtitles.com/pt-BR/features/redirect/13091","img_url":"https://s9.opensubtitles.com/features/1/5/7/374751.jpg"},{"label":"All
-        subtitles for Episode episode one","url":"https://www.opensubtitles.com/pt-BR/features/redirect/374751"}],"files":[{"file_id":4014152,"cd_number":1,"file_name":"The.Fall.S03E01.720p.HDTV.x264-FoV[eztv]"}]}},{"id":"3937531","type":"subtitle","attributes":{"subtitle_id":"3937531","language":"pt-BR","download_count":866,"new_download_count":10,"hearing_impaired":false,"hd":true,"fps":25.0,"votes":0,"ratings":0.0,"from_trusted":true,"foreign_parts_only":false,"upload_date":"2016-10-20T02:41:08Z","ai_translated":false,"nb_cd":1,"machine_translated":false,"release":"The.Fall.S03E01.HDTV.x264-TLA-AFG-FoV-mSD-RBB","comments":"","legacy_subtitle_id":6769109,"legacy_uploader_id":1267974,"uploader":{"uploader_id":55587,"name":"marocas62","rank":"subtranslator"},"feature_details":{"feature_id":374751,"feature_type":"Episode","year":2016,"title":"Episode
-        One","movie_name":"The Fall - S3E1 \"The Fall\" Silence and Suffering","imdb_id":4516230,"tmdb_id":1223686,"season_number":3,"episode_number":1,"parent_imdb_id":2294189,"parent_title":"The
-        Fall","parent_tmdb_id":49010,"parent_feature_id":13091},"url":"https://www.opensubtitles.com/pt-BR/subtitles/legacy/6769109","related_links":[{"label":"All
-        subtitles for Tv Show The Fall","url":"https://www.opensubtitles.com/pt-BR/features/redirect/13091","img_url":"https://s9.opensubtitles.com/features/1/5/7/374751.jpg"},{"label":"All
-        subtitles for Episode episode one","url":"https://www.opensubtitles.com/pt-BR/features/redirect/374751"}],"files":[{"file_id":4015178,"cd_number":1,"file_name":"The
-        Fall S03E01 HDTV x264-RBB BR-PORT"}]}}]}'
+      string: !!binary |
+        wYBXACD+u9Q6XdE74xhw5zaZ1rZ4S7WY+DtBi4uATLZ56tJALGAJRWxbWtXWKlWsGC1dq3cLSAO+
+        WIB+HmPwIG/8Lr+I57bTacDDVf/wi/o3dIvZU4CWfES+HWgUtOJYyEP4QJeC49RnSY7eRAP97R9s
+        D42sycpCKHDEPwtBIxxfoo2OwGEEJfS/Cyt1bTFH26CxxGT7DhzSEYaWrWXFMdGpu/QmmeI4kPF2
+        2nd2XIz11EMPxgXiOPTQ0R+JY1gCdCE2guN13q0UHN5EO+0D9Jri4Oexi/4YIpYLhtmT3U/dYnwM
+        3Ty5PzvpceHy+3sTCRpKyDKRIhFZq6SWmS6qr+AwtvvBhTXOYLZOL92uVzt++UlWwOd4cmQCQaM9
+        0ObKOLd5L7JLITeVEsvm5qL9uPmtyjy5mj9+o7/x9Qc47P06NMDhaG92fzrlB5dVkRW1AoCiSMn3
+        AiHaQPLQ/7D84EzVimMyI0FjDok5xhkc3ky/oHG2LM7uTLTzxL6eaiD5gJXjNSeC7nPxgDfgswHq
+        viqvCgmKPOnIy8WGuSdw/CHjoZWQJYdzEYjN7HkicIzzq6WOu3XtgdiVcY4lTGV1GGuhtWP/Qn1L
+        XshSZYIjnvuWVCor65IjkAnz1H0vWB/ojIPwkNUOybEYT1PscAYr1eSybi7EDGOuSnApYcPYCCm2
+        aaq5UmaikSvH0TtoHGJcgk7T0+m0mRearFoS/r0CEDnC9Hxeal1+am0u3GmFidR3zk6/Qvim/mrI
+        YGicOccaU2fD7Fn7yt4f5hPjvEB8IEP2hNTTN9vlprIAzdfZd/I0Cs2YIPGRaZFWqYOk/l7JplfO
+        OTYzMpWUzc5RNOYh+VisPzgG60h18sFG0iu5kLksFMeudwsAk+KMBYjcvvXHuvKMyvCqyCRqm2/f
+        Ql2WYxpJQSNVoDxc0OV/U4lWKJ1LLeouxShfifbhLDm7uk6u5o/J+P4iebfdJlUmykaKZrxSlVVT
+        5anVWRRFXU3mjcbPOxNKNVOE40uF+M2zT6rO7FKy7+dS/A723jqadvQrS/+i3h+Hgbyd9okWeMCP
+        RE9PIasaOiiq99abi/Yju2a0x7vtlm3fJW+e37VYf6zrjxU=
     headers:
       Access-Control-Allow-Headers:
       - Origin, Authorization, Accept, Api-Key, Content-Type, X-User-Agent
@@ -136,32 +143,34 @@ interactions:
       - GET, HEAD, POST, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
+      Age:
+      - '48856'
       CF-Cache-Status:
-      - MISS
+      - HIT
       CF-RAY:
-      - 87c70472df6748af-LHR
+      - 883aac5ddd5722b6-CDG
       Cache-Control:
       - public, max-age=86400
       Connection:
       - keep-alive
       Content-Encoding:
-      - gzip
+      - br
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 30 Apr 2024 10:58:34 GMT
+      - Tue, 14 May 2024 11:50:54 GMT
       Last-Modified:
-      - Tue, 30 Apr 2024 10:58:34 GMT
+      - Mon, 13 May 2024 22:16:38 GMT
       NEL:
       - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
       RateLimit-Limit:
       - '5'
       RateLimit-Remaining:
-      - '4'
+      - '3'
       RateLimit-Reset:
       - '1'
       Report-To:
-      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=wxUZTUQbk8zKLQXjt2XBdihIVSbKV7dxLTEF4igGAZiKahXuBS%2BOaEvvSpf03ZJdr0xLCwBhcNW%2FNagZRvQknR8x4bfLPuyAVZ%2BZMBFS5df9H%2ByX0WgHEL3kpnhCJ9zvrz0G5Lx7Rg8%3D"}],"group":"cf-nel","max_age":604800}'
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=fnnnP5ScD1lo1UBgxgNXP26mYJ8pUTS8e2HruoeQp6EchIeUB%2FCNaqlgYU4kkCtDsLmh9oKaT9WZONDxsqbB6b1nL5sKh1MHHOGkQwOTXEcBEzbxlfb%2FItgjqwRiS1zZFNgl7bKsACE%3D"}],"group":"cf-nel","max_age":604800}'
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -171,7 +180,7 @@ interactions:
       Vary:
       - Accept-Encoding
       X-Cache-Backend:
-      - apigw1_8000 rb1
+      - apigw1_8000 rb8
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -179,19 +188,19 @@ interactions:
       X-Frame-Options:
       - SAMEORIGIN
       X-Kong-Proxy-Latency:
-      - '1'
+      - '0'
       X-Kong-Upstream-Latency:
-      - '40'
+      - '19'
       X-RateLimit-Limit-Second:
       - '5'
       X-RateLimit-Remaining-Second:
-      - '4'
+      - '3'
       X-Request-Id:
-      - 5c9502f8-7b48-45a1-959e-da98182a3f7c
+      - ad923681-97e6-4def-b49c-7e1704f43dd9
       X-Runtime:
-      - '0.038722'
+      - '0.016802'
       X-StackifyID:
-      - V1|23c787dd-72bc-4cc4-af7d-cd992a36adc4|C98184|CD5
+      - V1|81b3bd7f-2d7d-48be-862e-3579eb583828|C98087|CD1
       X-Var-Cache:
       - MISS
       X-Via:
@@ -215,7 +224,7 @@ interactions:
       Accept:
       - '*/*'
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Api-Key:
       - mij33pjc3kOlup1qOKxnWWxvle2kFbMH
       Connection:
@@ -228,66 +237,41 @@ interactions:
     uri: https://api.opensubtitles.com/api/v1/subtitles?episode_number=1&languages=pt-br&query=the+fall&season_number=3
   response:
     body:
-      string: '{"total_pages":1,"total_count":11,"per_page":60,"page":1,"data":[{"id":"3004905","type":"subtitle","attributes":{"subtitle_id":"3004905","language":"pt-BR","download_count":5865,"new_download_count":11,"hearing_impaired":false,"hd":true,"fps":23.976,"votes":0,"ratings":0.0,"from_trusted":true,"foreign_parts_only":false,"upload_date":"2016-11-10T04:21:09Z","ai_translated":false,"nb_cd":1,"machine_translated":false,"release":"HDTV.x264-KILLERS-FUM-KILLERS","comments":"","legacy_subtitle_id":6791294,"legacy_uploader_id":378614,"uploader":{"uploader_id":40309,"name":"clazevedo","rank":"translator"},"feature_details":{"feature_id":401839,"feature_type":"Episode","year":2016,"title":"After
-        the Fall","movie_name":"Salem - S03E01  After the Fall","imdb_id":4853240,"tmdb_id":1217259,"season_number":3,"episode_number":1,"parent_imdb_id":2963254,"parent_title":"Salem","parent_tmdb_id":60905,"parent_feature_id":14405},"url":"https://www.opensubtitles.com/pt-BR/subtitles/legacy/6791294","related_links":[{"label":"All
-        subtitles for Tv Show Salem","url":"https://www.opensubtitles.com/pt-BR/features/redirect/14405","img_url":"https://s9.opensubtitles.com/features/9/3/8/401839.jpg"},{"label":"All
-        subtitles for Episode after the fall","url":"https://www.opensubtitles.com/pt-BR/features/redirect/401839"}],"files":[{"file_id":3075098,"cd_number":1,"file_name":"Salem.S03E01.720p.HDTV.x264-KILLERS"}]}},{"id":"3936502","type":"subtitle","attributes":{"subtitle_id":"3936502","language":"pt-BR","download_count":2817,"new_download_count":32,"hearing_impaired":false,"hd":true,"fps":50.0,"votes":0,"ratings":0.0,"from_trusted":false,"foreign_parts_only":false,"upload_date":"2016-10-03T21:13:57Z","ai_translated":false,"nb_cd":1,"machine_translated":false,"release":"The.Fall.S03E01.720p.HDTV.x264-FoV[eztv]","comments":"","legacy_subtitle_id":6753582,"legacy_uploader_id":0,"uploader":{"uploader_id":3282,"name":"os-auto","rank":"Application
-        Developers"},"feature_details":{"feature_id":374751,"feature_type":"Episode","year":2016,"title":"Episode
-        One","movie_name":"The Fall - S03E01  Episode One","imdb_id":4516230,"tmdb_id":1223686,"season_number":3,"episode_number":1,"parent_imdb_id":2294189,"parent_title":"The
-        Fall","parent_tmdb_id":49010,"parent_feature_id":13091},"url":"https://www.opensubtitles.com/pt-BR/subtitles/legacy/6753582","related_links":[{"label":"All
-        subtitles for Tv Show The Fall","url":"https://www.opensubtitles.com/pt-BR/features/redirect/13091","img_url":"https://s9.opensubtitles.com/features/1/5/7/374751.jpg"},{"label":"All
-        subtitles for Episode episode one","url":"https://www.opensubtitles.com/pt-BR/features/redirect/374751"}],"files":[{"file_id":4014152,"cd_number":1,"file_name":"The.Fall.S03E01.720p.HDTV.x264-FoV[eztv]"}]}},{"id":"2852678","type":"subtitle","attributes":{"subtitle_id":"2852678","language":"pt-BR","download_count":1206,"new_download_count":34,"hearing_impaired":false,"hd":false,"fps":25.0,"votes":0,"ratings":0.0,"from_trusted":false,"foreign_parts_only":false,"upload_date":"2014-08-17T05:17:21Z","ai_translated":false,"nb_cd":1,"machine_translated":false,"release":"Doc.Martin.S03E01.(24
-        September 2007).[TVRip (Xvid)]","comments":"","legacy_subtitle_id":5790997,"legacy_uploader_id":0,"uploader":{"uploader_id":3282,"name":"os-auto","rank":"Application
-        Developers"},"feature_details":{"feature_id":217864,"feature_type":"Episode","year":2007,"title":"The
-        Apple Doesn''t Fall","movie_name":"Doc Martin - S03E01  The Apple Doesn''t
-        Fall","imdb_id":1111524,"tmdb_id":183215,"season_number":3,"episode_number":1,"parent_imdb_id":408381,"parent_title":"Doc
-        Martin","parent_tmdb_id":2430,"parent_feature_id":9526},"url":"https://www.opensubtitles.com/pt-BR/subtitles/legacy/5790997","related_links":[{"label":"All
-        subtitles for Tv Show Doc Martin","url":"https://www.opensubtitles.com/pt-BR/features/redirect/9526","img_url":"https://s9.opensubtitles.com/features/4/6/8/217864.jpg"},{"label":"All
-        subtitles for Episode the apple doesn''t fall","url":"https://www.opensubtitles.com/pt-BR/features/redirect/217864"}],"files":[{"file_id":2924588,"cd_number":1,"file_name":"Doc.Martin.S03E01.(24
-        September 2007).[TVRip (Xvid)]-spa"}]}},{"id":"3004939","type":"subtitle","attributes":{"subtitle_id":"3004939","language":"pt-BR","download_count":1127,"new_download_count":11,"hearing_impaired":false,"hd":true,"fps":23.976,"votes":0,"ratings":0.0,"from_trusted":true,"foreign_parts_only":false,"upload_date":"2016-11-10T04:24:45Z","ai_translated":false,"nb_cd":1,"machine_translated":false,"release":"720p-1080p.WEB-DL.DD5.1.H.264-DRACULA","comments":"","legacy_subtitle_id":6791295,"legacy_uploader_id":378614,"uploader":{"uploader_id":40309,"name":"clazevedo","rank":"translator"},"feature_details":{"feature_id":401839,"feature_type":"Episode","year":2016,"title":"After
-        the Fall","movie_name":"Salem - S03E01  \"Salem\" After the Fall","imdb_id":4853240,"tmdb_id":1217259,"season_number":3,"episode_number":1,"parent_imdb_id":2963254,"parent_title":"Salem","parent_tmdb_id":60905,"parent_feature_id":14405},"url":"https://www.opensubtitles.com/pt-BR/subtitles/legacy/6791295","related_links":[{"label":"All
-        subtitles for Tv Show Salem","url":"https://www.opensubtitles.com/pt-BR/features/redirect/14405","img_url":"https://s9.opensubtitles.com/features/9/3/8/401839.jpg"},{"label":"All
-        subtitles for Episode after the fall","url":"https://www.opensubtitles.com/pt-BR/features/redirect/401839"}],"files":[{"file_id":3075133,"cd_number":1,"file_name":"Salem.S03E01.1080p.WEB-DL.DD5.1.H.264-DRACULA"}]}},{"id":"3937531","type":"subtitle","attributes":{"subtitle_id":"3937531","language":"pt-BR","download_count":866,"new_download_count":10,"hearing_impaired":false,"hd":true,"fps":25.0,"votes":0,"ratings":0.0,"from_trusted":true,"foreign_parts_only":false,"upload_date":"2016-10-20T02:41:08Z","ai_translated":false,"nb_cd":1,"machine_translated":false,"release":"The.Fall.S03E01.HDTV.x264-TLA-AFG-FoV-mSD-RBB","comments":"","legacy_subtitle_id":6769109,"legacy_uploader_id":1267974,"uploader":{"uploader_id":55587,"name":"marocas62","rank":"subtranslator"},"feature_details":{"feature_id":374751,"feature_type":"Episode","year":2016,"title":"Episode
-        One","movie_name":"The Fall - S3E1 \"The Fall\" Silence and Suffering","imdb_id":4516230,"tmdb_id":1223686,"season_number":3,"episode_number":1,"parent_imdb_id":2294189,"parent_title":"The
-        Fall","parent_tmdb_id":49010,"parent_feature_id":13091},"url":"https://www.opensubtitles.com/pt-BR/subtitles/legacy/6769109","related_links":[{"label":"All
-        subtitles for Tv Show The Fall","url":"https://www.opensubtitles.com/pt-BR/features/redirect/13091","img_url":"https://s9.opensubtitles.com/features/1/5/7/374751.jpg"},{"label":"All
-        subtitles for Episode episode one","url":"https://www.opensubtitles.com/pt-BR/features/redirect/374751"}],"files":[{"file_id":4015178,"cd_number":1,"file_name":"The
-        Fall S03E01 HDTV x264-RBB BR-PORT"}]}},{"id":"7046307","type":"subtitle","attributes":{"subtitle_id":"7046307","language":"pt-BR","download_count":860,"new_download_count":1,"hearing_impaired":false,"hd":true,"fps":0.0,"votes":0,"ratings":0.0,"from_trusted":false,"foreign_parts_only":false,"upload_date":"2016-11-04T10:31:37Z","ai_translated":false,"nb_cd":1,"machine_translated":false,"release":"Salem.S03E01.720p.HDTV.x264-KILLERS[ettv]","comments":"","legacy_subtitle_id":6784308,"legacy_uploader_id":0,"uploader":{"uploader_id":3282,"name":"os-auto","rank":"Application
-        Developers"},"feature_details":{"feature_id":401839,"feature_type":"Episode","year":2016,"title":"After
-        the Fall","movie_name":"Salem - S03E01  After the Fall","imdb_id":4853240,"tmdb_id":1217259,"season_number":3,"episode_number":1,"parent_imdb_id":2963254,"parent_title":"Salem","parent_tmdb_id":60905,"parent_feature_id":14405},"url":"https://www.opensubtitles.com/pt-BR/subtitles/legacy/6784308","related_links":[{"label":"All
-        subtitles for Tv Show Salem","url":"https://www.opensubtitles.com/pt-BR/features/redirect/14405","img_url":"https://s9.opensubtitles.com/features/9/3/8/401839.jpg"},{"label":"All
-        subtitles for Episode after the fall","url":"https://www.opensubtitles.com/pt-BR/features/redirect/401839"}],"files":[{"file_id":7987169,"cd_number":1,"file_name":"Salem.S03E01.720p.HDTV.x264-KILLERS[ettv]"}]}},{"id":"7046347","type":"subtitle","attributes":{"subtitle_id":"7046347","language":"pt-BR","download_count":365,"new_download_count":4,"hearing_impaired":false,"hd":true,"fps":0.0,"votes":1,"ratings":5.0,"from_trusted":false,"foreign_parts_only":false,"upload_date":"2016-11-04T12:05:40Z","ai_translated":false,"nb_cd":1,"machine_translated":false,"release":"Salem.S03E01.720p.HDTV.x264-KILLERS[ettv]","comments":"","legacy_subtitle_id":6784338,"legacy_uploader_id":1441666,"uploader":{"uploader_id":59468,"name":"slayer999","rank":"Sub
-        leecher"},"feature_details":{"feature_id":401839,"feature_type":"Episode","year":2016,"title":"After
-        the Fall","movie_name":"Salem - S03E01  After the Fall","imdb_id":4853240,"tmdb_id":1217259,"season_number":3,"episode_number":1,"parent_imdb_id":2963254,"parent_title":"Salem","parent_tmdb_id":60905,"parent_feature_id":14405},"url":"https://www.opensubtitles.com/pt-BR/subtitles/legacy/6784338","related_links":[{"label":"All
-        subtitles for Tv Show Salem","url":"https://www.opensubtitles.com/pt-BR/features/redirect/14405","img_url":"https://s9.opensubtitles.com/features/9/3/8/401839.jpg"},{"label":"All
-        subtitles for Episode after the fall","url":"https://www.opensubtitles.com/pt-BR/features/redirect/401839"}],"files":[{"file_id":7987192,"cd_number":1,"file_name":"Salem.S03E01.720p.HDTV.x264-KILLERS[ettv]"}]}},{"id":"5043877","type":"subtitle","attributes":{"subtitle_id":"5043877","language":"pt-BR","download_count":263,"new_download_count":7,"hearing_impaired":false,"hd":false,"fps":0.0,"votes":0,"ratings":0.0,"from_trusted":false,"foreign_parts_only":false,"upload_date":"2019-03-09T03:33:46Z","ai_translated":false,"nb_cd":1,"machine_translated":false,"release":"Doc
-        Martin S03E01 The Apple Doesnt Fall","comments":"","legacy_subtitle_id":7680735,"legacy_uploader_id":0,"uploader":{"uploader_id":3282,"name":"os-auto","rank":"Application
-        Developers"},"feature_details":{"feature_id":217864,"feature_type":"Episode","year":2007,"title":"The
-        Apple Doesn''t Fall","movie_name":"Doc Martin - S03E01  \"Doc Martin\" The
-        Apple Doesn''t Fall","imdb_id":1111524,"tmdb_id":183215,"season_number":3,"episode_number":1,"parent_imdb_id":408381,"parent_title":"Doc
-        Martin","parent_tmdb_id":2430,"parent_feature_id":9526},"url":"https://www.opensubtitles.com/pt-BR/subtitles/legacy/7680735","related_links":[{"label":"All
-        subtitles for Tv Show Doc Martin","url":"https://www.opensubtitles.com/pt-BR/features/redirect/9526","img_url":"https://s9.opensubtitles.com/features/4/6/8/217864.jpg"},{"label":"All
-        subtitles for Episode the apple doesn''t fall","url":"https://www.opensubtitles.com/pt-BR/features/redirect/217864"}],"files":[{"file_id":5161591,"cd_number":1,"file_name":"Doc
-        Martin S03E01 The Apple Doesnt Fall"}]}},{"id":"7046329","type":"subtitle","attributes":{"subtitle_id":"7046329","language":"pt-BR","download_count":169,"new_download_count":1,"hearing_impaired":false,"hd":true,"fps":0.0,"votes":0,"ratings":0.0,"from_trusted":false,"foreign_parts_only":false,"upload_date":"2016-11-04T10:41:16Z","ai_translated":false,"nb_cd":1,"machine_translated":false,"release":"Salem.S03E01.720p.HDTV.x264-KILLERS[ettv]","comments":"there
-        is an error code in the previous , i correct in this one","legacy_subtitle_id":6784309,"legacy_uploader_id":0,"uploader":{"uploader_id":3282,"name":"os-auto","rank":"Application
-        Developers"},"feature_details":{"feature_id":401839,"feature_type":"Episode","year":2016,"title":"After
-        the Fall","movie_name":"Salem - S03E01  After the Fall","imdb_id":4853240,"tmdb_id":1217259,"season_number":3,"episode_number":1,"parent_imdb_id":2963254,"parent_title":"Salem","parent_tmdb_id":60905,"parent_feature_id":14405},"url":"https://www.opensubtitles.com/pt-BR/subtitles/legacy/6784309","related_links":[{"label":"All
-        subtitles for Tv Show Salem","url":"https://www.opensubtitles.com/pt-BR/features/redirect/14405","img_url":"https://s9.opensubtitles.com/features/9/3/8/401839.jpg"},{"label":"All
-        subtitles for Episode after the fall","url":"https://www.opensubtitles.com/pt-BR/features/redirect/401839"}],"files":[{"file_id":7987180,"cd_number":1,"file_name":"Salem.S03E01.720p.HDTV.x264-KILLERS[ettv]"}]}},{"id":"5125331","type":"subtitle","attributes":{"subtitle_id":"5125331","language":"pt-BR","download_count":168,"new_download_count":10,"hearing_impaired":false,"hd":false,"fps":0.0,"votes":0,"ratings":0.0,"from_trusted":false,"foreign_parts_only":false,"upload_date":"2020-06-10T01:23:32Z","ai_translated":false,"nb_cd":1,"machine_translated":false,"release":"Doc
-        Martin - 3x01 - The Apple Doesn''t Fall.port","comments":"","legacy_subtitle_id":8241276,"legacy_uploader_id":0,"uploader":{"uploader_id":3282,"name":"os-auto","rank":"Application
-        Developers"},"feature_details":{"feature_id":217864,"feature_type":"Episode","year":2007,"title":"The
-        Apple Doesn''t Fall","movie_name":"Doc Martin - S03E01  \"Doc Martin\" The
-        Apple Doesn''t Fall","imdb_id":1111524,"tmdb_id":183215,"season_number":3,"episode_number":1,"parent_imdb_id":408381,"parent_title":"Doc
-        Martin","parent_tmdb_id":2430,"parent_feature_id":9526},"url":"https://www.opensubtitles.com/pt-BR/subtitles/legacy/8241276","related_links":[{"label":"All
-        subtitles for Tv Show Doc Martin","url":"https://www.opensubtitles.com/pt-BR/features/redirect/9526","img_url":"https://s9.opensubtitles.com/features/4/6/8/217864.jpg"},{"label":"All
-        subtitles for Episode the apple doesn''t fall","url":"https://www.opensubtitles.com/pt-BR/features/redirect/217864"}],"files":[{"file_id":5236106,"cd_number":1,"file_name":"Doc
-        Martin - 3x01 - The Apple Doesnt Fall.port.br"}]}},{"id":"5118726","type":"subtitle","attributes":{"subtitle_id":"5118726","language":"pt-BR","download_count":52,"new_download_count":45,"hearing_impaired":false,"hd":false,"fps":60.0,"votes":0,"ratings":0.0,"from_trusted":false,"foreign_parts_only":false,"upload_date":"2020-05-01T14:58:08Z","ai_translated":false,"nb_cd":1,"machine_translated":false,"release":"Renegado
-        3 temporada ep1","comments":"","legacy_subtitle_id":8192907,"legacy_uploader_id":0,"uploader":{"uploader_id":3282,"name":"os-auto","rank":"Application
-        Developers"},"feature_details":{"feature_id":372940,"feature_type":"Episode","year":1994,"title":"Dutch
-        On the Run (1)","movie_name":"O Renegado - S03E01  Dutch On the Run (1)","imdb_id":685053,"tmdb_id":956021,"season_number":3,"episode_number":1,"parent_imdb_id":103524,"parent_title":"Renegade","parent_tmdb_id":600,"parent_feature_id":12976},"url":"https://www.opensubtitles.com/pt-BR/subtitles/legacy/8192907","related_links":[{"label":"All
-        subtitles for Tv Show Renegade","url":"https://www.opensubtitles.com/pt-BR/features/redirect/12976","img_url":"https://s9.opensubtitles.com/features/0/4/9/372940.jpg"},{"label":"All
-        subtitles for Episode dutch on the run (1)","url":"https://www.opensubtitles.com/pt-BR/features/redirect/372940"}],"files":[{"file_id":5229907,"cd_number":1,"file_name":"Renegado
-        3 temporada ep1"}]}}]}'
+      string: !!binary |
+        4ZDbASCXTavXV9V7lwV0K6SfJ23INhsipTGyTS0GSuCZTf5r7VWoTJSMsYAKkC7xu3ublACvwO9u
+        sUCsgMCV9RemxuRXZTr+T2TReCZXVduozhdCFcjWMMP+HykG3FK0c+bm+AVT1H+GZor7NEMgPqe9
+        A50QAhGHKeWXWCAY5HDv5iIObVwihE+/oGshgERUHjVwWH5MCQLMp9ulW/oEHLTQFcKvJ6fV8Joi
+        nQ0CTEtxsQYO2TMluo7aGc1hSPfNs9eIiMMhxdwN+6Y7TrHLqYWwi/2cOBxaCEs+JQ67aYYgZOmt
+        4XA3SlUnyCHHpRv2MwQskcMuj8dmyad5ScwXHnPq9kMzxbzMzTj0P96h5WkSs+7buCQIIJBMQVQQ
+        1qiCoID+I3CIXTPJhUv2cRFu4HDbbNsRb/4AhflCV3PqU5wTBHh0Vb8tvwujiqePnz27Xm+KmzfP
+        73cBDmp2HwIAhz7t4/ZHM8rHNNaT8OoFWP6WKafRpHWGVKZ2mDKEX/Ai1xVK9ByGeEwQYNvHn+ku
+        tSNwyHH4BgFyMNqY4czhZyZNmj+Fh/RvPoyHuAY56V9KbOcqr6duHtsEHH6kmCEIJMPBnLYfYLVb
+        Up4yyzPfxL4HDsfxrkuNWDd8E/t0ZAXboLxGYoyjV3dsb7MzudNSKOSwPForEmSF9hzmFOdxaHoD
+        a4EgOaQ53Z+DOEwxp2Fphjmm8EYKrZ40ZUZSafCU+Y5DDXrUyTZqXCSlUJ85nHIPAQ7LMs2hqu7v
+        78txSoNGtfkfVoDKStPq8UaVZhtXmm4I9nOKuKS26bvh21xg4YRCjgkBVn3PmM/OdmNm9R3bHMZ7
+        JrYkIUgW1pirnHqy27DKCBrn89g3w5rf7Bd0IBZfycpV1gGnT3KBz1xsYi8ag/NGO10rkx9LMDGc
+        v3DYdX0ada13XSlyR6LV6B2HbWsT6DU2S2xUrna6tAKnsvCOBucv5zOHTwN7aTQKyiua0iAc2QiS
+        oqEGSQkHgnMy998fWKCsBQWSQVs6LPUhlTex7zVzdNyMbz+ln8vdFyDNg5baiRlFDO0rhROL7Y5z
+        EU/Lqsaraeq7bVy6cWBd+13ZlGcwNaS0ymoiULtO9nJIp8Y1ZsKzAwc45aDJCFkoQhpnSiy8Iue1
+        GsUdz3lQHgkzVaInpG0VCUqu7pzREj1ZqNKVrQxEViIfeC3ZaBzKhMdvzwWmZa2QFGkhp+TaENW4
+        wmlhrAO8oiktJNCERJG7aP/+Ck3/HapAV5CtUQeyQRCd5Wrcls9jXrpBPWv8IxT7JukJCET7b/mp
+        frvuJvbP+7uu/RdevQdtPXpvqVwFWWdUOLTnrw+JraapT+xqTPPw9+KB2pG219W4ZeMROq187BQm
+        d0REpIWC3W3hpCC92GmFTjpaAAFZ/usKCCXnm9FrYQ7EBlSArl1yZcdN7bUwHqxFVaZyld3IQt2B
+        yyGxqHifVrUniyXhAuDdLrxQ2s2kl/N1FPMU3VsDIyovPeUVBuTPKAkbGfgyVFCa7s2twKkgdDiV
+        764viqtn5dWVLql8VAqjiqv16vLNsxUC4wjBK5GmRp8f/YT7DLGC1xOaEoaknCkqxHZoNbCXVkui
+        vKJpQZxxcxcVYbxV1m6WL7j6/YGFwBpFUBTQkWPMAARxPIn62apY3Twsbsa3xXFzVawvLvA1D8YT
+        +t1Mwlhvl35aa2crO8Y8buNsxKqbT7db/N3wPgwcDJXXxD4/WsPPwDZdn4ZtmgrzA29Ou13K3bAP
+        yT7aBBOQBahAWxgCUXd+NAkmpEeTddhAycf/wEdX9VsW/XN3fXHBLtbFq5frOpJgXIvKSLSAVxxl
+        g4OSorL39+K7hApUNWGQFCSJxslX0ae07OsHpyQ6wtUIMtMr8Kp6C2n78YPbum9a7ywZPyNF1xlQ
+        w0KFhloQaZoHzAaV/NNzpMnbEgF1UEjBkbuXlCJjDKwO1V4Zt9zf3McfKXvvQwG/49mcblmf0vaQ
+        Mpy+rpD0nnlBBtaopLOAVzTFQTgfEkvu3u/O6X+HL1AW6GuUQcqgDMGqGRydcTzRGh1B19R7sMah
+        lZpw7YQonj4OqNEiNqACZR+RZ+WjyZD2JF60neMAkSD8LBEVWB9J49NXrSiQIdqJk9p3M4sDSzmP
+        mW3HNrGOrrid0103nmbGWcd60thquzzv0MFH/ijC61FPryk8vWcOaS/WJLSUlV6AVxyOg+NeCuj7
+        DhRYoGlJ8K2jIGSQIh2WgsnvSKxokbTl5TTmJZrgPTihSFgDrA+UD6x/furT7jM08CIm8ZjDJTaE
+        kIbQcJV4uFhWeZsRuSM5+71CajJ5RWO6C6CFb7yolAHk59ssv2N0gVSTCtq1QfAY1mlI+9iOTLIl
+        HacxxzayNBH01hPkhceGtOUmrfAKk5D3ynp1WrYH9tKx39n1aWD/0L/B3LYv2bgCzWh5mCnObtc4
+        jVpGHSqE1wYFdSSUMQwTSok3TnQ4/eTg8rQ0WK3CW5DFylcRc4ByKzugvMjGWAtWqvKVvcgKOTRs
+        VW77l8b5ZmUxE2yznAjbUvgSxtm4i1qmYwke4fzlfP5yBg==
     headers:
       Access-Control-Allow-Headers:
       - Origin, Authorization, Accept, Api-Key, Content-Type, X-User-Agent
@@ -295,32 +279,34 @@ interactions:
       - GET, HEAD, POST, OPTIONS
       Access-Control-Allow-Origin:
       - '*'
+      Age:
+      - '48856'
       CF-Cache-Status:
-      - MISS
+      - HIT
       CF-RAY:
-      - 87c70474cabe0639-LHR
+      - 883aac5e2dc122b6-CDG
       Cache-Control:
       - public, max-age=86400
       Connection:
       - keep-alive
       Content-Encoding:
-      - gzip
+      - br
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 30 Apr 2024 10:58:34 GMT
+      - Tue, 14 May 2024 11:50:54 GMT
       Last-Modified:
-      - Tue, 30 Apr 2024 10:58:34 GMT
+      - Mon, 13 May 2024 22:16:38 GMT
       NEL:
       - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
       RateLimit-Limit:
       - '5'
       RateLimit-Remaining:
-      - '3'
+      - '2'
       RateLimit-Reset:
       - '1'
       Report-To:
-      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=BbNEKFEIze7e9LXVLbYqUz8LVFtA1dhNz7epVErLZd678G2XhXIiy%2Bby2DgLRhCV%2BLUiUaI2m7jZ0N2oqE74GMfwwfo%2Bq0jxfOsiGqaieJjdPj5nImLGtIC6vmb8i3RErAhYw1bZHfU%3D"}],"group":"cf-nel","max_age":604800}'
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=TI1soZsMSzVGGlsbLhtCfzm9d1Tavq2Z4c2cZHMuIeXpeL%2FConF6EJfHHZWXtFjkVT04pOISHDajpRLcdFmBkoLV3bJbCmNCI%2BSBvOSSH31XS%2BafXtIRwneYmyP4ygwLWpAyIYUv4%2Fo%3D"}],"group":"cf-nel","max_age":604800}'
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -330,7 +316,7 @@ interactions:
       Vary:
       - Accept-Encoding
       X-Cache-Backend:
-      - apigw1_8000 rb1
+      - apigw1_8000 rb8
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -340,17 +326,17 @@ interactions:
       X-Kong-Proxy-Latency:
       - '0'
       X-Kong-Upstream-Latency:
-      - '86'
+      - '268'
       X-RateLimit-Limit-Second:
       - '5'
       X-RateLimit-Remaining-Second:
-      - '3'
+      - '2'
       X-Request-Id:
-      - cd9047d4-863a-4bb6-891b-f493c2c59498
+      - 31f127a9-31ef-4b27-834b-9268e85e62b8
       X-Runtime:
-      - '0.083538'
+      - '0.072189'
       X-StackifyID:
-      - V1|ed52b294-9079-4d33-b9b0-d531f36d6d83|C98184|CD5
+      - V1|cdddd528-8704-4d29-8f1f-21e01eef1923|C98087|CD1
       X-Var-Cache:
       - MISS
       X-Via:

--- a/tests/cassettes/opensubtitlescom/test_user_infos.yaml
+++ b/tests/cassettes/opensubtitlescom/test_user_infos.yaml
@@ -5,13 +5,13 @@ interactions:
       Accept:
       - '*/*'
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Api-Key:
       - mij33pjc3kOlup1qOKxnWWxvle2kFbMH
       Connection:
       - keep-alive
       Content-Length:
-      - '64'
+      - '69'
       Content-Type:
       - application/json
       User-Agent:
@@ -20,8 +20,13 @@ interactions:
     uri: https://api.opensubtitles.com/api/v1/login
   response:
     body:
-      string: '{"user":{"allowed_translations":1,"allowed_downloads":20,"level":"Sub
-        leecher","user_id":699022,"ext_installed":false,"vip":false},"token":"eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJTNXJaWEYxVERvejR2ekpMMEZlTUUweFZvMURmTGpUaCIsImV4cCI6MTcxNDU2MTEwM30.wHJRyiYCBcS9iV8HG99H6af11dGzdpEn6A237gCp4tI","status":200,"base_url":"api.opensubtitles.com"}'
+      string: !!binary |
+        g64AAOQyt17fm31nOojmB97gWtmDbZ0k4I5x4DbqpKMNi10L0eAxfA4pynGN+YCWeAP+ARZVRfd0
+        DdAFlqI4ksCzzEQZS+C5DAOc1AgcZtr+CxCdK96AJY5O5AIvVauZXI4BPtWJIqmsIEAX+L8VSGRw
+        p0Q//jFQsY8RcMCXyOC6RiMSvWV2Qv2GuNodh0YkzMXbzA5JVA18icTJD2hEQs/X29fCr4bTbPs9
+        WF2VtXJv6D9fdj4IZ51MZpgfWtvmprglU5rhsuA0zNJg7jyHc+c1nLfyw27G2Mar/vv0SifFYeax
+        mYsRvgrmJXwmNR3o5vL1cNuZkjlW28sEGEhlKT1CJ8PAtiSe9C0ADlZCRpxgJLWtSAUoDScO4WcA
+        Aw==
     headers:
       Access-Control-Allow-Headers:
       - Origin, Authorization, Accept, Api-Key, Content-Type, X-User-Agent
@@ -34,17 +39,17 @@ interactions:
       CF-Cache-Status:
       - DYNAMIC
       CF-RAY:
-      - 87c70430cc530686-LHR
+      - 883aac449fa03c8f-CDG
       Cache-Control:
       - max-age=0, private, must-revalidate, s-maxage=600
       Connection:
       - keep-alive
       Content-Encoding:
-      - gzip
+      - br
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 30 Apr 2024 10:58:23 GMT
+      - Tue, 14 May 2024 11:50:50 GMT
       NEL:
       - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
       RateLimit-Limit:
@@ -54,7 +59,7 @@ interactions:
       RateLimit-Reset:
       - '1'
       Report-To:
-      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=9xEJKhhAAvhXmkNz3SPL6roK8JAvTJwHXCt0ka667%2BbkgsDGuunumuAlZqFaMWrHSpFb1riXzZyyv81HCHvxjwPz1Jqexfz2k%2FjhanAoWxbYVk1idZE5cCJQQVWKKRuS1b6KoTXVvXQ%3D"}],"group":"cf-nel","max_age":604800}'
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=iTy0jgxuOgXFNxAWAgRpNoaEBhZDeaZiQraTS2hz6JwG8%2Fp3iItrmC2%2FscRgakp1Hwg8l91JYw8SAaFtxZYl%2Fz%2FwV6mnSkXOb8vAQLr0SWqUVPWz99MvJf0qzK5ujtyfKrhHi4Fsubw%3D"}],"group":"cf-nel","max_age":604800}'
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -62,7 +67,7 @@ interactions:
       Transfer-Encoding:
       - chunked
       X-Cache-Backend:
-      - apigw1_8000 rb8
+      - apigw1_8000 rb1-temp
       X-Content-Type-Options:
       - nosniff
       X-Download-Options:
@@ -70,9 +75,9 @@ interactions:
       X-Frame-Options:
       - SAMEORIGIN
       X-Kong-Proxy-Latency:
-      - '1'
+      - '0'
       X-Kong-Upstream-Latency:
-      - '320'
+      - '274'
       X-RateLimit-Limit-Hour:
       - '60'
       X-RateLimit-Limit-Second:
@@ -82,11 +87,9 @@ interactions:
       X-RateLimit-Remaining-Second:
       - '0'
       X-Request-Id:
-      - dbbbd857-a98d-4a60-9b28-2d0fe89caad9
+      - 40fc6d16-60c0-4a37-9ccf-942dea89647e
       X-Runtime:
-      - '0.318098'
-      X-StackifyID:
-      - V1|d72480cd-e0a3-4d2f-ac22-6c35605a0708|C98087|CD1
+      - '0.271679'
       X-Var-Cache:
       - MISS
       X-Via:
@@ -108,11 +111,11 @@ interactions:
       Accept:
       - '*/*'
       Accept-Encoding:
-      - gzip, deflate
+      - gzip, deflate, br
       Api-Key:
       - mij33pjc3kOlup1qOKxnWWxvle2kFbMH
       Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJTNXJaWEYxVERvejR2ekpMMEZlTUUweFZvMURmTGpUaCIsImV4cCI6MTcxNDU2MTEwM30.wHJRyiYCBcS9iV8HG99H6af11dGzdpEn6A237gCp4tI
+      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJuTXZyUk9mR1FzMWhtaWdrekxyb3lmSG00N3NaZDY5ZiIsImV4cCI6MTcxNTcyNTE3NH0.ZoWLz_yqQ5N0wYTJOey4IgmxpAuluDVywdF06IPtZgQ
       Connection:
       - keep-alive
       Content-Type:
@@ -123,8 +126,10 @@ interactions:
     uri: https://api.opensubtitles.com/api/v1/infos/user
   response:
     body:
-      string: '{"data":{"allowed_translations":1,"allowed_downloads":20,"level":"Sub
-        leecher","user_id":699022,"ext_installed":false,"vip":false,"downloads_count":0,"remaining_downloads":20,"username":"python-subliminal-test"}}'
+      string: !!binary |
+        oZgGACBm6pzW3M8l1LL2dqMaclByy25w4FYYYZgvNFrigwwew+eQohzXlC+iUwf6gkV1czTXAFty
+        Wg+9gLYLE2UpoN1mAZzUTxBu2ReJOVQ8Y4EsPJs6gk7X62a3W4Bfaupe1KXEEXR3SXiBRz1qZssg
+        iRq0WWD9sfkkC8+96xiE8a3V0C8l+1R3de/SUlkU/z8=
     headers:
       Access-Control-Allow-Methods:
       - GET, HEAD, POST, OPTIONS
@@ -133,17 +138,17 @@ interactions:
       CF-Cache-Status:
       - BYPASS
       CF-RAY:
-      - 87c70434cfbd527e-LHR
+      - 883aac46ca303c8f-CDG
       Cache-Control:
       - private, no-store
       Connection:
       - keep-alive
       Content-Encoding:
-      - gzip
+      - br
       Content-Type:
       - application/json; charset=utf-8
       Date:
-      - Tue, 30 Apr 2024 10:58:24 GMT
+      - Tue, 14 May 2024 11:50:50 GMT
       NEL:
       - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
       RateLimit-Limit:
@@ -153,7 +158,7 @@ interactions:
       RateLimit-Reset:
       - '1'
       Report-To:
-      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=UowbDOLD1%2BGV6D8NGunUyeXA%2FfI6UDogul%2FFtMqtXJZ03a2JE%2FTweG0s9QJCo5IwStYiOkFrr6Dsj%2FhOlUb3qwazhxbr%2FZjB7UQyA0uCjcx0%2BPvBxip7u5Xj7I3MYp%2FO7kJLsFki5ss%3D"}],"group":"cf-nel","max_age":604800}'
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=COOK2orSLSvmUA%2B5Azy%2FY42qcxFkIIWkIE5AcxLmaY%2BX7OX%2FRyT1fEXxnJBOBVjeZRXByO7ETTMKemb6Isa%2BUvdNzKPrAJRFJeU2Xqpv%2FWdmWJyMfoJPVx0aqIkhxwsZFrfne5yTKqs%3D"}],"group":"cf-nel","max_age":604800}'
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -171,117 +176,17 @@ interactions:
       X-Frame-Options:
       - SAMEORIGIN
       X-Kong-Proxy-Latency:
-      - '10'
+      - '2'
       X-Kong-Upstream-Latency:
-      - '60'
+      - '17'
       X-RateLimit-Limit-Second:
       - '5'
       X-RateLimit-Remaining-Second:
       - '4'
       X-Request-Id:
-      - d2a82f03-90c5-4b7c-9129-fcf02d6fff9c
+      - e56b9a5b-fa56-4283-a96e-4006bcda2a75
       X-Runtime:
-      - '0.056931'
-      X-Var-Cache:
-      - MISS
-      X-Via:
-      - fw1
-      X-Vip:
-      - 'false'
-      X-Vip-Consumer:
-      - 'false'
-      X-Vip-User:
-      - 'false'
-      X-XSS-Protection:
-      - 1; mode=block
-      alt-svc:
-      - h3=":443"; ma=86400
-    status:
-      code: 200
-      message: OK
-- request:
-    body: null
-    headers:
-      Accept:
-      - '*/*'
-      Accept-Encoding:
-      - gzip, deflate
-      Api-Key:
-      - mij33pjc3kOlup1qOKxnWWxvle2kFbMH
-      Authorization:
-      - Bearer eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJTNXJaWEYxVERvejR2ekpMMEZlTUUweFZvMURmTGpUaCIsImV4cCI6MTcxNDU2MTEwM30.wHJRyiYCBcS9iV8HG99H6af11dGzdpEn6A237gCp4tI
-      Connection:
-      - keep-alive
-      Content-Length:
-      - '0'
-      Content-Type:
-      - application/json
-      User-Agent:
-      - Subliminal v2.1
-    method: DELETE
-    uri: https://api.opensubtitles.com/api/v1/logout
-  response:
-    body:
-      string: '{"message":"token successfully destroyed","status":200}'
-    headers:
-      Access-Control-Allow-Headers:
-      - Origin, Authorization, Accept, Api-Key, Content-Type, X-User-Agent
-      Access-Control-Allow-Methods:
-      - GET, HEAD, POST, OPTIONS
-      Access-Control-Allow-Origin:
-      - '*'
-      Age:
-      - '0'
-      CF-Cache-Status:
-      - DYNAMIC
-      CF-RAY:
-      - 87c704368f7a069a-LHR
-      Cache-Control:
-      - max-age=0, private, must-revalidate, s-maxage=600
-      Connection:
-      - keep-alive
-      Content-Encoding:
-      - gzip
-      Content-Type:
-      - application/json; charset=utf-8
-      Date:
-      - Tue, 30 Apr 2024 10:58:24 GMT
-      NEL:
-      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
-      RateLimit-Limit:
-      - '5'
-      RateLimit-Remaining:
-      - '3'
-      RateLimit-Reset:
-      - '1'
-      Report-To:
-      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=UAFjmkmeJzPt7Ti%2BCCAQciKDD4CGbHNivivHL%2Be08vSQ3OUyRmlDVvr14ReyQK7bBy9kmIIz2b5rplAmOdJkzQeZaSsnM70N8qG%2FZt6ZwzvvUq3ofQchvjWph%2FdVgriy8mRSgYh5plM%3D"}],"group":"cf-nel","max_age":604800}'
-      Server:
-      - cloudflare
-      Strict-Transport-Security:
-      - max-age=15552000; includeSubDomains; preload
-      Transfer-Encoding:
-      - chunked
-      X-Cache-Backend:
-      - apigw1_8000 rb11
-      X-Content-Type-Options:
-      - nosniff
-      X-Download-Options:
-      - noopen
-      X-Frame-Options:
-      - SAMEORIGIN
-      X-Kong-Proxy-Latency:
-      - '0'
-      X-Kong-Upstream-Latency:
-      - '33'
-      X-RateLimit-Limit-Second:
-      - '5'
-      X-RateLimit-Remaining-Second:
-      - '3'
-      X-Request-Id:
-      - a5dcf5bd-3e00-44de-951f-18b5af89b10a
-      X-Runtime:
-      - '0.030549'
+      - '0.015425'
       X-Var-Cache:
       - MISS
       X-Via:


### PR DESCRIPTION
So we get rid of the `requests-cache` dependency I introduced in #1067 

Loosely based on Bazarr implementation.