### PR TITLE
Added setuptools as an install dependency

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,9 @@ target/
 # Pycharm
 .idea
 
+# Visual Studio Code
+.vscode
+
 # Subliminal
 tests/data/mkv/
 tests/data/rar/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -46,6 +46,7 @@ dependencies = [
     "rarfile>=2.7",
     "rebulk>=3.0",
     "requests>=2.0",
+    # "setuptools>=64", # enzyme uses pkg_resources
     "srt>=3.5",
     "stevedore>=3.0",
     "tomli>=2",

--- a/tox.ini
+++ b/tox.ini
@@ -5,3 +5,4 @@ envlist = {py38,py39,py310,py311,py312}-{native,lxml}
 deps =
     lxml: lxml
 commands = pytest
+allowlist_externals = pytest


### PR DESCRIPTION
enzyme and, by extension, the metadata refiner, relies on the (deprecated) pkg_resources module from setuptools.

This can break the refiner in newly created venvs, since pip doesn't requipre setuptools.