### PR TITLE
Add Provider.hash_video staticmethod

### DIFF
--- a/changelog.d/1172.change.rst
+++ b/changelog.d/1172.change.rst
@@ -1,0 +1,1 @@
+Add Provider.hash_video staticmethod, to allow creating standalone providers.

--- a/subliminal/providers/__init__.py
+++ b/subliminal/providers/__init__.py
@@ -24,6 +24,7 @@ from subliminal.subtitle import Subtitle
 from subliminal.video import Episode, Movie, Video
 
 if TYPE_CHECKING:
+    import os
     from collections.abc import Sequence, Set
     from http.client import HTTPSConnection
     from types import TracebackType
@@ -135,6 +136,11 @@ class Provider(Generic[S]):
 
     #: User Agent to use
     user_agent: str = f'Subliminal/{__short_version__}'
+
+    @staticmethod
+    def hash_video(video_path: str | os.PathLike) -> str | None:
+        """Hash the video to be used by the provider."""
+        return None
 
     def __enter__(self) -> Self:
         self.initialize()

--- a/subliminal/providers/napiprojekt.py
+++ b/subliminal/providers/napiprojekt.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import io
 import logging
 from gzip import BadGzipFile, GzipFile
@@ -16,6 +17,7 @@ from subliminal.subtitle import Subtitle, fix_line_ending
 from . import Provider
 
 if TYPE_CHECKING:
+    import os
     from collections.abc import Set
 
     from subliminal.video import Video
@@ -95,6 +97,20 @@ class NapiProjektProvider(Provider):
     def __init__(self, *, timeout: int = 10) -> None:
         self.timeout = timeout
         self.session = None
+
+    @staticmethod
+    def hash_video(video_path: str | os.PathLike) -> str | None:
+        """Compute a hash using NapiProjekt's algorithm.
+
+        :param str video_path: path of the video.
+        :return: the hash.
+        :rtype: str
+
+        """
+        readsize = 1024 * 1024 * 10
+        with open(video_path, 'rb') as f:
+            data = f.read(readsize)
+        return hashlib.md5(data).hexdigest()  # noqa: S324
 
     def initialize(self) -> None:
         """Initialize the provider."""

--- a/tests/providers/test_bsplayer.py
+++ b/tests/providers/test_bsplayer.py
@@ -16,6 +16,15 @@ vcr = VCR(
 SEARCH_URL = 'http://s1.api.bsplayer-subtitles.com/v1.php'
 
 
+def test_hash_bsplayer(mkv):
+    assert BSPlayerProvider.hash_video(mkv['test1']) == '40b44a7096b71ec3'
+
+
+def test_hash_bsplayer_too_small(tmpdir):
+    path = tmpdir.ensure('test_too_small.mkv')
+    assert BSPlayerProvider.hash_video(str(path)) is None
+
+
 def test_get_matches_movie_hash(episodes):
     subtitle = BSPlayerSubtitle(
         subtitle_id='16442520',

--- a/tests/providers/test_napiprojekt.py
+++ b/tests/providers/test_napiprojekt.py
@@ -13,6 +13,10 @@ vcr = VCR(
 )
 
 
+def test_hash_napiprojekt(mkv):
+    assert NapiProjektProvider.hash_video(mkv['test1']) == '9884a2b66dcb2965d0f45ce84e37b60c'
+
+
 def test_get_matches(movies):
     subtitle = NapiProjektSubtitle(Language('pol'), '6303e7ee6a835e9fcede9fb2fb00cb36')
     matches = subtitle.get_matches(movies['man_of_steel'])

--- a/tests/refiners/test_hash.py
+++ b/tests/refiners/test_hash.py
@@ -1,13 +1,4 @@
-from subliminal.refiners.hash import hash_bsplayer, hash_opensubtitles, hash_thesubdb
-
-
-def test_hash_bsplayer(mkv):
-    assert hash_bsplayer(mkv['test1']) == '40b44a7096b71ec3'
-
-
-def test_hash_bsplayer_too_small(tmpdir):
-    path = tmpdir.ensure('test_too_small.mkv')
-    assert hash_bsplayer(str(path)) is None
+from subliminal.refiners.hash import hash_opensubtitles
 
 
 def test_hash_opensubtitles(mkv):
@@ -17,12 +8,3 @@ def test_hash_opensubtitles(mkv):
 def test_hash_opensubtitles_too_small(tmpdir):
     path = tmpdir.ensure('test_too_small.mkv')
     assert hash_opensubtitles(str(path)) is None
-
-
-def test_hash_thesubdb(mkv):
-    assert hash_thesubdb(mkv['test1']) == '054e667e93e254f8fa9f9e8e6d4e73ff'
-
-
-def test_hash_thesubdb_too_small(tmpdir):
-    path = tmpdir.ensure('test_too_small.mkv')
-    assert hash_thesubdb(str(path)) is None


### PR DESCRIPTION
To allow creating standalone providers.

The idea is to keep the providers (except from some core/historical providers) outside of the main `subliminal` repo to ease maintenance.