### PR TITLE
Move hash functions to refiners/hash.py

### DIFF
--- a/subliminal/refiners/hash.py
+++ b/subliminal/refiners/hash.py
@@ -1,24 +1,130 @@
+"""Refine the :class:`~subliminal.video.Video` object with video hashes."""
+
 from __future__ import annotations
 
+import hashlib
 import logging
+import os
+import struct
+from typing import TYPE_CHECKING, Any, cast
 
-from ..extensions import provider_manager, default_providers
-from ..utils import hash_napiprojekt, hash_opensubtitles, hash_shooter, hash_thesubdb
+from subliminal.extensions import default_providers, provider_manager
+from subliminal.providers import Provider
+
+if TYPE_CHECKING:
+    from collections.abc import Sequence, Set
+    from typing import Callable, TypeAlias
+
+    from babelfish import Language  # type: ignore[import-untyped]
+
+    from subliminal.video import Video
+
+    HashFunc: TypeAlias = Callable[[str | os.PathLike], str | None]
 
 logger = logging.getLogger(__name__)
 
-hash_functions = {
+
+def hash_opensubtitles(video_path: str | os.PathLike) -> str | None:
+    """Compute a hash using OpenSubtitles' algorithm.
+
+    :param (str | os.PathLike) video_path: path of the video.
+    :return: the hash.
+    :rtype: str
+
+    """
+    video_path = os.fspath(video_path)
+    bytesize = struct.calcsize(b'<q')
+    with open(video_path, 'rb') as f:
+        filesize = os.path.getsize(video_path)
+        filehash = filesize
+        if filesize < 65536 * 2:
+            return None
+        for _ in range(65536 // bytesize):
+            filebuffer = f.read(bytesize)
+            (l_value,) = struct.unpack(b'<q', filebuffer)
+            filehash += l_value
+            filehash &= 0xFFFFFFFFFFFFFFFF  # to remain as 64bit number
+        f.seek(max(0, filesize - 65536), 0)
+        for _ in range(65536 // bytesize):
+            filebuffer = f.read(bytesize)
+            (l_value,) = struct.unpack(b'<q', filebuffer)
+            filehash += l_value
+            filehash &= 0xFFFFFFFFFFFFFFFF
+    return f'{filehash:016x}'
+
+
+def hash_thesubdb(video_path: str | os.PathLike) -> str | None:
+    """Compute a hash using TheSubDB's algorithm.
+
+    :param str video_path: path of the video.
+    :return: the hash.
+    :rtype: str
+
+    """
+    readsize = 64 * 1024
+    if os.path.getsize(video_path) < readsize:
+        return None
+    with open(video_path, 'rb') as f:
+        data = f.read(readsize)
+        f.seek(-readsize, os.SEEK_END)
+        data += f.read(readsize)
+
+    return hashlib.md5(data).hexdigest()  # noqa: S324
+
+
+def hash_napiprojekt(video_path: str | os.PathLike) -> str | None:
+    """Compute a hash using NapiProjekt's algorithm.
+
+    :param str video_path: path of the video.
+    :return: the hash.
+    :rtype: str
+
+    """
+    readsize = 1024 * 1024 * 10
+    with open(video_path, 'rb') as f:
+        data = f.read(readsize)
+    return hashlib.md5(data).hexdigest()  # noqa: S324
+
+
+def hash_shooter(video_path: str | os.PathLike) -> str | None:
+    """Compute a hash using Shooter's algorithm.
+
+    :param string video_path: path of the video
+    :return: the hash
+    :rtype: string
+
+    """
+    filesize = os.path.getsize(video_path)
+    readsize = 4096
+    if os.path.getsize(video_path) < readsize * 2:
+        return None
+    offsets = (readsize, filesize // 3 * 2, filesize // 3, filesize - readsize * 2)
+    filehash = []
+    with open(video_path, 'rb') as f:
+        for offset in offsets:
+            f.seek(offset)
+            filehash.append(hashlib.md5(f.read(readsize)).hexdigest())  # noqa: S324
+    return ';'.join(filehash)
+
+
+hash_functions: dict[str, HashFunc] = {
     'napiprojekt': hash_napiprojekt,
     'opensubtitles': hash_opensubtitles,
     'opensubtitlesvip': hash_opensubtitles,
     'opensubtitlescom': hash_opensubtitles,
     'opensubtitlescomvip': hash_opensubtitles,
     'shooter': hash_shooter,
-    'thesubdb': hash_thesubdb
+    'thesubdb': hash_thesubdb,
 }
 
 
-def refine(video, providers=None, languages=None, **kwargs):
+def refine(
+    video: Video,
+    *,
+    providers: Sequence[str] | None = None,
+    languages: Set[Language] | None = None,
+    **kwargs: Any,
+) -> Video:
     """Refine a video computing required hashes for the given providers.
 
     The following :class:`~subliminal.video.Video` attribute can be found:
@@ -26,22 +132,25 @@ def refine(video, providers=None, languages=None, **kwargs):
       * :attr:`~subliminal.video.Video.hashes`
 
     """
-    if video.size <= 10485760:
+    if video.size is None or video.size <= 10485760:
         logger.warning('Size is lower than 10MB: hashes not computed')
-        return
+        return video
 
     logger.debug('Computing hashes for %r', video.name)
     for name in providers or default_providers:
-        provider = provider_manager[name].plugin
+        provider = cast(Provider, provider_manager[name].plugin)
         if name not in hash_functions:
             continue
 
         if not provider.check_types(video):
             continue
 
-        if languages and not provider.check_languages(languages):
+        if languages is not None and not provider.check_languages(languages):
             continue
 
-        video.hashes[name] = hash_functions[name](video.name)
+        h = hash_functions[name](video.name)
+        if h is not None:
+            video.hashes[name] = h
 
     logger.debug('Computed hashes %r', video.hashes)
+    return video

--- a/subliminal/utils.py
+++ b/subliminal/utils.py
@@ -4,10 +4,8 @@ from __future__ import annotations
 
 import functools
 import logging
-import os
 import re
 import socket
-import struct
 from datetime import datetime, timezone
 from types import GeneratorType
 from typing import TYPE_CHECKING, Any, Callable, Generic, Iterable, TypeVar, cast, overload

--- a/tests/refiners/test_hash.py
+++ b/tests/refiners/test_hash.py
@@ -1,0 +1,19 @@
+from subliminal.refiners.hash import hash_opensubtitles, hash_thesubdb
+
+
+def test_hash_opensubtitles(mkv):
+    assert hash_opensubtitles(mkv['test1']) == '40b44a7096b71ec3'
+
+
+def test_hash_opensubtitles_too_small(tmpdir):
+    path = tmpdir.ensure('test_too_small.mkv')
+    assert hash_opensubtitles(str(path)) is None
+
+
+def test_hash_thesubdb(mkv):
+    assert hash_thesubdb(mkv['test1']) == '054e667e93e254f8fa9f9e8e6d4e73ff'
+
+
+def test_hash_thesubdb_too_small(tmpdir):
+    path = tmpdir.ensure('test_too_small.mkv')
+    assert hash_thesubdb(str(path)) is None

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,22 +1,4 @@
-from subliminal.utils import hash_opensubtitles, hash_thesubdb, sanitize
-
-
-def test_hash_opensubtitles(mkv):
-    assert hash_opensubtitles(mkv['test1']) == '40b44a7096b71ec3'
-
-
-def test_hash_opensubtitles_too_small(tmpdir):
-    path = tmpdir.ensure('test_too_small.mkv')
-    assert hash_opensubtitles(str(path)) is None
-
-
-def test_hash_thesubdb(mkv):
-    assert hash_thesubdb(mkv['test1']) == '054e667e93e254f8fa9f9e8e6d4e73ff'
-
-
-def test_hash_thesubdb_too_small(tmpdir):
-    path = tmpdir.ensure('test_too_small.mkv')
-    assert hash_thesubdb(str(path)) is None
+from subliminal.utils import sanitize
 
 
 def test_sanitize():


### PR DESCRIPTION
Also updated `matches.py`.

First step of getting rid of the `rebulk` dependency.

The change is big because I also run `ruff format` and `ruff check` on theses files (both passing now).