### PR TITLE
Remove requirement for episode number when guessing

### DIFF
--- a/changelog.d/+4eebcb09.change.rst
+++ b/changelog.d/+4eebcb09.change.rst
@@ -1,0 +1,1 @@
+Remove requirement for episode number when guessing

--- a/subliminal/video.py
+++ b/subliminal/video.py
@@ -371,7 +371,7 @@ class Episode(Video):
             msg = 'The guess must be an episode guess'
             raise ValueError(msg)
 
-        if 'title' not in guess or 'episode' not in guess:
+        if 'title' not in guess:
             msg = 'Insufficient data to process the guess'
             raise ValueError(msg)
 


### PR DESCRIPTION
with some types of episodes, such as extras, the episode number will be missing, but the subtitle download succeeds with the check removed