### PR TITLE
Add a cli option to import from a toml config file

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -1,0 +1,26 @@
+[default]
+cache_dir = "~/.cache/subliminal"
+
+[provider.opensubtitlescom]
+username = "python-subliminal-test"
+password = "subliminal"
+apikey = "mij33pjc3kOlup1qOKxnWWxvle2kFbMH"
+
+[provider.addic7ed]
+username = "subliminal"
+password = "subliminal"
+
+[refiner.omdb]
+apikey = "44d5b275"
+
+[refiner.tmdb]
+apikey = "xxxxxxxxx"
+
+[download]
+provider = ["addic7ed", "opensubtitlescom", "opensubtitles"]
+refiner = ["metadata", "hash", "omdb", "tvdb"]
+language = ["fr", "en", "pt-br"]
+encoding = "utf-8"
+min_score = 50
+archives = true
+verbose = 3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,19 +33,21 @@ classifiers = [
 ]
 dynamic = ["version", "readme"]
 dependencies = [
-    "appdirs>=1.3",
     "babelfish>=0.6.1",
     "beautifulsoup4>=4.4.0",
     "chardet>=5.0",
-    "click>=4.0",
+    "click>=8.0",
+    "click-option-group>=0.5.6",
     "dogpile.cache>=1.0",
     "enzyme>=0.4.1",
     "guessit>=3.0.0",
+    "platformdirs>=4.2",
     "rarfile>=2.7",
     "rebulk>=3.0",
     "requests>=2.0",
     "srt>=3.5",
     "stevedore>=3.0",
+    "tomli>=2",
 ]
 
 # extras
@@ -155,19 +157,21 @@ select = [
     "DTZ",    # flake8-datetimez
     "A",      # flake8-builtins
     "FBT",    # flake8-boolean-trap
-    "ANN2",   # flake8-annotations
-    "ANN001",
+    "ANN0",   # flake8-annotations
+    "ANN2",
     "ASYNC",  # flake8-async
     "TRY",    # tryceratops
 ]
 ignore = [
+    "D105",   # Missing docstring in magic method
+    "D107",   # Missing docstring in `__init__`
     "D401",   # First line should be in imperative mood
 ]
 
 [tool.ruff.lint.per-file-ignores]
 "docs/conf*.py" = ["ALL"]
 "subliminal/__init__.py" = ["E402"]
-"tests/*.py" = ["D", "S", "RUF012"]
+"tests/*.py" = ["D", "S", "RUF012", "ANN", "FBT"]
 
 # https://docs.astral.sh/ruff/formatter/
 [tool.ruff.format]

--- a/subliminal/__init__.py
+++ b/subliminal/__init__.py
@@ -1,17 +1,29 @@
+"""Subliminal."""
+
 from __future__ import annotations
 
-__title__ = 'subliminal'
-__version__ = '2.1.1-dev'
-__short_version__ = '.'.join(__version__.split('.')[:2])
-__author__ = 'Antoine Bertin'
-__license__ = 'MIT'
-__copyright__ = 'Copyright 2016, Antoine Bertin'
+__title__: str = 'subliminal'
+__version__: str = '2.1.1-dev'
+__short_version__: str = '.'.join(__version__.split('.')[:2])
+__author__: str = 'Antoine Bertin'
+__license__: str = 'MIT'
+__copyright__: str = 'Copyright 2016, Antoine Bertin'
 
 import logging
 
-from .core import (AsyncProviderPool, ProviderPool, check_video, download_best_subtitles, download_subtitles,
-                   list_subtitles, refine, save_subtitles, scan_video, scan_videos)
 from .cache import region
+from .core import (
+    AsyncProviderPool,
+    ProviderPool,
+    check_video,
+    download_best_subtitles,
+    download_subtitles,
+    list_subtitles,
+    refine,
+    save_subtitles,
+    scan_video,
+    scan_videos,
+)
 from .exceptions import Error, ProviderError
 from .extensions import provider_manager, refiner_manager
 from .providers import Provider
@@ -20,3 +32,31 @@ from .subtitle import SUBTITLE_EXTENSIONS, Subtitle
 from .video import VIDEO_EXTENSIONS, Episode, Movie, Video
 
 logging.getLogger(__name__).addHandler(logging.NullHandler())
+
+
+__all__ = [
+    'region',
+    'AsyncProviderPool',
+    'ProviderPool',
+    'check_video',
+    'download_best_subtitles',
+    'download_subtitles',
+    'list_subtitles',
+    'refine',
+    'save_subtitles',
+    'scan_video',
+    'scan_videos',
+    'Error',
+    'ProviderError',
+    'provider_manager',
+    'refiner_manager',
+    'Provider',
+    'compute_score',
+    'get_scores',
+    'SUBTITLE_EXTENSIONS',
+    'Subtitle',
+    'VIDEO_EXTENSIONS',
+    'Episode',
+    'Movie',
+    'Video',
+]


### PR DESCRIPTION
closes https://github.com/Diaoul/subliminal/issues/553

I added an example file in `docs`.
If the `--config` option is not set it looks for the default path at `$USER_CONFIG_PATH / subliminal.toml` 

Also change the `appdirs` dependency to `platformdirs`, as the former was deprecated in favor of the latter (https://github.com/ActiveState/appdirs).

The change is big because I also run `ruff format` and `ruff check` on theses files (both passing now).