### PR TITLE
Fix disabled providers

### DIFF
--- a/changelog.d/1181.change.rst
+++ b/changelog.d/1181.change.rst
@@ -1,0 +1,3 @@
+Remove addic7ed and napiprojekt from the list of disabled providers.
+Remove the default_providers and default_refiners variables,
+instead the get_default_providers() and get_default_refiners() functions can be used.

--- a/subliminal/cli.py
+++ b/subliminal/cli.py
@@ -39,7 +39,7 @@ from subliminal import (
     scan_videos,
 )
 from subliminal.core import ARCHIVE_EXTENSIONS, scan_name, search_external_subtitles
-from subliminal.extensions import default_providers, default_refiners
+from subliminal.extensions import get_default_providers, get_default_refiners
 from subliminal.score import match_hearing_impaired
 from subliminal.utils import merge_extend_and_ignore_unions
 
@@ -508,7 +508,7 @@ def download(
             'ignore': ignore_provider,
         },
         obj['provider_lists'],
-        default_providers,
+        get_default_providers(),
     )
     logger.info('Use providers: %s', use_providers)
     use_refiners = merge_extend_and_ignore_unions(
@@ -518,7 +518,7 @@ def download(
             'ignore': ignore_refiner,
         },
         obj['refiner_lists'],
-        default_refiners,
+        get_default_refiners(),
     )
     logger.info('Use refiners: %s', use_refiners)
 

--- a/subliminal/core.py
+++ b/subliminal/core.py
@@ -16,10 +16,10 @@ from guessit import guessit  # type: ignore[import-untyped]
 from rarfile import BadRarFile, Error, NotRarFile, RarCannotExec, RarFile, is_rarfile  # type: ignore[import-untyped]
 
 from .extensions import (
-    default_providers,
-    default_refiners,
     discarded_episode_refiners,
     discarded_movie_refiners,
+    get_default_providers,
+    get_default_refiners,
     provider_manager,
     refiner_manager,
 )
@@ -75,7 +75,7 @@ class ProviderPool:
         providers: Sequence[str] | None = None,
         provider_configs: Mapping[str, Any] | None = None,
     ) -> None:
-        self.providers = providers if providers is not None else default_providers
+        self.providers = providers if providers is not None else get_default_providers()
         self.provider_configs = provider_configs or {}
         self.initialized_providers = {}
         self.discarded_providers = set()
@@ -687,7 +687,7 @@ def refine(
     :param kwargs: additional parameters for the :func:`~subliminal.refiners.refine` functions.
 
     """
-    refiners = refiners if refiners is not None else default_refiners
+    refiners = refiners if refiners is not None else get_default_refiners()
     if isinstance(video, Movie):
         refiners = [r for r in refiners if r not in discarded_movie_refiners]
     if isinstance(video, Episode):

--- a/subliminal/extensions.py
+++ b/subliminal/extensions.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import re
 from importlib.metadata import EntryPoint
 from typing import TYPE_CHECKING, Any
@@ -138,10 +139,15 @@ provider_manager = RegistrableExtensionManager(
 )
 
 #: Disabled providers
-disabled_providers = ['addic7ed', 'napiprojekt', 'opensubtitlesvip', 'opensubtitlescomvip']
+disabled_providers = ['opensubtitlesvip', 'opensubtitlescomvip']
+if 'SUBLIMINAL_DISABLED_PROVIDERS' in os.environ:
+    disabled_providers = os.environ['SUBLIMINAL_DISABLED_PROVIDERS'].split(' ')
 
-#: Default enabled providers
-default_providers = [p for p in provider_manager.names() if p not in disabled_providers]
+
+def get_default_providers() -> list[str]:
+    """Return the default enabled providers."""
+    return [p for p in provider_manager.names() if p not in disabled_providers]
+
 
 #: Refiner manager
 refiner_manager = RegistrableExtensionManager(
@@ -157,9 +163,14 @@ refiner_manager = RegistrableExtensionManager(
 
 #: Disabled refiners
 disabled_refiners: list[str] = []
+if 'SUBLIMINAL_DISABLED_REFINERS' in os.environ:
+    disabled_refiners = os.environ['SUBLIMINAL_DISABLED_REFINERS'].split(' ')
 
-#: Default enabled refiners
-default_refiners = [r for r in refiner_manager.names() if r not in disabled_refiners]
+
+def get_default_refiners() -> list[str]:
+    """Return the default enabled refiners."""
+    return [r for r in refiner_manager.names() if r not in disabled_refiners]
+
 
 #: Discarded Movie refiners
 discarded_movie_refiners: list[str] = ['tvdb']

--- a/subliminal/extensions.py
+++ b/subliminal/extensions.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import os
 import re
 from importlib.metadata import EntryPoint
 from typing import TYPE_CHECKING, Any
@@ -140,8 +139,6 @@ provider_manager = RegistrableExtensionManager(
 
 #: Disabled providers
 disabled_providers = ['opensubtitlesvip', 'opensubtitlescomvip']
-if 'SUBLIMINAL_DISABLED_PROVIDERS' in os.environ:
-    disabled_providers = os.environ['SUBLIMINAL_DISABLED_PROVIDERS'].split(' ')
 
 
 def get_default_providers() -> list[str]:
@@ -163,8 +160,6 @@ refiner_manager = RegistrableExtensionManager(
 
 #: Disabled refiners
 disabled_refiners: list[str] = []
-if 'SUBLIMINAL_DISABLED_REFINERS' in os.environ:
-    disabled_refiners = os.environ['SUBLIMINAL_DISABLED_REFINERS'].split(' ')
 
 
 def get_default_refiners() -> list[str]:

--- a/subliminal/refiners/hash.py
+++ b/subliminal/refiners/hash.py
@@ -7,7 +7,7 @@ import os
 import struct
 from typing import TYPE_CHECKING, Any, cast
 
-from subliminal.extensions import default_providers, provider_manager
+from subliminal.extensions import get_default_providers, provider_manager
 from subliminal.providers import Provider
 
 if TYPE_CHECKING:
@@ -78,8 +78,10 @@ def refine(
         logger.warning('Size is lower than 10MB: hashes not computed')
         return video
 
+    providers = providers if providers is not None else get_default_providers()
+
     logger.debug('Computing hashes for %r', video.name)
-    for name in providers or default_providers:
+    for name in providers:
         provider = cast(Provider, provider_manager[name].plugin)
         if not provider.check_types(video):
             continue

--- a/tests/cassettes/providers/test_list_subtitles_providers_download.yaml
+++ b/tests/cassettes/providers/test_list_subtitles_providers_download.yaml
@@ -1,0 +1,577 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - Subliminal/2.2
+      accept:
+      - application/json
+    method: GET
+    uri: https://api.gestdown.info/shows/external/tvdb/80379
+  response:
+    body:
+      string: '{"shows":[{"id":"91eb9278-8cf5-4ddd-9111-7f60b15958cb","name":"The
+        Big Bang Theory","nbSeasons":12,"seasons":[1,2,3,4,5,6,7,8,9,10,11,12],"tvDbId":80379,"tmdbId":1418,"slug":"the-big-bang-theory"}]}'
+    headers:
+      Age:
+      - '423190'
+      CF-Cache-Status:
+      - HIT
+      CF-RAY:
+      - 8d2b0a6eaf7e499a-LHR
+      Cache-Control:
+      - public, max-age=14400
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 14 Oct 2024 22:35:07 GMT
+      Last-Modified:
+      - Thu, 03 Oct 2024 00:04:48 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=%2FnO3SpD8X%2BA%2BDtnbMFxTsEdZKNTbJvrFFD%2FK43zePt9krWw3m9QnSdV4Kb%2BpvUcuA%2FftfrU7MAaKEqlssDH6Ra8CS5YQZmSCqf6flXia76VxvpaAF7O2k2p8f72rzExOtDWmVw%3D%3D"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-length:
+      - '198'
+      vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - Subliminal/2.2
+      accept:
+      - application/json
+    method: GET
+    uri: https://api.gestdown.info/subtitles/get/91eb9278-8cf5-4ddd-9111-7f60b15958cb/7/5/eng
+  response:
+    body:
+      string: '{"matchingSubtitles":[{"subtitleId":"a245f3f1-920f-41f5-b9af-876a633cc8dd","version":"DIMENSION","completed":true,"hearingImpaired":true,"corrected":true,"hd":true,"downloadUri":"/subtitles/download/a245f3f1-920f-41f5-b9af-876a633cc8dd","language":"English","discovered":"2022-05-30T14:51:00.621696Z","downloadCount":61},{"subtitleId":"a295515c-a460-44ea-9ba8-8d37bcb9b5a6","version":"DIMENSION","completed":true,"hearingImpaired":false,"corrected":true,"hd":true,"downloadUri":"/subtitles/download/a295515c-a460-44ea-9ba8-8d37bcb9b5a6","language":"English","discovered":"2022-05-30T14:51:00.621698Z","downloadCount":67},{"subtitleId":"a00559a0-f510-4f7f-bc95-071ded7d852a","version":"WEB-DL","completed":true,"hearingImpaired":false,"corrected":true,"hd":true,"downloadUri":"/subtitles/download/a00559a0-f510-4f7f-bc95-071ded7d852a","language":"English","discovered":"2022-05-30T14:51:00.621703Z","downloadCount":60},{"subtitleId":"c85f0280-f3c2-4558-bad6-780334ac7e21","version":"WEB-DL","completed":true,"hearingImpaired":true,"corrected":true,"hd":true,"downloadUri":"/subtitles/download/c85f0280-f3c2-4558-bad6-780334ac7e21","language":"English","discovered":"2022-05-30T14:51:00.621705Z","downloadCount":23},{"subtitleId":"95c351b3-3889-490a-acd3-92a8067894f5","version":"BDRip.x264.DEMAND","completed":true,"hearingImpaired":false,"corrected":true,"hd":false,"downloadUri":"/subtitles/download/95c351b3-3889-490a-acd3-92a8067894f5","language":"English","discovered":"2022-05-30T14:51:00.621728Z","downloadCount":581}],"episode":{"season":7,"number":5,"title":"The
+        Workplace Proximity","show":"The Big Bang Theory","discovered":"2022-05-30T14:51:00.621694Z"}}'
+    headers:
+      CF-Cache-Status:
+      - EXPIRED
+      CF-RAY:
+      - 8d2b0a6f7930068e-LHR
+      Cache-Control:
+      - public, max-age=7200
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Mon, 14 Oct 2024 22:35:08 GMT
+      Last-Modified:
+      - Mon, 14 Oct 2024 22:35:08 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=zdYWynSb7hNgpYiWS7djVJafzOoBC53JYvfvrO4akbNDgJe9Cj%2FOjhkjIzFSkAC9P7a2Anj7cszMS%2FOocEWipjSqhzCbUPbgkIWq9esLaDraRVbu1CVmXJOpKf95diE2oyhlHQ%3D%3D"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-length:
+      - '1665'
+      vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - Subliminal/2.2
+      accept:
+      - application/json
+    method: GET
+    uri: https://api.gestdown.info/subtitles/download/a245f3f1-920f-41f5-b9af-876a633cc8dd
+  response:
+    body:
+      string: "\uFEFF1\r\n00:00:05,532 --> 00:00:07,400\r\nAwkward silence.\r\n\r\n2\r\n00:00:07,402
+        --> 00:00:08,684\r\nSheldon on his phone.\r\n\r\n3\r\n00:00:08,686 --> 00:00:09,719\r\nNo
+        touching.\r\n\r\n4\r\n00:00:09,721 --> 00:00:13,122\r\nSomebody's having date
+        night.\r\n\r\n5\r\n00:00:13,124 --> 00:00:15,208\r\nIt's actually steamier\r\nthan
+        it looks.\r\n\r\n6\r\n00:00:15,210 --> 00:00:18,077\r\nSheldon's looking up
+        the phallic\r\nsymbolism of root vegetables\r\n\r\n7\r\n00:00:18,079 --> 00:00:19,796\r\nin
+        Renaissance paintings.\r\n\r\n8\r\n00:00:19,798 --> 00:00:21,447\r\nOh, no,
+        I got bored\r\nwith that.\r\n\r\n9\r\n00:00:21,449 --> 00:00:25,418\r\nI'm
+        just browsing\r\ncuticle scissors on Amazon.\r\n\r\n10\r\n00:00:26,370 -->
+        00:00:28,004\r\nHow do you\r\nnot tear off his clothes\r\n\r\n11\r\n00:00:28,006
+        --> 00:00:30,556\r\nand take him right here\r\non this table?\r\n\r\n12\r\n00:00:30,558
+        --> 00:00:33,259\r\nIf you do that, I'll scream.\r\n\r\n13\r\n00:00:36,430
+        --> 00:00:38,631\r\nSheldon, I have some\r\nexciting news to tell you.\r\n\r\n14\r\n00:00:38,633
+        --> 00:00:39,782\r\nThat makes two of us.\r\n\r\n15\r\n00:00:39,784 --> 00:00:41,267\r\nMy
+        new cuticle scissors\r\nwill be here\r\n\r\n16\r\n00:00:41,269 --> 00:00:43,152\r\nin
+        one to two business days.\r\n\r\n17\r\n00:00:43,154 --> 00:00:45,721\r\nCome
+        on, one.\r\n\r\n18\r\n00:00:45,723 --> 00:00:47,824\r\nI've been invited to\r\nconsult
+        on an experiment\r\n\r\n19\r\n00:00:47,826 --> 00:00:50,193\r\nat your university\r\nfor
+        a few months.\r\n\r\n20\r\n00:00:50,195 --> 00:00:51,327\r\nIsn't that great?\r\n\r\n21\r\n00:00:51,329
+        --> 00:00:52,912\r\nWe could have lunch together.\r\n\r\n22\r\n00:00:52,914
+        --> 00:00:54,314\r\nWe could carpool.\r\n\r\n23\r\n00:00:54,316 --> 00:00:56,466\r\nYou
+        know, riding with Leonard\r\n\r\n24\r\n00:00:56,468 --> 00:00:58,735\r\nhas
+        gotten\r\na little tedious lately.\r\n\r\n25\r\n00:00:58,737 --> 00:01:02,205\r\nTh-The
+        only car game he ever\r\nwants to play is the Quiet Game.\r\n\r\n26\r\n00:01:02,207
+        --> 00:01:03,306\r\nAnd he's terrible at it.\r\n\r\n27\r\n00:01:03,308 -->
+        00:01:05,458\r\nI always win.\r\n\r\n28\r\n00:01:06,844 --> 00:01:08,728\r\nSo,
+        you're okay with this?\r\n\r\n29\r\n00:01:08,730 --> 00:01:10,396\r\nWell,
+        why wouldn't I be?\r\n\r\n30\r\n00:01:10,398 --> 00:01:12,432\r\nWell, this
+        project\r\nwould have us working\r\n\r\n31\r\n00:01:12,434 --> 00:01:14,467\r\nin
+        close proximity\r\nto one another.\r\n\r\n32\r\n00:01:14,469 --> 00:01:15,968\r\nAnd
+        there's the vulgar adage\r\n\r\n33\r\n00:01:15,970 --> 00:01:19,639\r\nthat
+        one should not\r\ndefecate where one eats.\r\n\r\n34\r\n00:01:19,641 --> 00:01:21,974\r\nMy
+        father used to say\r\nthat all the time.\r\n\r\n35\r\n00:01:21,976 --> 00:01:25,161\r\nThat
+        and, um, \"Who does one\r\nhave to orally gratify\r\n\r\n36\r\n00:01:25,163
+        --> 00:01:27,880\r\nto get a drink around here?\"\r\n\r\n37\r\n00:01:29,233
+        --> 00:01:31,718\r\nBut what does that have to do\r\n\r\n38\r\n00:01:31,720
+        --> 00:01:33,636\r\nwith you working\r\nat the university?\r\n\r\n39\r\n00:01:33,638
+        --> 00:01:36,239\r\nSheldon, \"Don't defecate\r\nwhere you eat,\"\r\n\r\n40\r\n00:01:36,241
+        --> 00:01:38,274\r\nmeans don't have a\r\nromantic relationship\r\n\r\n41\r\n00:01:38,276
+        --> 00:01:39,876\r\nin the workplace.\r\n\r\n42\r\n00:01:41,078 --> 00:01:43,062\r\nReally?\r\n\r\n43\r\n00:01:45,766
+        --> 00:01:47,383\r\nYes.\r\n\r\n44\r\n00:01:47,385 --> 00:01:48,468\r\nHuh.\r\n\r\n45\r\n00:01:48,470
+        --> 00:01:50,787\r\nYeah, I always\r\ntook it literally.\r\n\r\n46\r\n00:01:50,789
+        --> 00:01:53,622\r\nThat's why I have never\r\nonce moved my bowels\r\n\r\n47\r\n00:01:53,624
+        --> 00:01:55,992\r\nin this or any restaurant.\r\n\r\n48\r\n00:01:55,994 -->
+        00:01:57,944\r\nHmm.\r\n\r\n49\r\n00:01:57,946 --> 00:01:59,979\r\nI'm relieved
+        that you\r\ndon't have a problem\r\n\r\n50\r\n00:01:59,981 --> 00:02:01,264\r\nwith
+        us working together.\r\n\r\n51\r\n00:02:01,266 --> 00:02:03,516\r\nNot as
+        relieved\r\nas I'm about to be.\r\n\r\n52\r\n00:02:04,518 --> 00:02:06,753\r\nIt's
+        a brave new world,\r\nlittle lady.\r\n\r\n53\r\n00:02:09,189 --> 00:02:12,825\r\n\u266A
+        Our whole universe\r\nwas in a hot, dense state \u266A\r\n\r\n54\r\n00:02:12,827
+        --> 00:02:16,162\r\n\u266A Then nearly 14 billion years\r\nago expansion started...
+        Wait! \u266A\r\n\r\n55\r\n00:02:16,164 --> 00:02:17,813\r\n\u266A The Earth
+        began to cool\r\n\r\n56\r\n00:02:17,815 --> 00:02:20,333\r\n\u266A The autotrophs
+        began to drool,\r\nNeanderthals developed tools \u266A\r\n\r\n57\r\n00:02:20,335
+        --> 00:02:23,002\r\n\u266A We built the Wall\r\n\u266A <i>We built the pyramids</i>
+        \u266A\r\n\r\n58\r\n00:02:23,004 --> 00:02:25,688\r\n\u266A Math, Science,
+        History,\r\nunraveling the mystery \u266A\r\n\r\n59\r\n00:02:25,690 --> 00:02:27,573\r\n\u266A
+        That all started\r\nwith a big bang \u266A\r\n\r\n60\r\n00:02:27,575 --> 00:02:28,341\r\n\u266A
+        <i>Bang!</i> \u266A\r\n\r\n61\r\n00:02:28,342 --> 00:02:32,342\r\n<font color=#00FF00>\u266A
+        The Big Bang Theory 7x05 \u266A</font>\r\n<font color=#00FFFF>The Workplace
+        Proximity</font>\r\nOriginal Air Date on October 17, 2013\r\n\r\n62\r\n00:02:32,367
+        --> 00:02:37,367\r\n== sync, corrected by <font color=#00FF00>elderman</font>
+        ==\r\n<font color=#00FFFF>@elder_man</font>\r\n\r\n63\r\n00:02:37,818 -->
+        00:02:39,385\r\nAre you crazy?\r\n\r\n64\r\n00:02:39,387 --> 00:02:40,436\r\nYou
+        don't want\r\n\r\n65\r\n00:02:40,438 --> 00:02:42,305\r\nyour girlfriend\r\nat
+        work with you.\r\n\r\n66\r\n00:02:42,307 --> 00:02:45,007\r\nHell Clam.\r\n\r\n67\r\n00:02:45,009
+        --> 00:02:46,526\r\nWhy not?\r\n\r\n68\r\n00:02:46,528 --> 00:02:49,112\r\nHairy
+        Fairy.\r\n\r\n69\r\n00:02:49,114 --> 00:02:50,680\r\nI think it could be romantic.\r\n\r\n70\r\n00:02:50,682
+        --> 00:02:52,649\r\nYou know, my parents met\r\nat his place of work.\r\n\r\n71\r\n00:02:52,651
+        --> 00:02:55,685\r\nYour father's a gynecologist.\r\n\r\n72\r\n00:02:55,687
+        --> 00:02:56,869\r\nI know.\r\n\r\n73\r\n00:02:56,871 --> 00:02:59,822\r\nWhat
+        started as a pap smear\r\nturned into a date.\r\n\r\n74\r\n00:03:01,292 -->
+        00:03:02,675\r\nWhich turned\r\ninto her working there,\r\n\r\n75\r\n00:03:02,677
+        --> 00:03:04,644\r\nwhich turned into marriage,\r\nwhich then turned into
+        hatred,\r\n\r\n76\r\n00:03:04,646 --> 00:03:07,196\r\nwhich continues to this
+        day.\r\n\r\n77\r\n00:03:07,298 --> 00:03:10,066\r\nTwo-Eyed Cyclops.\r\n\r\n78\r\n00:03:10,068
+        --> 00:03:12,902\r\nWould you please tell him\r\nthis isn't a good idea?\r\n\r\n79\r\n00:03:12,904
+        --> 00:03:14,270\r\nNo, no, I think it'll be great.\r\n\r\n80\r\n00:03:14,272
+        --> 00:03:15,888\r\nMaybe next time he gets\r\nconjunctivitis at work,\r\n\r\n81\r\n00:03:15,890
+        --> 00:03:19,942\r\nshe can hold his head and try\r\nto put the drops in his
+        eyes.\r\n\r\n82\r\n00:03:19,944 --> 00:03:22,428\r\nGiant baby.\r\n\r\n83\r\n00:03:22,430
+        --> 00:03:24,280\r\nThat's a Raging Ogre.\r\n\r\n84\r\n00:03:24,282 --> 00:03:26,516\r\nYeah,
+        I know.\r\n\r\n85\r\n00:03:28,519 --> 00:03:30,686\r\nI'm just saying, I'd
+        never want\r\nto work with Bernadette.\r\n\r\n86\r\n00:03:30,688 --> 00:03:32,655\r\nCan
+        you imagine seeing\r\nsomeone all day long\r\n\r\n87\r\n00:03:32,657 --> 00:03:34,123\r\nand
+        then you're\r\nsupposed to hang out\r\n\r\n88\r\n00:03:34,125 --> 00:03:35,825\r\nwith
+        them after work, too?\r\n\r\n89\r\n00:03:35,827 --> 00:03:37,493\r\nHold on.
+        We do\r\nthat all the time.\r\n\r\n90\r\n00:03:37,495 --> 00:03:39,228\r\nYou
+        and I work together\r\nand play together.\r\n\r\n91\r\n00:03:39,230 --> 00:03:42,882\r\nYeah,
+        I know, and it drove me\r\ninto the arms of another woman.\r\n\r\n92\r\n00:03:44,701
+        --> 00:03:46,719\r\nBipolar Bear.\r\n\r\n93\r\n00:03:46,721 --> 00:03:49,605\r\nWell,
+        I appreciate your concern,\r\n\r\n94\r\n00:03:49,607 --> 00:03:52,809\r\nbut
+        I won't be seeing any more\r\nof Amy than I already do.\r\n\r\n95\r\n00:03:52,811
+        --> 00:03:55,094\r\nI assume we'll deduct\r\nany extra time we spend together\r\n\r\n96\r\n00:03:55,096
+        --> 00:03:57,964\r\nat work from our weekly quota.\r\n\r\n97\r\n00:03:59,883
+        --> 00:04:02,552\r\nPlease let me be there\r\nwhen you tell her that.\r\n\r\n98\r\n00:04:03,520
+        --> 00:04:05,688\r\nWhy? So you can see the\r\nlook on Amy's face\r\n\r\n99\r\n00:04:05,690
+        --> 00:04:07,990\r\nwhen she hears\r\nmy top-notch idea?\r\n\r\n100\r\n00:04:07,992
+        --> 00:04:10,576\r\nPlease, oh, please,\r\njust let me be there.\r\n\r\n101\r\n00:04:12,546
+        --> 00:04:15,681\r\nSo, Amy, what are you gonna\r\nbe working on at Caltech?\r\n\r\n102\r\n00:04:15,683
+        --> 00:04:17,467\r\nI'm leading a study to see\r\n\r\n103\r\n00:04:17,469
+        --> 00:04:19,368\r\nif deficiency of the\r\nmonoamine oxidase enzyme\r\n\r\n104\r\n00:04:19,370
+        --> 00:04:21,444\r\nleads to paralyzing\r\nfear in monkeys.\r\n\r\n105\r\n00:04:21,469
+        --> 00:04:22,339\r\nOh.\r\n\r\n106\r\n00:04:22,340 --> 00:04:25,158\r\nIf
+        they're anything like humans,\r\nthe answer's yes.\r\n\r\n107\r\n00:04:25,160
+        --> 00:04:27,577\r\nWait, you've-you've done\r\nthis experiment on humans?\r\n\r\n108\r\n00:04:27,579
+        --> 00:04:30,263\r\nYou mean like death row inmates\r\nwith nothing to lose?\r\n\r\n109\r\n00:04:30,365
+        --> 00:04:33,082\r\nNo, that would be unethical.\r\n\r\n110\r\n00:04:34,618
+        --> 00:04:36,586\r\nYou know,\r\nnot a lot of people know this,\r\n\r\n111\r\n00:04:36,588
+        --> 00:04:37,837\r\nbut the monoamine oxidase enzyme\r\n\r\n112\r\n00:04:37,839
+        --> 00:04:39,789\r\nwas discovered by a woman,\r\nMary Bernheim.\r\n\r\n113\r\n00:04:42,276
+        --> 00:04:43,542\r\nThat's right.\r\n\r\n114\r\n00:04:43,544 --> 00:04:46,545\r\nMy
+        phone is just\r\nas smart as you guys.\r\n\r\n115\r\n00:04:47,264 --> 00:04:48,314\r\n(knocking)\r\n\r\n116\r\n00:04:48,316
+        --> 00:04:49,448\r\nSHELDON:\r\nAmy, Bernadette, Penny.\r\n\r\n117\r\n00:04:49,450
+        --> 00:04:51,150\r\n(knocks) Amy, Bernadette,\r\nPenny.\r\n\r\n118\r\n00:04:51,152
+        --> 00:04:53,536\r\n(knocks)\r\nAmy, Bernadette, Penny.\r\n\r\n119\r\n00:04:53,538
+        --> 00:04:56,305\r\nHe's never gonna\r\nstop doing that, is he?\r\n\r\n120\r\n00:04:56,307
+        --> 00:04:57,440\r\nI don't mind.\r\n\r\n121\r\n00:04:57,442 --> 00:04:59,108\r\nI'm
+        hoping to put\r\nhis love of repetition\r\n\r\n122\r\n00:04:59,110 --> 00:05:00,860\r\nto
+        good use someday.\r\n\r\n123\r\n00:05:03,246 --> 00:05:05,231\r\nHi. Um...\r\n\r\n124\r\n00:05:05,233
+        --> 00:05:06,399\r\nI've reconsidered.\r\n\r\n125\r\n00:05:06,401 --> 00:05:07,900\r\nUh,
+        you can't work\r\nwhere I work.\r\n\r\n126\r\n00:05:07,902 --> 00:05:09,268\r\nEnjoy
+        the rest\r\nof your evening.\r\n\r\n127\r\n00:05:09,270 --> 00:05:10,903\r\nSheldon.\r\n\r\n128\r\n00:05:10,905
+        --> 00:05:13,122\r\nI-I already signed\r\nthe contract.\r\n\r\n129\r\n00:05:13,124
+        --> 00:05:14,523\r\nI cashed a check.\r\n\r\n130\r\n00:05:14,525 --> 00:05:16,575\r\nMmm...
+        you are not going\r\n\r\n131\r\n00:05:16,577 --> 00:05:18,427\r\nto come out
+        of\r\nthis looking good.\r\n\r\n132\r\n00:05:18,429 --> 00:05:19,662\r\nPENNY:
+        Sheldon,\r\nI don't understand.\r\n\r\n133\r\n00:05:19,664 --> 00:05:21,580\r\nI
+        thought you said\r\nyou were fine with it.\r\n\r\n134\r\n00:05:21,582 -->
+        00:05:22,698\r\nWell, I was.\r\n\r\n135\r\n00:05:22,700 --> 00:05:24,333\r\nBut
+        that was before\r\nHoward explained to me\r\n\r\n136\r\n00:05:24,335 --> 00:05:26,469\r\nhow
+        awful it would be\r\nif he had to work\r\n\r\n137\r\n00:05:26,471 --> 00:05:28,137\r\nwith
+        his significant other.\r\n\r\n138\r\n00:05:28,139 --> 00:05:30,723\r\nHe said
+        what?\r\n\r\n139\r\n00:05:30,725 --> 00:05:32,675\r\nNow, don't be insulted.\r\n\r\n140\r\n00:05:32,677
+        --> 00:05:36,896\r\nHe just thinks too much of you\r\nwould be mind-numbingly
+        tedious.\r\n\r\n141\r\n00:05:36,898 --> 00:05:40,066\r\nExcuse me, I need
+        to have\r\na chat with my husband.\r\n\r\n142\r\n00:05:40,068 --> 00:05:41,901\r\nYeah,
+        well, now,\r\nwell... keep it short.\r\n\r\n143\r\n00:05:41,903 --> 00:05:45,438\r\nFr-From
+        what I gather,\r\nbrevity is your friend.\r\n\r\n144\r\n00:05:46,573 --> 00:05:48,741\r\nSo,
+        are we good here?\r\n\r\n145\r\n00:05:48,743 --> 00:05:50,326\r\nNo, we're
+        not good here.\r\n\r\n146\r\n00:05:50,328 --> 00:05:51,827\r\nI am working
+        on this project.\r\n\r\n147\r\n00:05:51,829 --> 00:05:54,080\r\nYeah, and
+        you can't tell her\r\nwhat she can and cannot do.\r\n\r\n148\r\n00:05:54,082
+        --> 00:05:56,098\r\nLast week, you told Leonard\r\nhe couldn't wear\r\n\r\n149\r\n00:05:56,100
+        --> 00:05:58,300\r\nhis Wookiee jacket\r\nout in public.\r\n\r\n150\r\n00:05:58,302
+        --> 00:05:59,518\r\nThat's different.\r\n\r\n151\r\n00:05:59,520 --> 00:06:01,454\r\nI'm
+        not going to the mall\r\nwith someone dressed\r\n\r\n152\r\n00:06:01,456 -->
+        00:06:03,539\r\ndumb space bear.\r\n\r\n153\r\n00:06:05,575 --> 00:06:07,626\r\nSheldon,
+        you don't have to worry\r\nabout me bothering you.\r\n\r\n154\r\n00:06:07,628
+        --> 00:06:08,878\r\nI'll be in a different building.\r\n\r\n155\r\n00:06:08,880
+        --> 00:06:10,746\r\nAnd we don't even have\r\nto have lunch together.\r\n\r\n156\r\n00:06:10,748
+        --> 00:06:11,864\r\nReally?\r\n\r\n157\r\n00:06:11,866 --> 00:06:14,517\r\nYes.
+        Before all things,\r\nI'm a scientist.\r\n\r\n158\r\n00:06:14,519 --> 00:06:16,969\r\nI'm
+        just there to do my work\r\nand, with a little luck,\r\n\r\n159\r\n00:06:16,971
+        --> 00:06:19,605\r\nscare the living crap\r\nout of some monkeys.\r\n\r\n160\r\n00:06:19,607
+        --> 00:06:23,142\r\nHmm.\r\n\r\n161\r\n00:06:23,144 --> 00:06:25,811\r\nYou
+        sure your mothlike\r\npersonality won't be drawn\r\n\r\n162\r\n00:06:25,813
+        --> 00:06:28,564\r\nto this blazing fire\r\nthat is myself?\r\n\r\n163\r\n00:06:31,535
+        --> 00:06:33,786\r\nMore and more sure.\r\n\r\n164\r\n00:06:33,788 --> 00:06:36,872\r\nWell,
+        then, you\r\nhave my permission.\r\n\r\n165\r\n00:06:36,874 --> 00:06:37,957\r\nI
+        didn't ask\r\nfor your permission.\r\n\r\n166\r\n00:06:37,959 --> 00:06:39,158\r\nToo
+        late. No backsies.\r\n\r\n167\r\n00:06:41,611 --> 00:06:44,413\r\nNo, no,
+        listen to me.\r\nSheldon misunderstood.\r\n\r\n168\r\n00:06:44,415 --> 00:06:45,381\r\nWhat
+        I meant was,\r\n\r\n169\r\n00:06:45,383 --> 00:06:46,448\r\nif we worked together,\r\n\r\n170\r\n00:06:46,450
+        --> 00:06:48,117\r\nthere'd be too much\r\nof me for you,\r\n\r\n171\r\n00:06:48,119
+        --> 00:06:50,252\r\nnot the other way around.\r\n\r\n172\r\n00:06:50,254 -->
+        00:06:52,722\r\nHoward, if you're going\r\nto lie to your wife,\r\n\r\n173\r\n00:06:52,724
+        --> 00:06:55,324\r\ndon't start the sentence\r\nwith \"Sheldon misunderstood.\"\r\n\r\n174\r\n00:06:56,877
+        --> 00:06:58,010\r\nThat's a dead giveaway.\r\n\r\n175\r\n00:06:58,012 -->
+        00:06:59,929\r\nWell?\r\n\r\n176\r\n00:06:59,931 --> 00:07:01,130\r\nOkay,
+        fine.\r\n\r\n177\r\n00:07:01,132 --> 00:07:02,898\r\nI did say that,\r\nand
+        I think it's true.\r\n\r\n178\r\n00:07:02,900 --> 00:07:05,017\r\nI think
+        if we worked together\r\nand lived together,\r\n\r\n179\r\n00:07:05,019 -->
+        00:07:06,519\r\nwe'd get sick of each other.\r\n\r\n180\r\n00:07:06,521 -->
+        00:07:08,104\r\nYeah, but to be fair,\r\nhe only said the part\r\n\r\n181\r\n00:07:08,106
+        --> 00:07:09,188\r\nabout him\r\ngetting sick of you.\r\n\r\n182\r\n00:07:09,190
+        --> 00:07:11,023\r\nFor the love of God, why?!\r\n\r\n183\r\n00:07:15,212
+        --> 00:07:17,863\r\nWhat exactly do you\r\nthink you'd get sick of?\r\n\r\n184\r\n00:07:17,865
+        --> 00:07:20,015\r\nHis only options here\r\nare to fake a heart attack\r\n\r\n185\r\n00:07:20,017
+        --> 00:07:22,384\r\nor have a real one.\r\n\r\n186\r\n00:07:22,386 --> 00:07:25,654\r\nIt-it's
+        nothing\r\nin particular. I...\r\n\r\n187\r\n00:07:25,656 --> 00:07:27,823\r\nIs
+        it my voice?\r\nAm I too bossy?\r\n\r\n188\r\n00:07:27,825 --> 00:07:28,958\r\n(quietly):\r\nWhat...?\r\n\r\n189\r\n00:07:28,960
+        --> 00:07:31,877\r\nMy arm is feeling numb.\r\n\r\n190\r\n00:07:32,796 -->
+        00:07:35,781\r\nNailed it.\r\n\r\n191\r\n00:07:35,783 --> 00:07:39,385\r\nThat's
+        the wrong arm for\r\na heart attack, doofus.\r\n\r\n192\r\n00:07:41,221 -->
+        00:07:44,356\r\nMy point is, I'm sure\r\nthere are things about me\r\n\r\n193\r\n00:07:44,358
+        --> 00:07:46,642\r\nthat would drive you crazy\r\nif you had to deal\r\n\r\n194\r\n00:07:46,644
+        --> 00:07:48,394\r\nwith them all day long.\r\n\r\n195\r\n00:07:48,396 -->
+        00:07:50,596\r\nLike looking me in the\r\neye and lying to me?\r\n\r\n196\r\n00:07:50,598
+        --> 00:07:52,148\r\nOh, well, come on, I just...\r\n\r\n197\r\n00:07:52,150
+        --> 00:07:55,401\r\nWhere am I supposed to\r\nlook when I lie to you?\r\n\r\n198\r\n00:07:55,403
+        --> 00:07:57,753\r\nFind somewhere else \r\nto sleep tonight.\r\n\r\n199\r\n00:07:57,755
+        --> 00:07:59,905\r\nOh, Bernie...\r\n\r\n200\r\n00:08:06,863 --> 00:08:10,466\r\nIf
+        it makes you feel any better,\r\nAmy and I are fine.\r\n\r\n201\r\n00:08:13,069
+        --> 00:08:15,237\r\nI mean, really good.\r\n\r\n202\r\n00:08:17,474 --> 00:08:19,842\r\nSo,
+        boys, how was\r\nthe pajama party?\r\n\r\n203\r\n00:08:19,844 --> 00:08:23,729\r\nYou
+        guys jump on the bed\r\nand sing into hair brushes?\r\n\r\n204\r\n00:08:23,731
+        --> 00:08:25,931\r\nIt wasn't a pajama party.\r\n\r\n205\r\n00:08:25,933 -->
+        00:08:28,434\r\nIt was just a couple of bros\r\nhanging out, giggling,\r\n\r\n206\r\n00:08:28,436
+        --> 00:08:31,520\r\neating cookie dough\r\nand watching <i>Princess Bride.</i>\r\n\r\n207\r\n00:08:33,073
+        --> 00:08:34,607\r\nPlease, stop talking.\r\n\r\n208\r\n00:08:36,243 --> 00:08:38,861\r\nAs
+        you wish.\r\n\r\n209\r\n00:08:42,666 --> 00:08:44,733\r\nI mean, you know,
+        Sheldon,\r\nnone of this would've happened\r\n\r\n210\r\n00:08:44,735 -->
+        00:08:46,202\r\nif I hadn't tried\r\nto help you.\r\n\r\n211\r\n00:08:46,204
+        --> 00:08:48,787\r\nUh, it also wouldn't\r\nhave happened\r\n\r\n212\r\n00:08:48,789
+        --> 00:08:50,289\r\nif, in the early universe,\r\n\r\n213\r\n00:08:50,291
+        --> 00:08:53,792\r\nhydrogen was a little more\r\ncommon or a little less
+        common.\r\n\r\n214\r\n00:08:53,794 --> 00:08:56,278\r\nThis is fun. Your turn.\r\n\r\n215\r\n00:08:57,264
+        --> 00:08:58,597\r\nGentlemen.\r\nHey, Amy.\r\n\r\n216\r\n00:08:58,599 -->
+        00:09:00,282\r\nHello.\r\n\r\n217\r\n00:09:00,284 --> 00:09:01,684\r\nThat
+        was kind of icy.\r\n\r\n218\r\n00:09:01,686 --> 00:09:03,335\r\nYou two okay?\r\n\r\n219\r\n00:09:03,337
+        --> 00:09:04,353\r\nOh, we're fine.\r\n\r\n220\r\n00:09:04,355 --> 00:09:05,771\r\nAs
+        Howard advised,\r\n\r\n221\r\n00:09:05,773 --> 00:09:07,973\r\nshe's merely
+        respecting our\r\nprofessional boundaries.\r\n\r\n222\r\n00:09:07,975 -->
+        00:09:08,941\r\nSmart.\r\n\r\n223\r\n00:09:08,943 --> 00:09:10,543\r\nTake
+        relationship advice\r\nfrom a man\r\n\r\n224\r\n00:09:10,545 --> 00:09:12,962\r\nwho
+        spent last night\r\nbraiding Raj's hair.\r\n\r\n225\r\n00:09:15,431 --> 00:09:18,450\r\nYeah,
+        you make\r\na good point.\r\n\r\n226\r\n00:09:18,452 --> 00:09:20,653\r\nIt
+        would appear\r\nI was worried for nothing.\r\n\r\n227\r\n00:09:20,655 -->
+        00:09:22,204\r\nLook at her, desperately wishing\r\n\r\n228\r\n00:09:22,206
+        --> 00:09:24,156\r\nshe was over here\r\nat the cool table.\r\n\r\n229\r\n00:09:26,576
+        --> 00:09:28,327\r\nDon't worry, little moth.\r\n\r\n230\r\n00:09:28,329 -->
+        00:09:30,629\r\nThe flame will come to you.\r\n\r\n231\r\n00:09:32,832 -->
+        00:09:34,567\r\nKOOTHRAPPALI:\r\nOh, uh...\r\n\r\n232\r\n00:09:34,569 -->
+        00:09:36,385\r\non the off chance that\r\nBernadette doesn't call back\r\n\r\n233\r\n00:09:36,387
+        --> 00:09:37,770\r\nand apologize,\r\nhow do you feel\r\n\r\n234\r\n00:09:37,772
+        --> 00:09:39,672\r\nabout Mexican food\r\nfor dinner tonight?\r\n\r\n235\r\n00:09:39,674
+        --> 00:09:41,840\r\nI-I don't know.\r\nSounds kind of heavy.\r\n\r\n236\r\n00:09:41,842
+        --> 00:09:44,810\r\nThat's 'cause you always\r\nfill up on chips.\r\n\r\n237\r\n00:09:44,812
+        --> 00:09:47,479\r\nAnd this is Dr. Gunderson\r\nfrom Stockholm.\r\n\r\n238\r\n00:09:47,481
+        --> 00:09:49,031\r\nAh, Sweden.\r\n\r\n239\r\n00:09:49,033 --> 00:09:50,733\r\nYeah,
+        home of my favorite Muppet\r\n\r\n240\r\n00:09:50,735 --> 00:09:53,719\r\nand,
+        uh,\r\nsecond favorite meatball.\r\n\r\n241\r\n00:09:57,140 --> 00:10:01,343\r\nOkay,
+        the Nordic reputation for\r\nlack of humor is well-founded.\r\n\r\n242\r\n00:10:02,812
+        --> 00:10:05,581\r\nBoy, is his name Gunderson\r\nor No-Funderson?\r\n\r\n243\r\n00:10:06,833
+        --> 00:10:09,068\r\nWhere are we going\r\nwith this, Dr. Cooper?\r\n\r\n244\r\n00:10:09,070
+        --> 00:10:11,103\r\nOh, please, I'm your boyfriend.\r\n\r\n245\r\n00:10:11,105
+        --> 00:10:13,555\r\nYou call me Sheldon.\r\n\r\n246\r\n00:10:13,557 --> 00:10:16,158\r\nThat's
+        right,\r\nI am in a boy-girl relationship\r\n\r\n247\r\n00:10:16,160 --> 00:10:18,928\r\nwith
+        this cute little\r\nlump of wool.\r\n\r\n248\r\n00:10:18,930 --> 00:10:20,045\r\nSheldon...\r\n\r\n249\r\n00:10:20,047
+        --> 00:10:21,764\r\nIt's a physical\r\nrelationship, too.\r\n\r\n250\r\n00:10:21,766
+        --> 00:10:25,517\r\nHand-holding, hugging...\r\neven on hot days.\r\n\r\n251\r\n00:10:25,519
+        --> 00:10:27,386\r\nOw.\r\n\r\n252\r\n00:10:28,171 --> 00:10:29,538\r\nOkay,
+        here's a new one.\r\n\r\n253\r\n00:10:29,540 --> 00:10:31,140\r\nApparently
+        now\r\nwe kick each other\r\n\r\n254\r\n00:10:31,142 --> 00:10:32,775\r\nin
+        the shin under the table.\r\n\r\n255\r\n00:10:34,477 --> 00:10:37,012\r\nHow
+        do you like it\r\nwhen I do it to you?\r\n\r\n256\r\n00:10:38,398 --> 00:10:41,066\r\nNot
+        so much, huh?\r\n\r\n257\r\n00:10:53,498 --> 00:10:55,883\r\nTest subject
+        D7,\r\n\r\n258\r\n00:10:55,885 --> 00:10:58,535\r\naka Betsy, fear response
+        study.\r\n\r\n259\r\n00:10:58,537 --> 00:11:02,389\r\nImage number one: Frenchman\r\non
+        bicycle carrying baguettes.\r\n\r\n260\r\n00:11:05,393 --> 00:11:08,395\r\nNo
+        visible reaction.\r\n\r\n261\r\n00:11:08,397 --> 00:11:10,764\r\nImage number
+        two: sousaphone.\r\n\r\n262\r\n00:11:13,234 --> 00:11:14,735\r\nStill no reaction.\r\n\r\n263\r\n00:11:14,737
+        --> 00:11:15,736\r\nOkay.\r\n\r\n264\r\n00:11:15,738 --> 00:11:17,371\r\nLet's
+        kick things up a notch.\r\n\r\n265\r\n00:11:17,373 --> 00:11:20,090\r\nImage
+        number three: crocodile\r\nwith a mouthful of monkeys.\r\n\r\n266\r\n00:11:20,092
+        --> 00:11:22,292\r\n(screeching)\r\n\r\n267\r\n00:11:24,078 --> 00:11:27,131\r\nOkay,
+        now we're talking.\r\n\r\n268\r\n00:11:27,133 --> 00:11:29,066\r\nDr. Fowler?\r\n\r\n269\r\n00:11:29,068
+        --> 00:11:31,135\r\nWhat do you want, Sheldon?\r\n\r\n270\r\n00:11:31,137
+        --> 00:11:33,220\r\nWell, I'm done\r\nwith work, so...\r\n\r\n271\r\n00:11:33,222
+        --> 00:11:34,421\r\n(gasps)\r\n\r\n272\r\n00:11:34,423 --> 00:11:36,357\r\nOh,
+        sorry, sorry, sorry.\r\n\r\n273\r\n00:11:36,359 --> 00:11:39,092\r\nSorry.
+        Uh...\r\n\r\n274\r\n00:11:39,094 --> 00:11:40,527\r\nBetter?\r\n\r\n275\r\n00:11:40,529
+        --> 00:11:41,695\r\nOh, baguettes.\r\n\r\n276\r\n00:11:41,697 --> 00:11:43,897\r\nYes,
+        I like baguettes.\r\n\r\n277\r\n00:11:43,899 --> 00:11:46,099\r\nWhat exactly\r\nare
+        you doing?\r\n\r\n278\r\n00:11:46,101 --> 00:11:48,535\r\nDetermining baseline
+        fear levels\r\nin capuchin monkeys\r\n\r\n279\r\n00:11:48,537 --> 00:11:50,871\r\nby
+        measuring their response\r\nto visual stimuli.\r\n\r\n280\r\n00:11:50,873
+        --> 00:11:52,339\r\nSo, goofing off.\r\n\r\n281\r\n00:11:54,909 --> 00:11:57,578\r\nAs
+        I was saying, I'm done\r\nwith work and Leonard's not.\r\n\r\n282\r\n00:11:57,580
+        --> 00:12:00,214\r\nSo good news,\r\nyou get to take me home.\r\n\r\n283\r\n00:12:00,216
+        --> 00:12:01,248\r\nPlay your cards right,\r\n\r\n284\r\n00:12:01,250 -->
+        00:12:02,750\r\nI'll let you drive me\r\n\r\n285\r\n00:12:02,752 --> 00:12:05,836\r\npast
+        the lot\r\nwhere the buses park at night.\r\n\r\n286\r\n00:12:05,838 --> 00:12:07,638\r\nI
+        can't leave now, Sheldon.\r\n\r\n287\r\n00:12:07,640 --> 00:12:08,756\r\nI'm
+        very busy.\r\n\r\n288\r\n00:12:08,758 --> 00:12:10,557\r\nBesides, why would
+        I want\r\nto do you a favor\r\n\r\n289\r\n00:12:10,559 --> 00:12:12,576\r\nafter
+        the way you treated\r\nme in the cafeteria?\r\n\r\n290\r\n00:12:12,578 -->
+        00:12:15,128\r\nImage number four:\r\nboa constrictor.\r\n\r\n291\r\n00:12:15,647
+        --> 00:12:17,431\r\n(shudders)\r\n\r\n292\r\n00:12:18,967 --> 00:12:21,935\r\nWhat
+        on earth\r\nare you talking about?\r\n\r\n293\r\n00:12:21,937 --> 00:12:23,487\r\nMy
+        behavior\r\nin the cafeteria\r\n\r\n294\r\n00:12:23,489 --> 00:12:25,305\r\nwas
+        delightful.\r\n\r\n295\r\n00:12:25,307 --> 00:12:27,491\r\nMaybe your friend\r\nGunderson
+        needs\r\n\r\n296\r\n00:12:27,493 --> 00:12:29,443\r\nto head over\r\nto IKEA
+        and assemble\r\n\r\n297\r\n00:12:29,445 --> 00:12:32,379\r\na sense of humor.\r\n\r\n298\r\n00:12:32,381
+        --> 00:12:34,364\r\nYou embarrassed me\r\nin front of my colleagues\r\n\r\n299\r\n00:12:34,366
+        --> 00:12:35,982\r\non my first day here.\r\n\r\n300\r\n00:12:36,684 --> 00:12:37,785\r\nImage
+        number five:\r\n\r\n301\r\n00:12:37,787 --> 00:12:39,186\r\nkitten in a teacup.\r\n\r\n302\r\n00:12:39,188
+        --> 00:12:41,388\r\nOh.\r\n\r\n303\r\n00:12:44,959 --> 00:12:47,528\r\nOh...
+        embarrassed you?\r\nYou know what?\r\n\r\n304\r\n00:12:47,530 --> 00:12:50,431\r\nI
+        don't have time for this.\r\nFind another way home.\r\n\r\n305\r\n00:12:50,433
+        --> 00:12:53,450\r\nI'm starting to get the sense\r\nthat you're angry with
+        me.\r\n\r\n306\r\n00:12:53,452 --> 00:12:55,001\r\nReally?\r\nWhat tipped
+        you off?\r\n\r\n307\r\n00:12:55,003 --> 00:12:56,053\r\nCouple things, actually.\r\n\r\n308\r\n00:12:56,055
+        --> 00:12:57,170\r\nYour tone of voice,\r\nyour body language...\r\n\r\n309\r\n00:12:57,172
+        --> 00:12:58,806\r\nGet out.\r\nWell, now, that.\r\n\r\n310\r\n00:13:00,675
+        --> 00:13:03,310\r\nImage number six:\r\nwoman giving birth.\r\n\r\n311\r\n00:13:03,312
+        --> 00:13:05,612\r\n(gags)\r\n\r\n312\r\n00:13:12,570 --> 00:13:14,187\r\nIt's
+        9:00.\r\nWhere you been?\r\n\r\n313\r\n00:13:14,189 --> 00:13:17,307\r\nOh,
+        I had to take\r\nthe bus home.\r\n\r\n314\r\n00:13:17,309 --> 00:13:20,844\r\nFell
+        asleep and missed my stop.\r\n\r\n315\r\n00:13:20,846 --> 00:13:22,646\r\nOh,
+        no.\r\n\r\n316\r\n00:13:22,648 --> 00:13:26,633\r\nDid you know that Los Angeles\r\nhas
+        a Little Sri Lanka?\r\n\r\n317\r\n00:13:26,635 --> 00:13:28,986\r\nI did not.\r\n\r\n318\r\n00:13:28,988
+        --> 00:13:31,004\r\nWell, I do... now.\r\n\r\n319\r\n00:13:31,006 --> 00:13:33,707\r\nThey're
+        a lovely people.\r\n\r\n320\r\n00:13:33,709 --> 00:13:37,377\r\nAlthough terrifying
+        when you\r\nwake up face-to-face with them.\r\n\r\n321\r\n00:13:38,379 -->
+        00:13:39,646\r\nIf you're hungry, I brought home\r\n\r\n322\r\n00:13:39,648
+        --> 00:13:41,632\r\nsome mutton and coconut milk.\r\n\r\n323\r\n00:13:41,634
+        --> 00:13:43,617\r\nWhy'd you get that?\r\nYou hate lamb.\r\n\r\n324\r\n00:13:43,619
+        --> 00:13:45,686\r\nI was asking for directions.\r\n\r\n325\r\n00:13:45,688
+        --> 00:13:49,206\r\nApparently, there was\r\na communication problem.\r\n\r\n326\r\n00:13:49,208
+        --> 00:13:52,326\r\nI thought Amy was gonna\r\ndrive you home.\r\n\r\n327\r\n00:13:52,328
+        --> 00:13:53,610\r\nYeah, I thought so, too,\r\n\r\n328\r\n00:13:53,612 -->
+        00:13:55,779\r\nbut she's acting very strangely.\r\n\r\n329\r\n00:13:55,781
+        --> 00:13:58,782\r\nI was discussing it with\r\na Sri Lankan fellow on the
+        bus,\r\n\r\n330\r\n00:13:58,784 --> 00:14:01,869\r\nand he hypothesized\r\nthat
+        a tiger may have\r\n\r\n331\r\n00:14:01,871 --> 00:14:04,054\r\nrecently run
+        across her shadow.\r\n\r\n332\r\n00:14:05,907 --> 00:14:08,342\r\nAlthough
+        he may have just been\r\ntrying to drum up business\r\n\r\n333\r\n00:14:08,344
+        --> 00:14:11,345\r\nfor his brother-in-law's\r\nwitch doctor practice.\r\n\r\n334\r\n00:14:14,265
+        --> 00:14:16,834\r\nOkay, Sheldon, what happened\r\nbetween you and Amy?\r\n\r\n335\r\n00:14:16,836
+        --> 00:14:20,571\r\nWell, can you believe\r\nshe said I embarrassed her?\r\n\r\n336\r\n00:14:20,573
+        --> 00:14:22,656\r\nYeah.\r\n\r\n337\r\n00:14:22,658 --> 00:14:25,442\r\nBut
+        you didn't\r\neven hear the details.\r\n\r\n338\r\n00:14:25,444 --> 00:14:27,477\r\nSheldon...\r\n\r\n339\r\n00:14:29,247
+        --> 00:14:31,865\r\nI've known you\r\na long time,\r\n\r\n340\r\n00:14:31,867
+        --> 00:14:33,283\r\nand I'm going\r\nto tell you this\r\n\r\n341\r\n00:14:33,285
+        --> 00:14:37,154\r\nwith all the love\r\nI can possibly muster.\r\n\r\n342\r\n00:14:37,156
+        --> 00:14:38,155\r\nAmy's right.\r\n\r\n343\r\n00:14:38,157 --> 00:14:39,606\r\nYou're
+        wrong.\r\n\r\n344\r\n00:14:40,458 --> 00:14:41,658\r\nBut you don't even know...\r\n\r\n345\r\n00:14:41,660
+        --> 00:14:43,076\r\nDoesn't matter.\r\n\r\n346\r\n00:14:43,078 --> 00:14:45,696\r\nBut,
+        now, but in my defense...\r\nDoesn't matter.\r\n\r\n347\r\n00:14:45,698 -->
+        00:14:47,931\r\nYou're not listening\r\nto my side of it.\r\n\r\n348\r\n00:14:47,933
+        --> 00:14:50,267\r\nOkay, fine, Sheldon.\r\nWhat is your side?\r\n\r\n349\r\n00:14:50,269
+        --> 00:14:52,285\r\nWell...\r\n\r\n350\r\n00:14:52,287 --> 00:14:54,788\r\nNope,
+        got to go with\r\nAmy on this one.\r\n\r\n351\r\n00:14:59,260 --> 00:15:00,627\r\n(groans)\r\n\r\n352\r\n00:15:00,629
+        --> 00:15:01,678\r\nShrimp was spicy.\r\n\r\n353\r\n00:15:01,680 --> 00:15:03,113\r\nYou
+        want a TUMS?\r\n\r\n354\r\n00:15:03,115 --> 00:15:04,431\r\nYou got\r\nthe
+        tropical fruit kind?\r\n\r\n355\r\n00:15:04,433 --> 00:15:06,950\r\nNo, if
+        I buy those, I just\r\ngo through them like candy.\r\n\r\n356\r\n00:15:06,952
+        --> 00:15:08,385\r\nTell me about it.\r\n\r\n357\r\n00:15:08,387 --> 00:15:11,104\r\nOne
+        time, I swear\r\nI pooped out a stick of chalk.\r\n\r\n358\r\n00:15:11,940
+        --> 00:15:13,139\r\n(knocking)\r\n\r\n359\r\n00:15:13,141 --> 00:15:15,359\r\nI'll
+        get it.\r\nThanks.\r\n\r\n360\r\n00:15:17,278 --> 00:15:18,362\r\nHi.\r\n\r\n361\r\n00:15:18,364
+        --> 00:15:19,529\r\nOh, hi.\r\n\r\n362\r\n00:15:19,531 --> 00:15:21,698\r\nI
+        may have overreacted.\r\n\r\n363\r\n00:15:21,700 --> 00:15:25,619\r\nYeah,
+        well, I didn't\r\nhandle it so great, either.\r\n\r\n364\r\n00:15:25,621 -->
+        00:15:28,038\r\nIt's just sometimes I feel\r\nlike you enjoy spending time\r\n\r\n365\r\n00:15:28,040
+        --> 00:15:30,090\r\nwith your friends\r\nmore than with me.\r\n\r\n366\r\n00:15:30,092
+        --> 00:15:31,909\r\nThat's not true.\r\nIt's not?\r\n\r\n367\r\n00:15:31,911
+        --> 00:15:33,594\r\nYou spend all day\r\ntogether at work,\r\n\r\n368\r\n00:15:33,596
+        --> 00:15:35,712\r\nand then you all hang out\r\nat night playing games,\r\n\r\n369\r\n00:15:35,714
+        --> 00:15:37,230\r\ngoing to the comic book store.\r\n\r\n370\r\n00:15:37,232
+        --> 00:15:39,850\r\nLast week, you two got\r\na couples massage.\r\n\r\n371\r\n00:15:42,487
+        --> 00:15:45,055\r\nSo, when you said you wouldn't\r\nwant to spend that much
+        time\r\n\r\n372\r\n00:15:45,057 --> 00:15:48,025\r\nwith me, it really\r\nhurt
+        my feelings.\r\n\r\n373\r\n00:15:48,027 --> 00:15:49,643\r\nOh, wow.\r\n\r\n374\r\n00:15:49,645
+        --> 00:15:50,978\r\nYeah, no, I get that.\r\n\r\n375\r\n00:15:50,980 --> 00:15:52,112\r\nI'm
+        so sorry.\r\n\r\n376\r\n00:15:52,114 --> 00:15:54,865\r\nStarting tomorrow,
+        I am\r\nturning over a new leaf.\r\n\r\n377\r\n00:15:54,867 --> 00:15:57,985\r\nTime
+        with you is my\r\nnumber one priority.\r\n\r\n378\r\n00:15:57,987 --> 00:15:59,987\r\n(chuckles)\r\n\r\n379\r\n00:15:59,989
+        --> 00:16:01,688\r\nWhy tomorrow?\r\n\r\n380\r\n00:16:03,190 --> 00:16:05,509\r\nWell,
+        we're real close\r\nto finishing off\r\n\r\n381\r\n00:16:05,511 --> 00:16:07,377\r\nthe
+        new Batman game.\r\n\r\n382\r\n00:16:08,513 --> 00:16:11,665\r\nIt is awesome.\r\n\r\n383\r\n00:16:13,968
+        --> 00:16:16,003\r\nUh, you should probably\r\ngo after her.\r\n\r\n384\r\n00:16:16,005
+        --> 00:16:17,754\r\nShould I go after you?\r\n\r\n385\r\n00:16:17,756 -->
+        00:16:19,923\r\nNo!\r\n\r\n386\r\n00:16:21,592 --> 00:16:24,094\r\nThanks
+        for getting me\r\nin trouble.\r\n\r\n387\r\n00:16:26,898 --> 00:16:28,265\r\nAmy.\r\n\r\n388\r\n00:16:29,067
+        --> 00:16:30,283\r\nAmy.\r\n\r\n389\r\n00:16:31,069 --> 00:16:33,103\r\nAmy.\r\n\r\n390\r\n00:16:34,722
+        --> 00:16:37,324\r\nSheldon, what are you\r\ndoing here so late?\r\n\r\n391\r\n00:16:37,326
+        --> 00:16:39,192\r\nI couldn't sleep\r\nbecause I kept thinking\r\n\r\n392\r\n00:16:39,194
+        --> 00:16:41,445\r\nabout what happened\r\nearlier between us.\r\n\r\n393\r\n00:16:42,246
+        --> 00:16:45,615\r\nAlso, I had one heck\r\nof a bus nap.\r\n\r\n394\r\n00:16:46,751
+        --> 00:16:47,901\r\nOh, speaking of which,\r\n\r\n395\r\n00:16:47,903 -->
+        00:16:50,787\r\ndo you want some mutton\r\nand coconut milk?\r\n\r\n396\r\n00:16:50,789
+        --> 00:16:51,855\r\nNo.\r\n\r\n397\r\n00:16:51,857 --> 00:16:54,624\r\nWell,
+        I cannot give\r\nthis stuff away.\r\n\r\n398\r\n00:16:54,626 --> 00:16:57,077\r\nWhat
+        do you want?\r\n\r\n399\r\n00:16:57,079 --> 00:17:00,647\r\nAmy, this isn't
+        easy to say.\r\n\r\n400\r\n00:17:01,766 --> 00:17:04,751\r\nAll relationships
+        are difficult,\r\n\r\n401\r\n00:17:04,753 --> 00:17:07,688\r\nbut even more
+        so\r\nwhen you're in one\r\n\r\n402\r\n00:17:07,690 --> 00:17:09,523\r\nwith
+        a person who struggles\r\n\r\n403\r\n00:17:09,525 --> 00:17:11,858\r\nwith
+        everyday\r\nsocial interactions.\r\n\r\n404\r\n00:17:11,860 --> 00:17:13,527\r\nAnd
+        frankly...\r\n\r\n405\r\n00:17:13,529 --> 00:17:15,145\r\nwho can strike some
+        people\r\n\r\n406\r\n00:17:15,147 --> 00:17:17,664\r\nas being kind of a weirdo.\r\n\r\n407\r\n00:17:17,666
+        --> 00:17:19,649\r\nSheldon...\r\n\r\n408\r\n00:17:19,651 --> 00:17:21,651\r\nyou're
+        not a weirdo.\r\n\r\n409\r\n00:17:21,653 --> 00:17:24,271\r\nI wasn't speaking
+        about me.\r\n\r\n410\r\n00:17:26,307 --> 00:17:28,441\r\nI mean, honestly,\r\nthere's
+        no telling\r\n\r\n411\r\n00:17:28,443 --> 00:17:30,077\r\nwhat will set you
+        off.\r\n\r\n412\r\n00:17:30,079 --> 00:17:32,295\r\nYou know, introducing\r\nmyself
+        as your boyfriend.\r\n\r\n413\r\n00:17:32,297 --> 00:17:35,549\r\nGiving you
+        the opportunity\r\nto drive me home.\r\n\r\n414\r\n00:17:35,551 --> 00:17:37,617\r\nBreaking
+        the ice\r\nwith your colleagues\r\n\r\n415\r\n00:17:37,619 --> 00:17:40,787\r\nusing
+        ethnic humor,\r\nthe funniest kind of humor.\r\n\r\n416\r\n00:17:42,557 -->
+        00:17:44,224\r\nWhat's your point?\r\n\r\n417\r\n00:17:44,226 --> 00:17:46,626\r\nMy
+        point is, we're a couple.\r\n\r\n418\r\n00:17:46,628 --> 00:17:48,361\r\nAnd...\r\n\r\n419\r\n00:17:48,363
+        --> 00:17:50,480\r\nI like you for who you are.\r\n\r\n420\r\n00:17:50,482
+        --> 00:17:52,365\r\nQuirks and all.\r\n\r\n421\r\n00:17:54,102 --> 00:17:55,652\r\nI
+        like you, too.\r\n\r\n422\r\n00:17:55,654 --> 00:17:58,188\r\nWell, I should
+        hope so.\r\n\r\n423\r\n00:17:58,190 --> 00:18:00,323\r\nI don't see anyone
+        else\r\nbanging on this door\r\n\r\n424\r\n00:18:00,325 --> 00:18:02,826\r\nto
+        put up with your nonsense.\r\n\r\n425\r\n00:18:06,981 --> 00:18:09,583\r\nNot
+        even a good-bye?\r\n\r\n426\r\n00:18:09,585 --> 00:18:11,084\r\nYou see,\r\nthat's
+        the kind of thing\r\n\r\n427\r\n00:18:11,086 --> 00:18:13,620\r\nthat makes
+        people\r\nthink you're weird.\r\n\r\n428\r\n00:18:13,622 --> 00:18:15,422\r\nPoor
+        kid.\r\n\r\n429\r\n00:18:15,424 --> 00:18:17,507\r\nShe just doesn't see it.\r\n\r\n430\r\n00:18:27,608
+        --> 00:18:28,691\r\nI'm not apologizing\r\nto Howard.\r\n\r\n431\r\n00:18:28,693
+        --> 00:18:30,342\r\nHe can come beg me\r\non his knees.\r\n\r\n432\r\n00:18:30,344
+        --> 00:18:31,694\r\nSheldon, too.\r\n\r\n433\r\n00:18:31,696 --> 00:18:34,196\r\nIf
+        I see him at work,\r\nI'm just going to ignore him.\r\n\r\n434\r\n00:18:34,198
+        --> 00:18:36,032\r\nAll right, don't worry.\r\nI talked to Leonard.\r\n\r\n435\r\n00:18:36,034
+        --> 00:18:38,801\r\nHe is gonna sit the guys down\r\nand set them straight.\r\n\r\n436\r\n00:18:38,803
+        --> 00:18:40,820\r\nLaser's warmed up.\r\n\r\n437\r\n00:18:40,896 --> 00:18:41,928\r\nPull!\r\n\r\n438\r\n00:18:43,006
+        --> 00:18:44,272\r\n(all cheering)\r\n\r\n439\r\n00:18:44,274 --> 00:18:49,274\r\n==
+        sync, corrected by <font color=#00FF00>elderman</font> ==\r\n<font color=#00FFFF>@elder_man</font>\r\n\r\n"
+    headers:
+      CF-Cache-Status:
+      - HIT
+      CF-RAY:
+      - 8d2b0a70adf252b8-LHR
+      Cache-Control:
+      - public, max-age=691200
+      Connection:
+      - keep-alive
+      Content-Type:
+      - text/srt
+      Date:
+      - Mon, 14 Oct 2024 22:35:08 GMT
+      NEL:
+      - '{"success_fraction":0,"report_to":"cf-nel","max_age":604800}'
+      Report-To:
+      - '{"endpoints":[{"url":"https:\/\/a.nel.cloudflare.com\/report\/v4?s=YZdricHqUhH4IISB3i3INghi%2BJ8losCppMgVsGEjPYl8uBhdgMBAO0uwvAX98X1U3%2Bnu2XP%2BbemANRahi1kqj0MHT9U5WLetrIlUTZ8eQtnwqcl9c70h0%2BbcLQzY2q1wtwU2Rw%3D%3D"}],"group":"cf-nel","max_age":604800}'
+      Server:
+      - cloudflare
+      Strict-Transport-Security:
+      - max-age=15552000; includeSubDomains; preload
+      Transfer-Encoding:
+      - chunked
+      X-Content-Type-Options:
+      - nosniff
+      alt-svc:
+      - h3=":443"; ma=86400
+      content-disposition:
+      - attachment; filename=The.Big.Bang.Theory.S07E05.DIMENSION.en.hi.srt; filename*=UTF-8''The.Big.Bang.Theory.S07E05.DIMENSION.en.hi.srt
+      etag:
+      - W/"a245f3f1-920f-41f5-b9af-876a633cc8dd-637972328340612500"
+      last-modified:
+      - Sat, 27 Aug 2022 21:33:54 GMT
+      vary:
+      - Accept-Encoding
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/providers/test_providers.py
+++ b/tests/providers/test_providers.py
@@ -348,22 +348,32 @@ def test_list_subtitles_providers_download(episodes):
     languages = {Language('eng')}
 
     # modify global variable
-    if 'gestdown' not in disabled_providers:
-        disabled_providers.append('gestdown')
+    try:
+        if 'gestdown' not in disabled_providers:
+            disabled_providers.append('gestdown')
 
-    # force using 'gestdown', bypass default when init ProviderPool
-    subtitles = list_subtitles({video}, languages, providers=['gestdown'])
+        # no subtitles from 'gestdown'
+        subtitles = list_subtitles({video}, languages)
+        assert not any(sub.provider_name == 'gestdown' for sub in subtitles[video])
 
-    # test result
-    assert len(subtitles) == 1
-    assert len(subtitles[video]) > 0
-    subtitle = subtitles[video][0]
-    assert subtitle.content is None
+        # force using 'gestdown', bypass default when init ProviderPool
+        subtitles = list_subtitles({video}, languages, providers=['gestdown'])
 
-    # download subtitles
-    download_subtitles(subtitles[video][:1])
-    assert subtitle.content is not None
+        # test result
+        assert len(subtitles) == 1
+        assert len(subtitles[video]) > 0
+        subtitle = subtitles[video][0]
+        assert subtitle.provider_name == 'gestdown'
+        assert subtitle.content is None
 
-    # reset global variable
-    if 'gestdown' in disabled_providers:
-        disabled_providers.remove('gestdown')
+        # download subtitles
+        download_subtitles([subtitle], providers=['gestdown'])
+        assert subtitle.content is not None
+
+        # force using 'gestdown', bypass default when init ProviderPool
+        subtitles = list_subtitles({video}, languages, providers=['gestdown'])
+
+    finally:
+        # reset global variable
+        if 'gestdown' in disabled_providers:
+            disabled_providers.remove('gestdown')

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -10,10 +10,10 @@ import pytest
 from subliminal.extensions import (
     EntryPoint,
     RegistrableExtensionManager,
-    default_providers,
-    default_refiners,
     disabled_providers,
     disabled_refiners,
+    get_default_providers,
+    get_default_refiners,
     parse_entry_point,
     provider_manager,
     refiner_manager,
@@ -115,7 +115,7 @@ def test_provider_manager():
     internal_names = {
         parse_entry_point(iep, provider_manager.namespace).name for iep in provider_manager.internal_extensions
     }
-    enabled_names = set(default_providers)
+    enabled_names = set(get_default_providers())
     disabled_names = set(disabled_providers)
     assert enabled_names == setup_names - disabled_names
     assert internal_names == enabled_names | disabled_names
@@ -126,7 +126,7 @@ def test_refiner_manager():
     internal_names = {
         parse_entry_point(iep, refiner_manager.namespace).name for iep in refiner_manager.internal_extensions
     }
-    enabled_names = set(default_refiners)
+    enabled_names = set(get_default_refiners())
     disabled_names = set(disabled_refiners)
     assert enabled_names == setup_names - disabled_names
     assert internal_names == enabled_names | disabled_names


### PR DESCRIPTION
Remove 'addic7ed' and 'napiprojekt' from the list of disabled providers.

Fix a bug happening when using `subliminal` as a library for scripting and a new provider is defined.
You needed to add the new provider to the `default_provider` list to be able to download subtitles easily.

```python
>>> class MyProvider(Provider): pass
>>> provider_manager.register('myprovider = __main__.MyProvider')
>>> subtitles = list_subtitles([video], {Language('hun')}, providers=['myprovider'])
# a list of subtitles from myprovider matching the video.
>>> download_subtitles(subtitles)
# nothing happened, because myprovider is not in the default list. You needed to use:
>>> download_subtitles(subtitles, providers=['myprovider'])
# subtitles are downloaded
# with this PR, no need to add the 'providers' argument to 'download_subtitles'
```

Now the  `default_provider` list is computed dynamically.
This was not affecting the CLI.
