### PR TITLE
Add type hint to subtitle.py

### DIFF
--- a/subliminal/core.py
+++ b/subliminal/core.py
@@ -684,7 +684,7 @@ def save_subtitles(video, subtitles, single=False, directory=None, encoding=None
     saved_subtitles = []
     for subtitle in subtitles:
         # check content
-        if subtitle.content is None:
+        if not subtitle.content:
             logger.error('Skipping subtitle %r: no content', subtitle)
             continue
 

--- a/subliminal/subtitle.py
+++ b/subliminal/subtitle.py
@@ -143,6 +143,8 @@ class Subtitle:
         :rtype: str
 
         """
+        if not isinstance(self.content, bytes):
+            return None
         logger.info('Guessing encoding for language %s', self.language)
 
         # always try utf-8 first

--- a/subliminal/subtitle.py
+++ b/subliminal/subtitle.py
@@ -1,11 +1,19 @@
+"""Subtitle class."""
+
 from __future__ import annotations
 
 import codecs
 import logging
 import os
+from typing import TYPE_CHECKING, ClassVar
 
 import chardet
-import srt
+import srt  # type: ignore[import-untyped]
+
+if TYPE_CHECKING:
+    from babelfish import Language  # type: ignore[import-untyped]
+
+    from subliminal.video import Video
 
 logger = logging.getLogger(__name__)
 
@@ -25,10 +33,33 @@ class Subtitle:
     :type encoding: str
 
     """
-    #: Name of the provider that returns that class of subtitle
-    provider_name = ''
 
-    def __init__(self, language, hearing_impaired=False, page_link=None, encoding=None):
+    #: Name of the provider that returns that class of subtitle
+    provider_name: ClassVar[str] = ''
+
+    #: Language of the subtitle
+    language: Language
+
+    #: Whether or not the subtitle is hearing impaired
+    hearing_impaired: bool
+
+    #: URL of the web page from which the subtitle can be downloaded
+    page_link: str | None
+
+    #: Content as bytes
+    content: bytes | None
+
+    #: Encoding to decode with when accessing :attr:`text`
+    encoding: str | None
+
+    def __init__(
+        self,
+        language: Language,
+        *,
+        hearing_impaired: bool = False,
+        page_link: str | None = None,
+        encoding: str | None = None,
+    ) -> None:
         #: Language of the subtitle
         self.language = language
 
@@ -52,38 +83,39 @@ class Subtitle:
                 logger.debug('Unsupported encoding %s', encoding)
 
     @property
-    def id(self):
-        """Unique identifier of the subtitle"""
-        return ""
+    def id(self) -> str:
+        """Unique identifier of the subtitle."""
+        return ''
 
     @property
-    def info(self):
-        """Info of the subtitle, human readable. Usually the subtitle name for GUI rendering"""
-        return ""
+    def info(self) -> str:
+        """Info of the subtitle, human readable. Usually the subtitle name for GUI rendering."""
+        return ''
 
     @property
-    def text(self):
-        """Content as string
+    def text(self) -> str:
+        """Content as string.
 
         If :attr:`encoding` is None, the encoding is guessed with :meth:`guess_encoding`
 
         """
-        if not self.content:
-            return
+        if not isinstance(self.content, bytes) or not self.content:
+            return ''
 
-        if isinstance(self.content, bytes):
-            if self.encoding:
-                return self.content.decode(self.encoding, errors='replace')
+        # Decode
+        if self.encoding:
+            return self.content.decode(self.encoding, errors='replace')
 
-            guessed_encoding = self.guess_encoding()
-            if guessed_encoding:
-                return self.content.decode(guessed_encoding, errors='replace')
+        # Get encoding
+        guessed_encoding = self.guess_encoding()
+        if guessed_encoding:
+            return self.content.decode(guessed_encoding, errors='replace')
 
-            return None
+        # Cannot decode
+        logger.warning('Cannot guess encoding to decode subtitle content.')
+        return ''
 
-        return self.content
-
-    def is_valid(self):
+    def is_valid(self) -> bool:
         """Check if a :attr:`text` is a valid SubRip format.
 
         :return: whether or not the subtitle is valid.
@@ -100,13 +132,11 @@ class Subtitle:
 
         return True
 
-    def parsed(self):
-        """Text content parsed to a valid subtitle.
+    def parsed(self) -> str:
+        """Text content parsed to a valid subtitle."""
+        return str(srt.compose(srt.parse(self.text)))
 
-        """
-        return srt.compose(srt.parse(self.text))
-
-    def guess_encoding(self):
+    def guess_encoding(self) -> str | None:
         """Guess encoding using the language, falling back on chardet.
 
         :return: the guessed encoding.
@@ -153,12 +183,12 @@ class Subtitle:
         logger.warning('Could not guess encoding from language')
 
         # fallback on chardet
-        encoding = chardet.detect(self.content)['encoding']
-        logger.info('Chardet found encoding %s', encoding)
+        encoding_or_none = chardet.detect(self.content)['encoding']
+        logger.info('Chardet found encoding %s', encoding_or_none)
 
-        return encoding
+        return encoding_or_none
 
-    def get_path(self, video, single=False):
+    def get_path(self, video: Video, *, single: bool = False) -> str:
         """Get the subtitle path using the `video`, `language` and `extension`.
 
         :param video: path to the video.
@@ -170,7 +200,7 @@ class Subtitle:
         """
         return get_subtitle_path(video.name, None if single else self.language)
 
-    def get_matches(self, video):
+    def get_matches(self, video: Video) -> set[str]:
         """Get the matches against the `video`.
 
         :param video: the video to get the matches with.
@@ -181,14 +211,14 @@ class Subtitle:
         """
         raise NotImplementedError
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash(self.provider_name + '-' + self.id)
 
-    def __repr__(self):
-        return '<%s %r [%s]>' % (self.__class__.__name__, self.id, self.language)
+    def __repr__(self) -> str:
+        return f'<{self.__class__.__name__} {self.id!r} [{self.language}]>'
 
 
-def get_subtitle_path(video_path, language=None, extension='.srt'):
+def get_subtitle_path(video_path: str | os.PathLike, language: Language | None = None, extension: str = '.srt') -> str:
     """Get the subtitle path using the `video_path` and `language`.
 
     :param str video_path: path to the video.
@@ -207,8 +237,8 @@ def get_subtitle_path(video_path, language=None, extension='.srt'):
     return subtitle_root + extension
 
 
-def fix_line_ending(content):
-    """Fix line ending of `content` by changing it to \n.
+def fix_line_ending(content: bytes) -> bytes:
+    r"""Fix line ending of `content` by changing it to \n.
 
     :param bytes content: content of the subtitle.
     :return: the content with fixed line endings.

--- a/tests/test_subtitle.py
+++ b/tests/test_subtitle.py
@@ -1,8 +1,7 @@
 import os
 
-from babelfish import Language
 import pytest
-
+from babelfish import Language
 from subliminal.subtitle import Subtitle, fix_line_ending, get_subtitle_path
 
 
@@ -14,7 +13,7 @@ def test_subtitle_text():
 
 def test_subtitle_text_no_content():
     subtitle = Subtitle(Language('eng'))
-    assert subtitle.text is None
+    assert subtitle.text == ''
 
 
 def test_subtitle_is_valid_no_content():
@@ -24,32 +23,39 @@ def test_subtitle_is_valid_no_content():
 
 def test_subtitle_is_valid_valid(monkeypatch):
     subtitle = Subtitle(Language('fra'))
-    text = (u'1\n'
-            u'00:00:20,000 --> 00:00:24,400\n'
-            u'En réponse à l\'augmentation de la criminalité\n'
-            u'dans certains quartiers,\n')
+    text = (
+        '1\n'
+        '00:00:20,000 --> 00:00:24,400\n'
+        "En réponse à l'augmentation de la criminalité\n"
+        'dans certains quartiers,\n'
+    )
     monkeypatch.setattr(Subtitle, 'text', text)
     assert subtitle.is_valid() is True
 
-@pytest.mark.xfail
+
+@pytest.mark.xfail()
 def test_subtitle_is_valid_invalid(monkeypatch):
     subtitle = Subtitle(Language('fra'))
-    text = (u'1\n'
-            u'00:00:20,000 --> 00:00:24,400\n'
-            u'En réponse à l\'augmentation de la criminalité\n'
-            u'dans certains quartiers,\n\n')
-    text += u'This line shouldn\'t be here'
+    text = (
+        '1\n'
+        '00:00:20,000 --> 00:00:24,400\n'
+        "En réponse à l'augmentation de la criminalité\n"
+        'dans certains quartiers,\n\n'
+    )
+    text += "This line shouldn't be here"
     monkeypatch.setattr(Subtitle, 'text', text)
     assert subtitle.is_valid() is False
 
 
 def test_subtitle_is_valid_valid_begin(monkeypatch):
     subtitle = Subtitle(Language('fra'))
-    text = (u'1\n'
-            u'00:00:20,000 --> 00:00:24,400\n'
-            u'En réponse à l\'augmentation de la criminalité\n'
-            u'dans certains quartiers,\n\n')*20
-    text += u'This line shouldn\'t be here'
+    text = (
+        '1\n'
+        '00:00:20,000 --> 00:00:24,400\n'
+        "En réponse à l'augmentation de la criminalité\n"
+        'dans certains quartiers,\n\n'
+    ) * 20
+    text += "This line shouldn't be here"
     monkeypatch.setattr(Subtitle, 'text', text)
     assert subtitle.is_valid() is True
 
@@ -83,33 +89,58 @@ def test_fix_line_ending_chinese_characters():
 
 
 def test_subtitle_valid_encoding():
-    subtitle = Subtitle(Language('deu'), False, None, 'windows-1252')
+    subtitle = Subtitle(
+        language=Language('deu'),
+        hearing_impaired=False,
+        page_link=None,
+        encoding='windows-1252',
+    )
     assert subtitle.encoding == 'cp1252'
 
 
 def test_subtitle_empty_encoding():
-    subtitle = Subtitle(Language('deu'), False, None, None)
+    subtitle = Subtitle(
+        language=Language('deu'),
+        hearing_impaired=False,
+        page_link=None,
+        encoding=None,
+    )
     assert subtitle.encoding is None
 
 
 def test_subtitle_invalid_encoding():
-    subtitle = Subtitle(Language('deu'), False, None, 'rubbish')
+    subtitle = Subtitle(
+        language=Language('deu'),
+        hearing_impaired=False,
+        page_link=None,
+        encoding='rubbish',
+    )
     assert subtitle.encoding is None
 
 
 def test_subtitle_guess_encoding_utf8():
-    subtitle = Subtitle(Language('zho'), False, None, None)
+    subtitle = Subtitle(
+        language=Language('zho'),
+        hearing_impaired=False,
+        page_link=None,
+        encoding=None,
+    )
     subtitle.content = b'Something here'
     assert subtitle.guess_encoding() == 'utf-8'
-    assert isinstance(subtitle.text, str)
+    assert subtitle.text == 'Something here'
 
 
 # regression for #921
 def test_subtitle_text_guess_encoding_none():
     content = b'\x00d\x00\x80\x00\x00\xff\xff\xff\xff\xff\xff,\x00\x00\x00\x00d\x00d\x00\x00\x02s\x84\x8f\xa9'
-    subtitle = Subtitle(Language('zho'), False, None, None)
+    subtitle = Subtitle(
+        language=Language('zho'),
+        hearing_impaired=False,
+        page_link=None,
+        encoding=None,
+    )
     subtitle.content = content
 
     assert subtitle.guess_encoding() is None
     assert not subtitle.is_valid()
-    assert not isinstance(subtitle.text, str)
+    assert subtitle.text == ''


### PR DESCRIPTION
Breaking changes:
- `Subtitle` takes one positional argument (`language`), the rest are keyword only.
- ~~`Subtitle.content` is always a `bytes`, never `None`.~~  `content` can be `bytes` or `None`, it will be improved in another PR.
- `Subtitle.text` is always a `str` never a `bytes` or `None`. If the encoding cannot be guessed, return an empty string