### PR TITLE
Feature: Add __main__.py for using with python -m

### DIFF
--- a/src/subliminal/__main__.py
+++ b/src/subliminal/__main__.py
@@ -1,0 +1,20 @@
+from __future__ import annotations
+
+if len(__package__) == 0:
+    import sys
+
+    print(
+        f"""
+
+The '__main__' module does not seem to have been run in the context of a
+runnable package ... did you forget to add the '-m' flag?
+
+Usage: {sys.executable} -m subliminal {' '.join(sys.argv[1:])}
+
+"""
+    )
+    sys.exit(2)
+
+from subliminal.cli import cli
+
+cli()


### PR DESCRIPTION
This allows easily run the program from source tree after installing dependencies:

```
$ pip install -e .
$ python -m subliminal --help
```