### PR TITLE
Add CLI and config file options to ignore refiner, provider and subtitle ids

### DIFF
--- a/changelog.d/1018.change.rst
+++ b/changelog.d/1018.change.rst
@@ -1,0 +1,1 @@
+Add CLI `ignore` option for refiners, providers and subtitle ids.

--- a/changelog.d/585.change.rst
+++ b/changelog.d/585.change.rst
@@ -1,0 +1,1 @@
+Add CLI `ignore` option for refiners, providers and subtitle ids.

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -19,7 +19,8 @@ apikey = "xxxxxxxxx"
 
 [download]
 provider = ["addic7ed", "opensubtitlescom", "opensubtitles"]
-refiner = ["metadata", "hash", "omdb", "tmdb"]
+refiner = ["metadata", "hash", "omdb"]
+ignore_refiner = ["tmdb"]
 language = ["fr", "en", "pt-br"]
 encoding = "utf-8"
 min_score = 50

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -102,13 +102,12 @@ tvsubtitles = "subliminal.providers.tvsubtitles:TVsubtitlesProvider"
 hash = "subliminal.refiners.hash:refine"
 metadata = "subliminal.refiners.metadata:refine"
 omdb = "subliminal.refiners.omdb:refine"
+tmdb = "subliminal.refiners.tmdb:refine"
 tvdb = "subliminal.refiners.tvdb:refine"
 
 [project.entry-points."babelfish.language_converters"]
 addic7ed = "subliminal.converters.addic7ed:Addic7edConverter"
 opensubtitlescom = "subliminal.converters.opensubtitlescom:OpenSubtitlesComConverter"
-shooter = "subliminal.converters.shooter:ShooterConverter"
-thesubdb = "subliminal.converters.thesubdb:TheSubDBConverter"
 tvsubtitles = "subliminal.converters.tvsubtitles:TVsubtitlesConverter"
 
 [tool.setuptools]

--- a/subliminal/core.py
+++ b/subliminal/core.py
@@ -316,7 +316,7 @@ class AsyncProviderPool(ProviderPool):
 
     def list_subtitles(self, video: Video, languages: Set[Language]) -> list[Subtitle]:
         """List subtitles, multi-threaded."""
-        subtitles = []
+        subtitles: list[Subtitle] = []
 
         # Avoid raising a ValueError with `ThreadPoolExecutor(self.max_workers)`
         if self.max_workers == 0:

--- a/subliminal/core.py
+++ b/subliminal/core.py
@@ -15,7 +15,14 @@ from babelfish import Language, LanguageReverseError  # type: ignore[import-unty
 from guessit import guessit  # type: ignore[import-untyped]
 from rarfile import BadRarFile, Error, NotRarFile, RarCannotExec, RarFile, is_rarfile  # type: ignore[import-untyped]
 
-from .extensions import default_providers, provider_manager, refiner_manager
+from .extensions import (
+    default_providers,
+    default_refiners,
+    discarded_episode_refiners,
+    discarded_movie_refiners,
+    provider_manager,
+    refiner_manager,
+)
 from .score import compute_score as default_compute_score
 from .subtitle import SUBTITLE_EXTENSIONS, Subtitle
 from .utils import get_age, handle_exception
@@ -65,7 +72,7 @@ class ProviderPool:
         providers: Sequence[str] | None = None,
         provider_configs: Mapping[str, Any] | None = None,
     ) -> None:
-        self.providers = providers or default_providers
+        self.providers = providers if providers is not None else default_providers
         self.provider_configs = provider_configs or {}
         self.initialized_providers = {}
         self.discarded_providers = set()
@@ -213,6 +220,7 @@ class ProviderPool:
         hearing_impaired: bool = False,
         only_one: bool = False,
         compute_score: ComputeScore | None = None,
+        ignore_subtitles: Sequence[str] | None = None,
     ) -> list[Subtitle]:
         """Download the best matching subtitles.
 
@@ -227,11 +235,16 @@ class ProviderPool:
         :param bool only_one: download only one subtitle, not one per language.
         :param compute_score: function that takes `subtitle` and `video` as positional arguments,
             `hearing_impaired` as keyword argument and returns the score.
+        :param ignore_subtitles: list of subtitle ids to ignore (None defaults to an empty list).
         :return: downloaded subtitles.
         :rtype: list of :class:`~subliminal.subtitle.Subtitle`
 
         """
         compute_score = compute_score or default_compute_score
+        ignore_subtitles = ignore_subtitles or []
+
+        # ignore subtitles
+        subtitles = [s for s in subtitles if s.id not in ignore_subtitles]
 
         # sort subtitles by score
         scored_subtitles = sorted(
@@ -304,6 +317,10 @@ class AsyncProviderPool(ProviderPool):
     def list_subtitles(self, video: Video, languages: Set[Language]) -> list[Subtitle]:
         """List subtitles, multi-threaded."""
         subtitles = []
+
+        # Avoid raising a ValueError with `ThreadPoolExecutor(self.max_workers)`
+        if self.max_workers == 0:
+            return subtitles
 
         with ThreadPoolExecutor(self.max_workers) as executor:
             executor_map = executor.map(
@@ -648,8 +665,7 @@ def scan_videos(
 def refine(
     video: Video,
     *,
-    episode_refiners: Sequence[str] | None = None,
-    movie_refiners: Sequence[str] | None = None,
+    refiners: Sequence[str] | None = None,
     refiner_configs: Mapping[str, Any] | None = None,
     **kwargs: Any,
 ) -> Video:
@@ -661,20 +677,19 @@ def refine(
 
     :param video: the video to refine.
     :type video: :class:`~subliminal.video.Video`
-    :param tuple episode_refiners: refiners to use for episodes.
-    :param tuple movie_refiners: refiners to use for movies.
+    :param Sequence refiners: refiners to select. None defaults to all refiners.
     :param dict refiner_configs: refiner configuration as keyword arguments per refiner name to pass when
         calling the refine method
     :param kwargs: additional parameters for the :func:`~subliminal.refiners.refine` functions.
 
     """
-    refiners: tuple[str, ...] = ()
+    refiners = refiners if refiners is not None else default_refiners
+    if isinstance(video, Movie):
+        refiners = [r for r in refiners if r not in discarded_movie_refiners]
     if isinstance(video, Episode):
-        refiners = tuple(episode_refiners) if episode_refiners is not None else ('metadata', 'tvdb', 'omdb', 'tmdb')
-    elif isinstance(video, Movie):  # pragma: no branch
-        refiners = tuple(movie_refiners) if movie_refiners is not None else ('metadata', 'omdb', 'tmdb')
+        refiners = [r for r in refiners if r not in discarded_episode_refiners]
 
-    for refiner in ('hash', *refiners):
+    for refiner in refiners:
         logger.info('Refining video with %s', refiner)
         try:
             refiner_manager[refiner].plugin(video, **dict((refiner_configs or {}).get(refiner, {}), **kwargs))

--- a/subliminal/extensions.py
+++ b/subliminal/extensions.py
@@ -55,7 +55,7 @@ class RegistrableExtensionManager(ExtensionManager):
         # registered extensions
         for rep in self.registered_extensions:
             ep = parse_entry_point(rep, self.namespace)
-            if ep.name not in [e.name for e in eps]:
+            if ep.name not in [e.name for e in eps]:  # pragma: no branch
                 eps.append(ep)
 
         return eps
@@ -84,7 +84,7 @@ class RegistrableExtensionManager(ExtensionManager):
             verify_requirements=False,
         )
         self.extensions.append(ext)
-        if self._extensions_by_name is not None:
+        if self._extensions_by_name is not None:  # pragma: no branch
             self._extensions_by_name[ext.name] = ext
         self.registered_extensions.insert(0, entry_point)
 
@@ -101,9 +101,9 @@ class RegistrableExtensionManager(ExtensionManager):
 
         ep = parse_entry_point(entry_point, self.namespace)
         self.registered_extensions.remove(entry_point)
-        if self._extensions_by_name is not None:
+        if self._extensions_by_name is not None:  # pragma: no branch
             del self._extensions_by_name[ep.name]
-        for i, ext in enumerate(self.extensions):
+        for i, ext in enumerate(self.extensions):  # pragma: no branch
             if ext.name == ep.name:
                 del self.extensions[i]
                 break
@@ -153,3 +153,15 @@ refiner_manager = RegistrableExtensionManager(
         'tmdb = subliminal.refiners.tmdb:refine',
     ],
 )
+
+#: Disabled refiners
+disabled_refiners: list[str] = []
+
+#: Default enabled refiners
+default_refiners = [r for r in refiner_manager.names() if r not in disabled_refiners]
+
+#: Discarded Movie refiners
+discarded_movie_refiners: list[str] = ['tvdb']
+
+#: Discarded Episode refiners
+discarded_episode_refiners: list[str] = []

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -1,5 +1,4 @@
 # ruff: noqa: PT011, SIM115
-import logging
 import os
 import sys
 from datetime import datetime, timedelta, timezone
@@ -15,7 +14,6 @@ from subliminal.core import (
     download_best_subtitles,
     download_subtitles,
     list_subtitles,
-    refine,
     save_subtitles,
     scan_archive,
     scan_name,
@@ -23,7 +21,7 @@ from subliminal.core import (
     scan_videos,
     search_external_subtitles,
 )
-from subliminal.extensions import provider_manager, refiner_manager
+from subliminal.extensions import provider_manager
 from subliminal.providers.tvsubtitles import TVsubtitlesSubtitle
 from subliminal.score import episode_scores
 from subliminal.subtitle import Subtitle
@@ -53,24 +51,6 @@ def _mock_providers(monkeypatch):
         monkeypatch.setattr(provider.plugin, 'list_subtitles', Mock(return_value=[provider.name]))
         monkeypatch.setattr(provider.plugin, 'download_subtitle', Mock())
         monkeypatch.setattr(provider.plugin, 'terminate', Mock())
-
-
-@pytest.fixture()
-def refiner_mocks(monkeypatch):
-    mocks = {}
-    # monkeypatch refiners
-    for refiner in refiner_manager:
-        mocks[refiner.name] = Mock()
-
-        def mocked_refine(refiner):
-            def func(video, *args, **kwargs):
-                mocks[refiner.name](video)
-                return refiner.plugin(*args, **kwargs)
-
-            return func
-
-        monkeypatch.setattr(refiner, 'plugin', mocked_refine(refiner))
-    return mocks
 
 
 def test_provider_pool_get_keyerror():
@@ -465,38 +445,6 @@ def test_scan_videos_age(movies, tmpdir, monkeypatch):
     kwargs: dict[str, Any] = {'name': None}
     scan_video_calls = [((os.path.join('movies', movies['man_of_steel'].name),), kwargs)]
     mock_scan_video.assert_has_calls(scan_video_calls, any_order=True)  # type: ignore[arg-type]
-
-
-def test_refine_movie(movies, caplog, refiner_mocks):
-    video = movies['man_of_steel']
-
-    with caplog.at_level(logging.INFO):
-        refine(video, movie_refiners=['metadata'], providers=['opensubtitles'])
-
-    # test refiners
-    for name in ('omdb', 'tmdb'):
-        assert f'Refining video with {name}' not in caplog.text
-        refiner_mocks[name].assert_not_called()
-
-    for name in ('hash', 'metadata'):
-        assert f'Refining video with {name}' in caplog.text
-        refiner_mocks[name].assert_called_once_with(video)
-
-
-def test_refine_episode(episodes, caplog, refiner_mocks):
-    video = episodes['bbt_s07e05']
-
-    with caplog.at_level(logging.INFO):
-        refine(video, episode_refiners=['omdb', 'tvdb'], providers=['opensubtitles'])
-
-    # test refiners
-    for name in ('metadata', 'tmdb'):
-        assert f'Refining video with {name}' not in caplog.text
-        refiner_mocks[name].assert_not_called()
-
-    for name in ('hash', 'omdb', 'tvdb'):
-        assert f'Refining video with {name}' in caplog.text
-        refiner_mocks[name].assert_called_once_with(video)
 
 
 @pytest.mark.usefixtures('_mock_providers')

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -6,13 +6,33 @@ if version_info >= (3, 10):
 else:
     from importlib_metadata import entry_points  # type: ignore[assignment,no-redef,import-not-found]
 
+import pytest
 from subliminal.extensions import (
+    EntryPoint,
     RegistrableExtensionManager,
     default_providers,
+    default_refiners,
     disabled_providers,
+    disabled_refiners,
     parse_entry_point,
     provider_manager,
+    refiner_manager,
 )
+
+
+def test_parse_entry_point() -> None:
+    src = 'addic7ed = subliminal.providers.addic7ed:Addic7edProvider'
+    ep = parse_entry_point(src, group='subliminal.providers')
+    assert isinstance(ep, EntryPoint)
+    assert ep.name == 'addic7ed'
+    assert ep.value == 'subliminal.providers.addic7ed:Addic7edProvider'
+    assert ep.group == 'subliminal.providers'
+
+
+def test_parse_entry_point_wrong() -> None:
+    src = 'subliminal.providers.addic7ed:Addic7edProvider'
+    with pytest.raises(ValueError, match='EntryPoint must be'):
+        parse_entry_point(src, group='subliminal.providers')
 
 
 def test_registrable_extension_manager_all_extensions():
@@ -53,6 +73,18 @@ def test_registrable_extension_manager_register():
     assert len(list(manager)) == 3
     assert 'de7cidda' in manager.names()
 
+    eps = manager.list_entry_points()
+    ep_names = [ep.name for ep in eps]
+    assert ep_names == ['addic7ed', 'opensubtitles', 'de7cidda']
+
+    # Raise ValueError on same entry point
+    with pytest.raises(ValueError, match='Extension already registered'):
+        manager.register('de7cidda = subliminal.providers.addic7ed:Addic7edProvider')
+
+    # Raise ValueError on same entry point name
+    with pytest.raises(ValueError, match='An extension with the same name already exist'):
+        manager.register('de7cidda = subliminal.providers.opensubtitles:OpenSubtitlesProvider')
+
 
 def test_registrable_extension_manager_unregister():
     manager = RegistrableExtensionManager(
@@ -68,6 +100,10 @@ def test_registrable_extension_manager_unregister():
     assert len(list(manager)) == 2
     assert set(manager.names()) == {'gestdown', 'tvsubtitles'}
 
+    # Raise ValueError on entry point not found
+    with pytest.raises(ValueError, match='Extension not registered'):
+        manager.unregister('seltitbusnepo = subliminal.providers.opensubtitles:OpenSubtitlesProvider')
+
 
 def test_provider_manager():
     setup_names = {ep.name for ep in entry_points(group=provider_manager.namespace)}
@@ -76,5 +112,16 @@ def test_provider_manager():
     }
     enabled_names = set(default_providers)
     disabled_names = set(disabled_providers)
+    assert enabled_names == setup_names - disabled_names
+    assert internal_names == enabled_names | disabled_names
+
+
+def test_refiner_manager():
+    setup_names = {ep.name for ep in entry_points(group=refiner_manager.namespace)}
+    internal_names = {
+        parse_entry_point(iep, refiner_manager.namespace).name for iep in refiner_manager.internal_extensions
+    }
+    enabled_names = set(default_refiners)
+    disabled_names = set(disabled_refiners)
     assert enabled_names == setup_names - disabled_names
     assert internal_names == enabled_names | disabled_names

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -90,7 +90,7 @@ def test_handle_exception(caplog: pytest.LogCaptureFixture, err: Exception, msg:
 
 
 def test_ensure_list() -> None:
-    ret = ensure_list(None)
+    ret: list = ensure_list(None)
     assert isinstance(ret, list)
     assert ret == []
 
@@ -102,7 +102,7 @@ def test_ensure_list() -> None:
     assert isinstance(ret, list)
     assert set(ret) == {'a', 'b'}
 
-    ret = ensure_list({'a', 'b'})
+    ret = ensure_list({'a', 'b'})  # type: ignore[arg-type]
     assert isinstance(ret, list)
     assert set(ret) == {'a', 'b'}
 
@@ -180,5 +180,5 @@ def test_merge_extend_and_ignore_unions(
     defaults: list[str],
     expected: set[str],
 ) -> None:
-    final = set(merge_extend_and_ignore_unions(lists, default_lists, defaults))
+    final = set(merge_extend_and_ignore_unions(lists, default_lists, defaults))  # type: ignore[arg-type]
     assert final == expected


### PR DESCRIPTION
fixes #585, #752, #1018

This PR adds some CLI options:

* `--ignore-refiner`: can be repeated, refiner to ignore.
* `--ignore-provider`: can be repeated, provider to ignore.
* `--extend-refiner`: can be repeated, refiner to extend to the list of refiners to use.
* `--extend-provider`: can be repeated, provider to extend to the list of providers to use.
* `--ignore-subtitles`: can be repeated, subtitle id to ignore.

These can also be defined in the configuration file, so it's important to make sure the CLI options always takes precedence over the config file. This logic is implemented (and tested) in `merge_extend_and_ignore_unions`.

(I followed the naming of `ruff`, select-extend-ignore :))
