### PR TITLE
Use towncrier to avoid conflicts in HISTORY.rst

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -31,3 +31,12 @@ repos:
       - id: doc8
         description: This hook runs doc8 for linting docs
         require_serial: true
+
+  - repo: local
+    hooks:
+    - id: changelog-fragment-filenames
+      name: changelog fragment
+      language: fail
+      entry: changelog fragment files must be named *.(breaking|change|provider|refiner|deprecation|doc|misc).rst
+      exclude: ^changelog.d/(\..*|towncrier_template.rst|.*\.(breaking|change|provider|refiner|deprecation|doc|misc).rst)
+      files: ^changelog.d/

--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,6 +1,8 @@
 Changelog
 ---------
 
+.. towncrier release notes start
+
 2.2.1
 ^^^^^
 **release date:** 2024-06-27

--- a/changelog.d/.gitignore
+++ b/changelog.d/.gitignore
@@ -1,0 +1,1 @@
+!.gitignore

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,6 +57,7 @@ docs = [
     "sphinx",
     "sphinx_rtd_theme",
     "sphinxcontrib-programoutput",
+    "towncrier",
 ]
 test = [
     "mypy",
@@ -211,6 +212,52 @@ omit = ["subliminal/cli.py"]
 [tool.coverage.run]
 source = ["subliminal"]
 relative_files = true
+
+
+# https://towncrier.readthedocs.io/en/stable/tutorial.html
+[tool.towncrier]
+name = "subliminal"
+package = "subliminal"
+directory = "changelog.d"
+filename = "HISTORY.rst"
+title_format = "`version <https://github.com/Diaoul/subliminal/tree/{version}>`_ - {project_date}"
+issue_format = "`#{issue} <https://github.com/Diaoul/subliminal/issues/{issue}>`_"
+underlines = ["^", "-", "~"]
+
+[[tool.towncrier.type]]
+directory = "breaking"
+name = "Backwards-incompatible Changes"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "change"
+name = "Changes"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "provider"
+name = "Provider Changes"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "refiner"
+name = "Refiner Changes"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "deprecation"
+name = "Deprecations"
+showcontent = true
+
+[[tool.towncrier.type]]
+directory = "doc"
+name = "Documentation"
+showcontent = false
+
+[[tool.towncrier.type]]
+directory = "misc"
+name = "Misc"
+showcontent = false
 
 
 # https://mypy.readthedocs.io/en/stable/config_file.html


### PR DESCRIPTION
See #1138

Documentation [here](https://towncrier.readthedocs.io/en/stable/). It is used by many many projects (attrs, pytest, numpy, ...) so it seems a good choice.

Like that, with each commit or PR, we add a news fragment (a file) in the `changelog.d` folder.
Before making a new release, we call `towncrier -- version 2.3.0` and the files are parsed and added nicely to the `HISTORY.rst` file. They are also deleted from the `changelog.d` folder.
You can add a news fragment from the command line with: `towncrier create --content 'use towncrier' 1138.misc.rst`

We have to decide the type of fragments to add. I put:
 - `breaking`
 - `change`
 - `provider`
 - `refiner`
 - `deprecation`
 - `doc`
 - `misc`

With `doc` and `misc` showing only the list of PR numbers in the changelog, not the text.

Notice that it will change the formatting of the `HISTORY.rst` file, now the title for a new release with the date will be on the same line.

I will add the information about how to make a new release in another PR (first handle the conflicts in `HISTORY.rst`).
