### PR TITLE
Preference or avoidance per language type (hearing impaired, foreign only)

### DIFF
--- a/changelog.d/1175.change.rst
+++ b/changelog.d/1175.change.rst
@@ -1,0 +1,1 @@
+Add cli option to prefer or avoid hearing impaired or foreign only subtitles.

--- a/changelog.d/1175.change.rst
+++ b/changelog.d/1175.change.rst
@@ -1,1 +1,1 @@
-Add cli option to prefer or avoid hearing impaired or foreign only subtitles.
+Add cli option to prefer or disfavor hearing impaired (-hi/-HI) or foreign only (-fo/-FO) subtitles.

--- a/docs/config.toml
+++ b/docs/config.toml
@@ -22,6 +22,7 @@ provider = ["addic7ed", "opensubtitlescom", "opensubtitles"]
 refiner = ["metadata", "hash", "omdb"]
 ignore_refiner = ["tmdb"]
 language = ["fr", "en", "pt-br"]
+foreign_only = false
 encoding = "utf-8"
 min_score = 50
 archives = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -321,6 +321,8 @@ extend-ignore-re = [
     "(?Rm)^.*#\\s*spellchecker:\\s*disable-line$",
     "#\\s*spellchecker:off\\s*\\n.*\\n\\s*#\\s*spellchecker:on"
 ]
+[tool.typos.default.extend-words]
+fo = "fo"
 [tool.typos.default.extend-identifiers]
 tha = "tha"
 bre = "bre"

--- a/subliminal/cli.py
+++ b/subliminal/cli.py
@@ -191,11 +191,11 @@ providers_config = OptionGroup('Providers configuration')
 refiners_config = OptionGroup('Refiners configuration')
 hearing_impaired_group = MutuallyExclusiveOptionGroup(
     'Hearing impaired subtitles',
-    help='Require or avoid hearing impaired subtitles. Set to empty if no preference (default).',
+    help='Require or avoid hearing impaired subtitles. If no preference (default), do not use any flag.',
 )
 foreign_only_group = MutuallyExclusiveOptionGroup(
     'Foreign only subtitles',
-    help='Require or avoid foreign-only/forced subtitles. Set to empty if no preference (default).',
+    help='Require or avoid foreign-only/forced subtitles.  If no preference (default), do not use any flag.',
 )
 
 

--- a/subliminal/cli.py
+++ b/subliminal/cli.py
@@ -423,12 +423,6 @@ def cache(ctx: click.Context, clear_subliminal: bool) -> None:
 @foreign_only_group.option('-fo', '--foreign-only', is_flag=True, default=False)
 @foreign_only_group.option('-FO', '--no-foreign-only', is_flag=True, default=False)
 @click.option(
-    '--forced',
-    is_flag=True,
-    default=False,
-    help='Require or avoid forced/foreign-only subtitles. Set to empty if no preference (default).',
-)
-@click.option(
     '-m',
     '--min-score',
     type=click.IntRange(0, 100),

--- a/subliminal/core.py
+++ b/subliminal/core.py
@@ -148,7 +148,7 @@ class ProviderPool:
         try:
             return self[provider].list_subtitles(video, provider_languages)
         except Exception as e:  # noqa: BLE001
-            handle_exception(e, 'Provider {provider}')
+            handle_exception(e, f'Provider {provider}')
 
         return []
 
@@ -251,10 +251,14 @@ class ProviderPool:
         # ignore subtitles
         subtitles = [s for s in subtitles if s.id not in ignore_subtitles]
 
-        # filter by hearing impaired and foreign only
+        # sort by hearing impaired and foreign only
         language_type = LanguageType.from_flags(hearing_impaired=hearing_impaired, foreign_only=foreign_only)
         if language_type != LanguageType.UNKNOWN:
-            subtitles = [s for s in subtitles if s.language_type == language_type]
+            subtitles = sorted(
+                subtitles,
+                key=lambda s: s.language_type == language_type,
+                reverse=True,
+            )
 
         # sort subtitles by score
         scored_subtitles = sorted(

--- a/subliminal/core.py
+++ b/subliminal/core.py
@@ -254,6 +254,7 @@ class ProviderPool:
         # sort by hearing impaired and foreign only
         language_type = LanguageType.from_flags(hearing_impaired=hearing_impaired, foreign_only=foreign_only)
         if language_type != LanguageType.UNKNOWN:
+            logger.info('Sort subtitles by %s types first', language_type.value)
             subtitles = sorted(
                 subtitles,
                 key=lambda s: s.language_type == language_type,

--- a/subliminal/core.py
+++ b/subliminal/core.py
@@ -252,9 +252,9 @@ class ProviderPool:
         subtitles = [s for s in subtitles if s.id not in ignore_subtitles]
 
         # filter by hearing impaired and foreign only
-        lt = LanguageType.from_flags(hearing_impaired=hearing_impaired, forced=foreign_only)
-        if lt != LanguageType.UNKNOWN:
-            subtitles = [s for s in subtitles if s.language_type == lt]
+        language_type = LanguageType.from_flags(hearing_impaired=hearing_impaired, foreign_only=foreign_only)
+        if language_type != LanguageType.UNKNOWN:
+            subtitles = [s for s in subtitles if s.language_type == language_type]
 
         # sort subtitles by score
         scored_subtitles = sorted(
@@ -418,7 +418,7 @@ def parse_subtitle_filename(subtitle_filename: str, video_filename: str) -> Subt
         except (ValueError, LanguageReverseError):
             logger.exception('Cannot parse language code %r', language_code)
 
-    # TODO: extract the hearing_impaired or forced attribute
+    # TODO: extract the hearing_impaired or foreign_only attribute
 
     return Subtitle(language, subtitle_id=subtitle_filename)
 
@@ -871,7 +871,7 @@ def save_subtitles(
     :param str directory: path to directory where to save the subtitles, default is next to the video.
     :param str encoding: encoding in which to save the subtitles, default is to keep original encoding.
     :param (str | None) extension: the subtitle extension, default is to match to the subtitle format.
-    :param bool language_type_suffix: add a suffix 'hi' or 'forced' if needed. Default to False.
+    :param bool language_type_suffix: add a suffix 'hi' or 'fo' if needed. Default to False.
     :param str language_format: format of the language suffix. Default to 'alpha2'.
     :return: the saved subtitles
     :rtype: list of :class:`~subliminal.subtitle.Subtitle`

--- a/subliminal/providers/opensubtitlescom.py
+++ b/subliminal/providers/opensubtitlescom.py
@@ -179,6 +179,7 @@ class OpenSubtitlesComSubtitle(Subtitle):
         subtitle_id: str,
         *,
         hearing_impaired: bool = False,
+        foreign_only: bool = False,
         movie_kind: str | None = None,
         release: str | None = None,
         movie_title: str | None = None,
@@ -199,7 +200,14 @@ class OpenSubtitlesComSubtitle(Subtitle):
         file_id: int = 0,
         file_name: str = '',
     ) -> None:
-        super().__init__(language, subtitle_id, hearing_impaired=hearing_impaired, page_link=None, encoding='utf-8')
+        super().__init__(
+            language,
+            subtitle_id,
+            hearing_impaired=hearing_impaired,
+            foreign_only=foreign_only,
+            page_link=None,
+            encoding='utf-8',
+        )
         self.movie_kind = movie_kind
         self.release = release
         self.movie_title = movie_title
@@ -235,6 +243,7 @@ class OpenSubtitlesComSubtitle(Subtitle):
         attributes = response.get('attributes', {})
         language = Language.fromopensubtitlescom(str(attributes.get('language')))
         hearing_impaired = bool(int(attributes.get('hearing_impaired')))
+        foreign_only = bool(int(attributes.get('foreign_parts_only')))
         release = str(attributes.get('release'))
         moviehash_match = bool(attributes.get('moviehash_match', False))
         download_count = int(attributes.get('download_count'))
@@ -266,6 +275,7 @@ class OpenSubtitlesComSubtitle(Subtitle):
             language,
             subtitle_id,
             hearing_impaired=hearing_impaired,
+            foreign_only=foreign_only,
             movie_kind=movie_kind,
             release=release,
             movie_title=movie_title,

--- a/subliminal/score.py
+++ b/subliminal/score.py
@@ -49,7 +49,7 @@ if TYPE_CHECKING:
     class ComputeScore(Protocol):
         """Compute the score of a subtitle matching a video."""
 
-        def __call__(self, subtitle: Subtitle, video: Video, *, hearing_impaired: bool | None) -> int: ...  # noqa: D102
+        def __call__(self, subtitle: Subtitle, video: Video) -> int: ...  # noqa: D102
 
 
 # Check if sympy is installed (for tests)
@@ -141,8 +141,8 @@ def match_hearing_impaired(subtitle: Subtitle, *, hearing_impaired: bool | None 
     )
 
 
-def compute_score(subtitle: Subtitle, video: Video, *, hearing_impaired: bool | None = None) -> int:
-    """Compute the score of the `subtitle` against the `video` with `hearing_impaired` preference.
+def compute_score(subtitle: Subtitle, video: Video) -> int:
+    """Compute the score of the `subtitle` against the `video`.
 
     :func:`compute_score` uses the :meth:`Subtitle.get_matches <subliminal.subtitle.Subtitle.get_matches>` method and
     applies the scores (either from :data:`episode_scores` or :data:`movie_scores`) after some processing.
@@ -151,12 +151,11 @@ def compute_score(subtitle: Subtitle, video: Video, *, hearing_impaired: bool | 
     :type subtitle: :class:`~subliminal.subtitle.Subtitle`
     :param video: the video to compute the score against.
     :type video: :class:`~subliminal.video.Video`
-    :param (bool | None) hearing_impaired: hearing impaired preference (None if no preference).
     :return: score of the subtitle.
     :rtype: int
 
     """
-    logger.info('Computing score of %r for video %r with %r', subtitle, video, {'hearing_impaired': hearing_impaired})
+    logger.info('Computing score of %r for video %r', subtitle, video)
 
     # get the scores dict
     scores = get_scores(video)
@@ -193,17 +192,12 @@ def compute_score(subtitle: Subtitle, video: Video, *, hearing_impaired: bool | 
             logger.debug('Adding imdb_id match equivalents')
             matches |= {'title', 'year', 'country'}
 
-    # handle hearing impaired
-    if match_hearing_impaired(subtitle, hearing_impaired=hearing_impaired):
-        logger.debug('Matched hearing_impaired')
-        matches.add('hearing_impaired')
-
     # compute the score
     score = int(sum(scores.get(match, 0) for match in matches))
     logger.info('Computed score %r with final matches %r', score, matches)
 
     # ensure score is within valid bounds
-    max_score = scores['hash'] + scores['hearing_impaired']
+    max_score = scores['hash']
     if not (0 <= score <= max_score):  # pragma: no cover
         logger.info('Clip score between 0 and %d: %d', max_score, score)
         score = int(clip(score, 0, max_score))

--- a/subliminal/score.py
+++ b/subliminal/score.py
@@ -141,7 +141,7 @@ def match_hearing_impaired(subtitle: Subtitle, *, hearing_impaired: bool | None 
     )
 
 
-def compute_score(subtitle: Subtitle, video: Video) -> int:
+def compute_score(subtitle: Subtitle, video: Video, **kwargs: Any) -> int:
     """Compute the score of the `subtitle` against the `video`.
 
     :func:`compute_score` uses the :meth:`Subtitle.get_matches <subliminal.subtitle.Subtitle.get_matches>` method and

--- a/tests/test_score.py
+++ b/tests/test_score.py
@@ -141,6 +141,4 @@ def test_compute_score_hash_hearing_impaired(movies):
         filename='',
         encoding='utf-8',
     )
-    assert compute_score(subtitle, video, hearing_impaired=True) == (
-        movie_scores['hash'] + movie_scores['hearing_impaired']
-    )
+    assert compute_score(subtitle, video, hearing_impaired=True) == movie_scores['hash']

--- a/tests/test_subtitle.py
+++ b/tests/test_subtitle.py
@@ -18,26 +18,26 @@ pytestmark = pytest.mark.core
 
 
 @pytest.mark.parametrize('hearing_impaired', [None, True, False])
-@pytest.mark.parametrize('forced', [None, True, False])
-def test_languague_type(hearing_impaired: bool | None, forced: bool | None) -> None:
-    language_type = LanguageType.from_flags(hearing_impaired=hearing_impaired, forced=forced)
+@pytest.mark.parametrize('foreign_only', [None, True, False])
+def test_languague_type(hearing_impaired: bool | None, foreign_only: bool | None) -> None:
+    language_type = LanguageType.from_flags(hearing_impaired=hearing_impaired, foreign_only=foreign_only)
 
     if hearing_impaired is True:
         assert language_type == LanguageType.HEARING_IMPAIRED
         assert language_type.is_hearing_impaired() is True
-        assert language_type.is_forced() is False
-    elif forced is True:
-        assert language_type == LanguageType.FORCED
+        assert language_type.is_foreign_only() is False
+    elif foreign_only is True:
+        assert language_type == LanguageType.FOREIGN_ONLY
         assert language_type.is_hearing_impaired() is False
-        assert language_type.is_forced() is True
-    elif hearing_impaired is False or forced is False:
+        assert language_type.is_foreign_only() is True
+    elif hearing_impaired is False or foreign_only is False:
         assert language_type == LanguageType.NORMAL
         assert language_type.is_hearing_impaired() is False
-        assert language_type.is_forced() is False
+        assert language_type.is_foreign_only() is False
     else:
         assert language_type == LanguageType.UNKNOWN
         assert language_type.is_hearing_impaired() is None
-        assert language_type.is_forced() is None
+        assert language_type.is_foreign_only() is None
 
 
 def test_subtitle_text() -> None:
@@ -175,14 +175,14 @@ def test_get_subtitle_path_hearing_impaired(movies):
     assert get_subtitle_path(video.name, suffix) == os.path.splitext(video.name)[0] + '.hi.de-CH-Latn.srt'
 
 
-def test_get_subtitle_path_forced(movies):
+def test_get_subtitle_path_foreign_only(movies):
     video = movies['man_of_steel']
     suffix = get_subtitle_suffix(
         Language('srp', None, 'Cyrl'),
-        language_type=LanguageType.FORCED,
+        language_type=LanguageType.FOREIGN_ONLY,
         language_type_suffix=True,
     )
-    assert get_subtitle_path(video.name, suffix) == os.path.splitext(video.name)[0] + '.forced.sr-Cyrl.srt'
+    assert get_subtitle_path(video.name, suffix) == os.path.splitext(video.name)[0] + '.fo.sr-Cyrl.srt'
 
 
 def test_get_subtitle_path_alpha3(movies):
@@ -243,12 +243,12 @@ def test_subtitle_invalid_encoding():
 def test_subtitle_guess_encoding_utf8():
     subtitle = Subtitle(
         language=Language('zho'),
-        forced=False,
+        foreign_only=False,
         page_link=None,
         encoding=None,
     )
     subtitle.content = b'Something here'
-    assert subtitle.forced is False
+    assert subtitle.foreign_only is False
     assert subtitle.guess_encoding() == 'utf-8'
     assert subtitle.text == 'Something here'
 
@@ -285,7 +285,7 @@ def test_subtitle_info(monkeypatch) -> None:
     subtitle = Subtitle(
         Language('eng'),
         'xv34e',
-        forced=True,
+        foreign_only=True,
     )
     text = '1\n00:00:20,000 --> 00:00:24,400\nIn response to your honored\n\n'
     monkeypatch.setattr(Subtitle, 'text', text)
@@ -306,10 +306,10 @@ def test_embedded_subtitle_info_hearing_impaired(monkeypatch) -> None:
     assert isinstance(subtitle.info, str)
 
 
-def test_embedded_subtitle_info_forced(monkeypatch) -> None:
+def test_embedded_subtitle_info_foreign_only(monkeypatch) -> None:
     subtitle = EmbeddedSubtitle(
         Language('fra'),
-        forced=True,
+        foreign_only=True,
     )
     text = '1\n00:00:20,000 --> 00:00:24,400\nEn réponse à votre honorée du tant\n\n'
     monkeypatch.setattr(Subtitle, 'text', text)


### PR DESCRIPTION
closes #535
partly solves #925

Currently, we can only choose to prefer hearing impaired subtitles (among subtitles with the same highest score) with the "-hi" option. This PR adds the following:
 - Add cli option "-HI" to prefer non-hearing-impaired subtitles, negation of existing "-hi".
 - Add cli options "-fo" and "-FO" to prefer (or disfavor, respectively) foreign-only/forced subtitles.

 "-hi" takes precedence over "-fo" and "-FO" (it cannot be used with "-HI").
 "-fo" takes precedence over "-HI" (it cannot be used with "-FO").
 Using "-HI" and "-FO" together is redundant and equivalent of using just one of the options.

However, not all providers are reporting foreign_only tags for subtitles (added opensubtitles.com support in this PR).

Other:
 - Rename "forced" to "foreign_only" from #1148
