### PR TITLE
Only check and extract the needed mkv files

### DIFF
--- a/changelog.d/1134.misc.rst
+++ b/changelog.d/1134.misc.rst
@@ -1,0 +1,1 @@
+Avoid downloading archive each time

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -439,15 +439,22 @@ def episodes() -> dict[str, Episode]:
 def mkv():
     data_path = os.path.join(TESTS, 'data', 'mkv')
 
-    # download matroska test suite
-    if not os.path.exists(data_path) or len(os.listdir(data_path)) != 8:
+    wanted_files = [f'test{i}.mkv' for i in range(1, 9)]
+
+    # check for missing files
+    missing_files = [f for f in wanted_files if not os.path.exists(os.path.join(data_path, f))]
+    if missing_files:
+        # download matroska test suite
         r = requests.get('http://downloads.sourceforge.net/project/matroska/test_files/matroska_test_w1_1.zip')
         with ZipFile(BytesIO(r.content), 'r') as f:
-            f.extractall(data_path, [m for m in f.namelist() if os.path.splitext(m)[1] == '.mkv'])
+            for missing_file in missing_files:
+                f.extract(missing_file, data_path)
 
     # populate a dict with mkv files
     files = {}
     for path in os.listdir(data_path):
+        if path not in wanted_files:
+            continue
         name, _ = os.path.splitext(path)
         files[name] = os.path.join(data_path, path)
 


### PR DESCRIPTION
fixes #1134

Before, the `mkv` fixture was dowloading the matroska archive and extracting all the files, which are 8 `mkv` files and `xml` files. The next time the `mkv` fixture was called, it checked if there were 8 files in the dowloaded folder, it was not the case because the extra `xml` files had been extracted and so the archive was downloaded and extracted again.

Now it checks only if the 8 `mkv` files exist in the data folder, if not it downloads the archive and extract only the needed `mkv` files. So the download is done only once.