### PR TITLE
Add a `-n/--name` option to use a replacement name for the video

### DIFF
--- a/changelog.d/1132.change.rst
+++ b/changelog.d/1132.change.rst
@@ -1,0 +1,2 @@
+Add a `-n/--name` option to use a replacement name for the video.
+Sort files alphabetically before scanning a directory.

--- a/changelog.d/991.change.rst
+++ b/changelog.d/991.change.rst
@@ -1,0 +1,2 @@
+Add a `-n/--name` option to use a replacement name for the video.
+Sort files alphabetically before scanning a directory.

--- a/subliminal/core.py
+++ b/subliminal/core.py
@@ -553,7 +553,7 @@ def scan_videos(path: str | os.PathLike, *, age: timedelta | None = None, archiv
                 dirnames.remove(dirname)
 
         # scan for videos
-        for filename in filenames:
+        for filename in sorted(filenames):
             # filter on videos and archives
             if not filename.lower().endswith(VIDEO_EXTENSIONS) and not (
                 archives and filename.lower().endswith(ARCHIVE_EXTENSIONS)


### PR DESCRIPTION
fixes #991, #1132

Also sort files alphabetically before scanning a directory.