### PR TITLE
Add two options for language name style in saved subtitles

### DIFF
--- a/changelog.d/1022.change.rst
+++ b/changelog.d/1022.change.rst
@@ -1,0 +1,2 @@
+Add an option to change the style of the language suffix of saved subtitles.
+Allow adding the language type, hi or forced.

--- a/subliminal/cli.py
+++ b/subliminal/cli.py
@@ -347,6 +347,17 @@ def cache(ctx: click.Context, clear_subliminal: bool) -> None:
     default=0,
     help='Minimum score for a subtitle to be downloaded (0 to 100).',
 )
+@click.option(
+    '--language-type-suffix',
+    is_flag=True,
+    default=False,
+    help='Add a suffix to the saved subtitle name to indicate a hearing impaired or foreign part subtitle.',
+)
+@click.option(
+    '--language-format',
+    default='alpha2',
+    help='Format of the language code in the saved subtitle name. Default is a 2-letter language code.',
+)
 @click.option('-w', '--max-workers', type=click.IntRange(1, 50), default=None, help='Maximum number of threads to use.')
 @click.option(
     '-z/-Z',
@@ -371,6 +382,8 @@ def download(
     force: bool,
     hearing_impaired: bool,
     min_score: int,
+    language_type_suffix: bool,
+    language_format: str,
     max_workers: int,
     archives: bool,
     verbose: int,
@@ -548,7 +561,15 @@ def download(
     # save subtitles
     total_subtitles = 0
     for v, subtitles in downloaded_subtitles.items():
-        saved_subtitles = save_subtitles(v, subtitles, single=single, directory=directory, encoding=encoding)
+        saved_subtitles = save_subtitles(
+            v,
+            subtitles,
+            single=single,
+            directory=directory,
+            encoding=encoding,
+            language_type_suffix=language_type_suffix,
+            language_format=language_format,
+        )
         total_subtitles += len(saved_subtitles)
 
         if verbose > 0:

--- a/subliminal/core.py
+++ b/subliminal/core.py
@@ -788,6 +788,8 @@ def save_subtitles(
     directory: str | os.PathLike | None = None,
     encoding: str | None = None,
     extension: str | None = None,
+    language_type_suffix: bool = False,
+    language_format: str = 'alpha2',
 ) -> list[Subtitle]:
     """Save subtitles on filesystem.
 
@@ -805,6 +807,8 @@ def save_subtitles(
     :param str directory: path to directory where to save the subtitles, default is next to the video.
     :param str encoding: encoding in which to save the subtitles, default is to keep original encoding.
     :param (str | None) extension: the subtitle extension, default is to match to the subtitle format.
+    :param bool language_type_suffix: add a suffix 'hi' or 'forced' if needed. Default to False.
+    :param str language_format: format of the language suffix. Default to 'alpha2'.
     :return: the saved subtitles
     :rtype: list of :class:`~subliminal.subtitle.Subtitle`
 
@@ -822,7 +826,13 @@ def save_subtitles(
             continue
 
         # create subtitle path
-        subtitle_path = subtitle.get_path(video, single=single, extension=extension)
+        subtitle_path = subtitle.get_path(
+            video,
+            single=single,
+            extension=extension,
+            language_type_suffix=language_type_suffix,
+            language_format=language_format,
+        )
         if directory is not None:
             subtitle_path = os.path.join(directory, os.path.split(subtitle_path)[1])
 

--- a/subliminal/subtitle.py
+++ b/subliminal/subtitle.py
@@ -14,7 +14,7 @@ import srt  # type: ignore[import-untyped]
 from pysubs2 import SSAFile, UnknownFPSError  # type: ignore[import-untyped]
 
 if TYPE_CHECKING:
-    from babelfish import Language
+    from babelfish import Language  # type: ignore[import-untyped]
 
     from subliminal.video import Video
 

--- a/tests/test_subtitle.py
+++ b/tests/test_subtitle.py
@@ -2,7 +2,7 @@ import os
 
 import pytest
 from babelfish import Language  # type: ignore[import-untyped]
-from subliminal.subtitle import Subtitle, fix_line_ending, get_subtitle_path
+from subliminal.subtitle import LanguageType, Subtitle, fix_line_ending, get_subtitle_path, get_subtitle_suffix
 
 
 def test_subtitle_text():
@@ -84,12 +84,46 @@ def test_get_subtitle_path(movies):
 
 def test_get_subtitle_path_language(movies):
     video = movies['man_of_steel']
-    assert get_subtitle_path(video.name, Language('por', 'BR')) == os.path.splitext(video.name)[0] + '.pt-BR.srt'
+    suffix = get_subtitle_suffix(Language('por', 'BR'))
+    assert get_subtitle_path(video.name, suffix) == os.path.splitext(video.name)[0] + '.pt-BR.srt'
 
 
 def test_get_subtitle_path_language_undefined(movies):
     video = movies['man_of_steel']
-    assert get_subtitle_path(video.name, Language('und')) == os.path.splitext(video.name)[0] + '.srt'
+    suffix = get_subtitle_suffix(Language('und'))
+    assert get_subtitle_path(video.name, suffix) == os.path.splitext(video.name)[0] + '.srt'
+
+
+def test_get_subtitle_path_hearing_impaired(movies):
+    video = movies['man_of_steel']
+    suffix = get_subtitle_suffix(
+        Language('deu', 'CH', 'Latn'),
+        language_type=LanguageType.HEARING_IMPAIRED,
+        language_type_suffix=True,
+    )
+    assert get_subtitle_path(video.name, suffix) == os.path.splitext(video.name)[0] + '.hi.de-CH-Latn.srt'
+
+
+def test_get_subtitle_path_forced(movies):
+    video = movies['man_of_steel']
+    suffix = get_subtitle_suffix(
+        Language('srp', None, 'Cyrl'),
+        language_type=LanguageType.FORCED,
+        language_type_suffix=True,
+    )
+    assert get_subtitle_path(video.name, suffix) == os.path.splitext(video.name)[0] + '.forced.sr-Cyrl.srt'
+
+
+def test_get_subtitle_path_alpha3(movies):
+    video = movies['man_of_steel']
+    suffix = get_subtitle_suffix(Language('fra', 'CA'), language_format='alpha3')
+    assert get_subtitle_path(video.name, suffix) == os.path.splitext(video.name)[0] + '.fra-CA.srt'
+
+
+def test_get_subtitle_path_extension(movies):
+    video = movies['man_of_steel']
+    suffix = get_subtitle_suffix(Language('zho', 'CN'), language_type_suffix=True)
+    assert get_subtitle_path(video.name, suffix, extension='.sub') == os.path.splitext(video.name)[0] + '.zh-CN.sub'
 
 
 def test_fix_line_ending():


### PR DESCRIPTION
fixes #1022 

Adds two options to the cli: 
 - `--language-type-suffix` (boolean flag) to add an suffix to the saved subtitle if it's hearing impaired ("hi" suffix) or forced, only-foreign parts ("forced" suffix).
 - `--language-format` (string) to add the possibility to save with a 3-letter language code ("video.eng.srt" instead of "video.en.srt").