### PR TITLE
Update pre commit versions

### DIFF
--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
-      - uses: pre-commit/action@v3.8.0
+      - uses: pre-commit/action@v3.0.1
 
   typing:
     if: github.event_name != 'schedule'

--- a/.github/workflows/check.yaml
+++ b/.github/workflows/check.yaml
@@ -25,7 +25,7 @@ jobs:
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
-      - uses: pre-commit/action@v3.0.1
+      - uses: pre-commit/action@v3.8.0
 
   typing:
     if: github.event_name != 'schedule'

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,43 +1,43 @@
 repos:
--   repo: https://github.com/pre-commit/pre-commit-hooks
+  - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.6.0
     hooks:
-    -   id: check-toml
-    -   id: check-yaml
+      - id: check-toml
+      - id: check-yaml
         exclude: ^tests/cassettes/
-    -   id: end-of-file-fixer
+      - id: end-of-file-fixer
 
--   repo: https://github.com/crate-ci/typos
+  - repo: https://github.com/crate-ci/typos
     rev: v1.24.5
     hooks:
-    -   id: typos
+      - id: typos
 
--   repo: https://github.com/astral-sh/ruff-pre-commit
+  - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.6.4
     hooks:
-    -   id: ruff
+      - id: ruff
         args: [--fix, --unsafe-fixes]
-    -   id: ruff-format
+      - id: ruff-format
 
--   repo: https://github.com/abravalheri/validate-pyproject
+  - repo: https://github.com/abravalheri/validate-pyproject
     rev: v0.19
     hooks:
-    -   id: validate-pyproject
+      - id: validate-pyproject
         name: validate-pyproject
 
--   repo: https://github.com/PyCQA/doc8
+  - repo: https://github.com/PyCQA/doc8
     rev: v1.1.2
     hooks:
-    -   id: doc8
+      - id: doc8
         description: This hook runs doc8 for linting docs
         require_serial: true
 
--   repo: local
+  - repo: local
     hooks:
-    -   id: changelog-fragment-filenames
+      - id: changelog-fragment-filenames
         name: changelog fragment
         language: fail
         entry: changelog fragment files must be named *.(breaking|change|provider|refiner|deprecation|doc|misc).rst
-        exclude: 
+        exclude:
           ^changelog.d/(\..*|towncrier_template.rst|.*\.(breaking|change|provider|refiner|deprecation|doc|misc).rst)
         files: ^changelog.d/

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,42 +1,43 @@
 repos:
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.5.0
+-   repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
     hooks:
-      - id: check-toml
-      - id: check-yaml
+    -   id: check-toml
+    -   id: check-yaml
         exclude: ^tests/cassettes/
-      - id: end-of-file-fixer
+    -   id: end-of-file-fixer
 
-  - repo: https://github.com/crate-ci/typos
-    rev: v1.22.0
+-   repo: https://github.com/crate-ci/typos
+    rev: v1.24.5
     hooks:
-      - id: typos
+    -   id: typos
 
-  - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.4.7
+-   repo: https://github.com/astral-sh/ruff-pre-commit
+    rev: v0.6.4
     hooks:
-      - id: ruff
-        args: [ --fix, --unsafe-fixes ]
-      - id: ruff-format
+    -   id: ruff
+        args: [--fix, --unsafe-fixes]
+    -   id: ruff-format
 
-  - repo: https://github.com/abravalheri/validate-pyproject
-    rev: v0.18
+-   repo: https://github.com/abravalheri/validate-pyproject
+    rev: v0.19
     hooks:
-      - id: validate-pyproject
+    -   id: validate-pyproject
         name: validate-pyproject
 
-  - repo: https://github.com/PyCQA/doc8
-    rev: v1.1.1
+-   repo: https://github.com/PyCQA/doc8
+    rev: v1.1.2
     hooks:
-      - id: doc8
+    -   id: doc8
         description: This hook runs doc8 for linting docs
         require_serial: true
 
-  - repo: local
+-   repo: local
     hooks:
-    - id: changelog-fragment-filenames
-      name: changelog fragment
-      language: fail
-      entry: changelog fragment files must be named *.(breaking|change|provider|refiner|deprecation|doc|misc).rst
-      exclude: ^changelog.d/(\..*|towncrier_template.rst|.*\.(breaking|change|provider|refiner|deprecation|doc|misc).rst)
-      files: ^changelog.d/
+    -   id: changelog-fragment-filenames
+        name: changelog fragment
+        language: fail
+        entry: changelog fragment files must be named *.(breaking|change|provider|refiner|deprecation|doc|misc).rst
+        exclude: 
+          ^changelog.d/(\..*|towncrier_template.rst|.*\.(breaking|change|provider|refiner|deprecation|doc|misc).rst)
+        files: ^changelog.d/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -207,6 +207,9 @@ ignore = [
     "D401",   # First line should be in imperative mood
 ]
 
+[tool.ruff.lint.flake8-pytest-style]
+mark-parentheses = true
+
 [tool.ruff.lint.per-file-ignores]
 "docs/conf*.py" = ["ALL"]
 "subliminal/__init__.py" = ["E402"]


### PR DESCRIPTION
Maybe it will fix the failing CI `docs`.

ruff modified its rules with `pytest.fixtures`, added a `tool.ruff.lint.flake8-pytest-style.mark-parentheses = true` parameter in `pyproject.toml` to not change too many files in this PR. This parameter can be switched back to its default value in another PR.