### PR TITLE
Improve security of github actions

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -19,12 +19,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - run: pipx run check-manifest
+        with:
+          persist-credentials: false
+      - run: pipx run check-manifest --ignore "_version.py"
 
   pre-commit:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v5
         with:
           python-version-file: .python-version-default
@@ -36,6 +40,8 @@ jobs:
       contents: read
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v5
         with:
           python-version-file: .python-version-default
@@ -49,6 +55,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v5
         with:
           # Keep in sync with tox/docs and .readthedocs.yaml.
@@ -71,6 +79,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v5
         with:
           python-version-file: .python-version-default
@@ -88,6 +98,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          persist-credentials: false
           fetch-depth: 0
 
       - uses: hynek/build-and-inspect-python-package@v2
@@ -110,6 +121,8 @@ jobs:
         python-version: ${{ fromJson(needs.build-package.outputs.supported-python-versions) }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
@@ -144,6 +157,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v5
         with:
           python-version-file: .python-version-default

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -8,8 +8,10 @@ on:
     types:
       - published
 
-permissions:
-  contents: read
+env:
+  FORCE_COLOR: "1"
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+  PIP_NO_PYTHON_VERSION_WARNING: "1"
 
 # https://packaging.python.org/en/latest/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/
 jobs:
@@ -17,6 +19,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
@@ -39,7 +43,8 @@ jobs:
     permissions:
       id-token: write
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/')  # only publish to PyPI on tag pushes
+    # only publish to PyPI on tag pushes
+    if: startsWith(github.ref, 'refs/tags/')
     steps:
       - uses: actions/download-artifact@v4
         with:
@@ -47,9 +52,6 @@ jobs:
           path: dist
       - name: Publish package
         uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          user: __token__
-          password: ${{ secrets.PYPI_API_TOKEN }}
 
   github-release:
     name: >-
@@ -77,19 +79,21 @@ jobs:
     - name: Create GitHub Release Draft
       env:
         GITHUB_TOKEN: ${{ github.token }}
+        VERSION: ${{ github.ref_name }}
       run: >-
         gh release create
-        '${{ github.ref_name }}'
+        '${VERSION}'
         --repo '${{ github.repository }}'
         --generate-notes
         --notes ""
     - name: Upload artifact signatures to GitHub Release
       env:
         GITHUB_TOKEN: ${{ github.token }}
+        VERSION: ${{ github.ref_name }}
       # Upload to GitHub Release using the `gh` CLI.
       # `dist/` contains the built packages, and the
       # sigstore-produced signatures and certificates.
       run: >-
         gh release upload
-        '${{ github.ref_name }}' dist/**
+        '${VERSION}' dist/**
         --repo '${{ github.repository }}'

--- a/.github/workflows/scheduled-tests.yaml
+++ b/.github/workflows/scheduled-tests.yaml
@@ -1,27 +1,37 @@
-name: Test-APIs
+name: Scheduled Tests
 
 on:
   schedule:
     - cron: "12 12 12 * *" # run once a month on the 12th at 12:12
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  FORCE_COLOR: "1"
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+  PIP_NO_PYTHON_VERSION_WARNING: "1"
+
 jobs:
   test-api:
-    name: Test APIs
-    if: github.repository == 'Diaoul/subliminal' && github.event_name == 'schedule'
+    name: Run tests with deleted requests cassettes
+    if: |
+      (github.repository == 'Diaoul/subliminal' && github.event_name == 'schedule')
+      || github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
       - uses: actions/setup-python@v5
         with:
           python-version: "3.x"
       - name: install
         run: |
-          python -m pip install -U pip
-          python -m pip install -e ".[test]"
+          python -Im pip install -U pip
+          python -Im pip install -e ".[tests]"
       - name: remove cassettes
         run: |
           rm -rf tests/cassettes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,7 +82,7 @@ Change into the newly created directory and after activating a virtual environme
 ```console
 $ cd subliminal
 $ python -m pip install --upgrade pip wheel  # PLEASE don't skip this step
-$ python -m pip install -e '.[docs,test,dev]'  # you can omit `docs` if you are not planning to build docs
+$ python -m pip install -e '.[docs,types,tests,dev]'  # you can omit `docs` if you are not planning to build docs
 ```
 
 At this point,

--- a/README.rst
+++ b/README.rst
@@ -89,7 +89,7 @@ clone your fork locally and install a development version::
 
     $ git clone https://github.com/<my-username>/subliminal
     $ cd subliminal
-    $ pip install --user -e '.[dev,test,docs]'
+    $ pip install --user -e '.[docs,types,tests,dev]'
 
 
 Integrations

--- a/changelog.d/1190.change.rst
+++ b/changelog.d/1190.change.rst
@@ -1,0 +1,2 @@
+Rename optional dependency test -> tests.
+Improve security of github actions using woodruffw/zizmor.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -62,11 +62,8 @@ docs = [
     "sphinx_autodoc_typehints",
     "towncrier",
 ]
-test = [
+tests = [
     "coverage[toml]>=7",
-    "mypy",
-    "types-requests",
-    "types-beautifulsoup4",
     "pytest>=6.0",
     "pytest-cov",
     "pytest-xdist",
@@ -74,8 +71,13 @@ test = [
     "vcrpy>=5",
     "importlib_metadata>=4.6; python_version<'3.10'",
 ]
+types = [
+    "mypy",
+    "types-requests",
+    "types-beautifulsoup4",
+]
 dev = [
-    "pre-commit",
+    "pre-commit>=2.9.3",
     "doc8",
     "mypy",
     "ruff",

--- a/tox.ini
+++ b/tox.ini
@@ -37,7 +37,9 @@ commands = {[testenv:tests]commands}
 
 
 [testenv:mypy]
-extras = types
+extras =
+    types
+    tests
 commands = mypy --install-types --non-interactive {posargs:subliminal tests}
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,7 @@ pass_env = SETUPTOOLS_SCM_PRETEND_VERSION
 [testenv]
 package = wheel
 wheel_build_env = .pkg
-extras = test
+extras = tests
 pass_env =
     COVERAGE_FILE
 allowlist_externals =

--- a/tox.ini
+++ b/tox.ini
@@ -37,6 +37,7 @@ commands = {[testenv:tests]commands}
 
 
 [testenv:mypy]
+extras = types
 commands = mypy --install-types --non-interactive {posargs:subliminal tests}
 
 


### PR DESCRIPTION
* improve security of github actions using [zizmor](https://github.com/woodruffw/zizmor)
* rename optional dependency `test` -> `tests`
* add optional dependency `types`
* allow triggering the Github `scheduled-tests` workflow manually

Split from #1188 