### PR TITLE
Add subtitle language_type and Embedded subtitle subclass

### DIFF
--- a/changelog.d/1148.doc.rst
+++ b/changelog.d/1148.doc.rst
@@ -1,0 +1,1 @@
+Add language_type attribute to Subtitle


### PR DESCRIPTION
`language_type` summarizes information about the subtitle type: hearing impaired, forced (only foreign parts), normal or unknown.

My idea is then to use it to score subtitles with 0 if they do not match the type (asked for HI and got normal), 1 if the type is unknown, and 2 if the type matches (asked for forced subtitle and got it).

The `Embedded` subclass will be used instead of `video.subtitle_languages` to check if subtitles with the given language and language_type were already present.