### PR TITLE
Reverse to using cassette for doctest

### DIFF
--- a/changelog.d/1185.change.rst
+++ b/changelog.d/1185.change.rst
@@ -1,1 +1,2 @@
-Add a mock provider to use in doctest. Re-enable doctest
+Add a mock provider.
+Fix doctest.

--- a/docs/cassettes/test_usage.yaml
+++ b/docs/cassettes/test_usage.yaml
@@ -2,84 +2,95 @@ interactions:
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [Subliminal/2.1]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - Subliminal/2.2
     method: GET
     uri: https://www.podnapisi.net/subtitles/search/advanced?keywords=The+Big+Bang+Theory&language=hu&seasons=5&episodes=18&movie_type=tv-series&movie_type=mini-series
   response:
-    body: {string: "{\n  \"all_pages\": 1, \n  \"data\": [\n    {\n      \"audited\"\
-        : true, \n      \"contributions\": [\n        {\n          \"contributor\"\
-        : {\n            \"id\": 40156, \n            \"name\": \"kvrle\", \n    \
-        \        \"type\": \"user\"\n          }, \n          \"role\": \"uploader\"\
-        , \n          \"share\": 0.0\n        }\n      ], \n      \"contributor\"\
-        : {\n        \"id\": 40156, \n        \"name\": \"kvrle\", \n        \"type\"\
-        : \"user\"\n      }, \n      \"created\": \"2012-02-26T00:42:49+00:00\", \n\
-        \      \"custom_releases\": [\n        \"The.Big.Bang.Theory.S05E18.HDTV-LOL\"\
-        , \n        \"The.Big.Bang.Theory.S05E18.720p.HDTV.x264-DIMENSION\"\n    \
-        \  ], \n      \"download\": \"/en/subtitles/hu-the-big-bang-theory-2007-S05E18-O/ZtAW/download\"\
-        , \n      \"flags\": [\n        \"high_definition\"\n      ], \n      \"fps\"\
-        : \"23.976\", \n      \"id\": \"ZtAW\", \n      \"language\": \"hu\", \n \
-        \     \"movie\": {\n        \"aliases\": [\n          \"Veliki pokovci\"\n\
-        \        ], \n        \"episode_info\": {\n          \"episode\": 18, \n \
-        \         \"id\": null, \n          \"season\": 5, \n          \"slug\": \"\
-        S05E18-O\", \n          \"title\": \"\", \n          \"type\": \"ordinary\"\
-        , \n          \"year\": null\n        }, \n        \"id\": \"uJE\", \n   \
-        \     \"posters\": {\n          \"inline\": \"/thumbnails/moviedb/inline/2c/9c/f5/c9/ae/30/0df660438f29fcf6bef8/uJE.jpg\"\
-        , \n          \"normal\": \"/thumbnails/moviedb/normal/2c/9c/f5/c9/ae/30/0df660438f29fcf6bef8/uJE.jpg\"\
-        , \n          \"small\": \"/thumbnails/moviedb/small/2c/9c/f5/c9/ae/30/0df660438f29fcf6bef8/uJE.jpg\"\
-        , \n          \"title\": \"/thumbnails/moviedb/title/2c/9c/f5/c9/ae/30/0df660438f29fcf6bef8/uJE.jpg\"\
-        \n        }, \n        \"providers\": [\n          \"omdb:sY0G\"\n       \
-        \ ], \n        \"slug\": \"the-big-bang-theory-2007-S05E18-O\", \n       \
-        \ \"title\": \"The Big Bang Theory\", \n        \"type\": \"tv-series\", \n\
-        \        \"year\": 2007\n      }, \n      \"notes\": \"\", \n      \"num_cds\"\
-        : 1, \n      \"rejected\": null, \n      \"releases\": [], \n      \"state\"\
-        : \"migration\", \n      \"stats\": {\n        \"downloads\": 4118, \n   \
-        \     \"lines\": 323\n      }, \n      \"url\": \"/en/subtitles/hu-the-big-bang-theory-2007-S05E18-O/ZtAW\"\
-        \n    }, \n    {\n      \"audited\": false, \n      \"contributions\": [\n\
-        \        {\n          \"contributor\": {\n            \"id\": 1, \n      \
-        \      \"name\": \"Anonymous\", \n            \"type\": \"user\"\n       \
-        \   }, \n          \"role\": \"uploader\", \n          \"share\": 0.0\n  \
-        \      }\n      ], \n      \"contributor\": {\n        \"id\": 1, \n     \
-        \   \"name\": \"Anonymous\", \n        \"type\": \"user\"\n      }, \n   \
-        \   \"created\": \"2012-02-25T02:49:35+00:00\", \n      \"custom_releases\"\
-        : [\n        \"The.Big.Bang.Theory.S05E18.HDTV.XviD-FQM\"\n      ], \n   \
-        \   \"download\": \"/en/subtitles/hu-the-big-bang-theory-2007-S05E18-O/ONAW/download\"\
-        , \n      \"flags\": [], \n      \"fps\": \"\", \n      \"id\": \"ONAW\",\
-        \ \n      \"language\": \"hu\", \n      \"movie\": {\n        \"aliases\"\
-        : [\n          \"Veliki pokovci\"\n        ], \n        \"episode_info\":\
-        \ {\n          \"episode\": 18, \n          \"id\": null, \n          \"season\"\
-        : 5, \n          \"slug\": \"S05E18-O\", \n          \"title\": \"\", \n \
-        \         \"type\": \"ordinary\", \n          \"year\": null\n        }, \n\
-        \        \"id\": \"uJE\", \n        \"posters\": {\n          \"inline\":\
-        \ \"/thumbnails/moviedb/inline/2c/9c/f5/c9/ae/30/0df660438f29fcf6bef8/uJE.jpg\"\
-        , \n          \"normal\": \"/thumbnails/moviedb/normal/2c/9c/f5/c9/ae/30/0df660438f29fcf6bef8/uJE.jpg\"\
-        , \n          \"small\": \"/thumbnails/moviedb/small/2c/9c/f5/c9/ae/30/0df660438f29fcf6bef8/uJE.jpg\"\
-        , \n          \"title\": \"/thumbnails/moviedb/title/2c/9c/f5/c9/ae/30/0df660438f29fcf6bef8/uJE.jpg\"\
-        \n        }, \n        \"providers\": [\n          \"omdb:sY0G\"\n       \
-        \ ], \n        \"slug\": \"the-big-bang-theory-2007-S05E18-O\", \n       \
-        \ \"title\": \"The Big Bang Theory\", \n        \"type\": \"tv-series\", \n\
-        \        \"year\": 2007\n      }, \n      \"notes\": null, \n      \"num_cds\"\
-        : 1, \n      \"rejected\": null, \n      \"releases\": [], \n      \"state\"\
-        : \"migration\", \n      \"stats\": {\n        \"downloads\": 421, \n    \
-        \    \"lines\": 323\n      }, \n      \"url\": \"/en/subtitles/hu-the-big-bang-theory-2007-S05E18-O/ONAW\"\
-        \n    }\n  ], \n  \"page\": 1, \n  \"per_page\": 50, \n  \"status\": \"ok\"\
-        \n}"}
+    body:
+      string: "{\n  \"all_pages\": 1, \n  \"data\": [\n    {\n      \"audited\": true,
+        \n      \"contributions\": [\n        {\n          \"contributor\": {\n            \"id\":
+        40156, \n            \"name\": \"kvrle\", \n            \"type\": \"user\"\n
+        \         }, \n          \"role\": \"uploader\", \n          \"share\": 0.0\n
+        \       }\n      ], \n      \"contributor\": {\n        \"id\": 40156, \n
+        \       \"name\": \"kvrle\", \n        \"type\": \"user\"\n      }, \n      \"created\":
+        \"2012-02-26T00:42:49+00:00\", \n      \"custom_releases\": [\n        \"The.Big.Bang.Theory.S05E18.HDTV-LOL\",
+        \n        \"The.Big.Bang.Theory.S05E18.720p.HDTV.x264-DIMENSION\"\n      ],
+        \n      \"download\": \"/en/subtitles/hu-the-big-bang-theory-2007-S05E18-O/ZtAW/download\",
+        \n      \"flags\": [\n        \"high_definition\"\n      ], \n      \"fps\":
+        \"23.976\", \n      \"id\": \"ZtAW\", \n      \"language\": \"hu\", \n      \"movie\":
+        {\n        \"aliases\": [\n          \"Veliki pokovci\"\n        ], \n        \"episode_info\":
+        {\n          \"episode\": 18, \n          \"id\": null, \n          \"season\":
+        5, \n          \"slug\": \"S05E18-O\", \n          \"title\": \"\", \n          \"type\":
+        \"ordinary\", \n          \"year\": null\n        }, \n        \"id\": \"uJE\",
+        \n        \"posters\": {\n          \"inline\": \"/thumbnails/moviedb/inline/2c/9c/f5/c9/ae/30/0df660438f29fcf6bef8/uJE.jpg\",
+        \n          \"normal\": \"/thumbnails/moviedb/normal/2c/9c/f5/c9/ae/30/0df660438f29fcf6bef8/uJE.jpg\",
+        \n          \"small\": \"/thumbnails/moviedb/small/2c/9c/f5/c9/ae/30/0df660438f29fcf6bef8/uJE.jpg\",
+        \n          \"title\": \"/thumbnails/moviedb/title/2c/9c/f5/c9/ae/30/0df660438f29fcf6bef8/uJE.jpg\"\n
+        \       }, \n        \"providers\": [\n          \"omdb:sY0G\"\n        ],
+        \n        \"slug\": \"the-big-bang-theory-2007-S05E18-O\", \n        \"title\":
+        \"The Big Bang Theory\", \n        \"type\": \"tv-series\", \n        \"year\":
+        2007\n      }, \n      \"notes\": \"\", \n      \"num_cds\": 1, \n      \"rejected\":
+        null, \n      \"releases\": [], \n      \"state\": \"migration\", \n      \"stats\":
+        {\n        \"downloads\": 4431, \n        \"lines\": 323\n      }, \n      \"url\":
+        \"/en/subtitles/hu-the-big-bang-theory-2007-S05E18-O/ZtAW\"\n    }, \n    {\n
+        \     \"audited\": false, \n      \"contributions\": [\n        {\n          \"contributor\":
+        {\n            \"id\": 1, \n            \"name\": \"Anonymous\", \n            \"type\":
+        \"user\"\n          }, \n          \"role\": \"uploader\", \n          \"share\":
+        0.0\n        }\n      ], \n      \"contributor\": {\n        \"id\": 1, \n
+        \       \"name\": \"Anonymous\", \n        \"type\": \"user\"\n      }, \n
+        \     \"created\": \"2012-02-25T02:49:35+00:00\", \n      \"custom_releases\":
+        [\n        \"The.Big.Bang.Theory.S05E18.HDTV.XviD-FQM\"\n      ], \n      \"download\":
+        \"/en/subtitles/hu-the-big-bang-theory-2007-S05E18-O/ONAW/download\", \n      \"flags\":
+        [], \n      \"fps\": \"\", \n      \"id\": \"ONAW\", \n      \"language\":
+        \"hu\", \n      \"movie\": {\n        \"aliases\": [\n          \"Veliki pokovci\"\n
+        \       ], \n        \"episode_info\": {\n          \"episode\": 18, \n          \"id\":
+        null, \n          \"season\": 5, \n          \"slug\": \"S05E18-O\", \n          \"title\":
+        \"\", \n          \"type\": \"ordinary\", \n          \"year\": null\n        },
+        \n        \"id\": \"uJE\", \n        \"posters\": {\n          \"inline\":
+        \"/thumbnails/moviedb/inline/2c/9c/f5/c9/ae/30/0df660438f29fcf6bef8/uJE.jpg\",
+        \n          \"normal\": \"/thumbnails/moviedb/normal/2c/9c/f5/c9/ae/30/0df660438f29fcf6bef8/uJE.jpg\",
+        \n          \"small\": \"/thumbnails/moviedb/small/2c/9c/f5/c9/ae/30/0df660438f29fcf6bef8/uJE.jpg\",
+        \n          \"title\": \"/thumbnails/moviedb/title/2c/9c/f5/c9/ae/30/0df660438f29fcf6bef8/uJE.jpg\"\n
+        \       }, \n        \"providers\": [\n          \"omdb:sY0G\"\n        ],
+        \n        \"slug\": \"the-big-bang-theory-2007-S05E18-O\", \n        \"title\":
+        \"The Big Bang Theory\", \n        \"type\": \"tv-series\", \n        \"year\":
+        2007\n      }, \n      \"notes\": null, \n      \"num_cds\": 1, \n      \"rejected\":
+        null, \n      \"releases\": [], \n      \"state\": \"migration\", \n      \"stats\":
+        {\n        \"downloads\": 426, \n        \"lines\": 323\n      }, \n      \"url\":
+        \"/en/subtitles/hu-the-big-bang-theory-2007-S05E18-O/ONAW\"\n    }\n  ], \n
+        \ \"page\": 1, \n  \"per_page\": 50, \n  \"status\": \"ok\"\n}"
     headers:
-      Connection: [keep-alive]
-      Content-Length: ['3982']
-      Content-Type: [application/json]
-      Date: ['Sun, 24 Feb 2019 11:52:04 GMT']
-      Server: [nginx/1.8.0]
-    status: {code: 200, message: OK}
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '3982'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 06 Jan 2025 20:53:38 GMT
+      Server:
+      - nginx
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [Subliminal/2.1]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - Subliminal/2.2
     method: GET
     uri: https://www.podnapisi.net/subtitles/ZtAW/download?container=zip
   response:
@@ -271,97 +282,119 @@ interactions:
         CllAZeWzQ10oAAAjXwAANwAAAAAAAAAAACAAAAAAAAAAVGhlLkJpZy5CYW5nLlRoZW9yeS5TMDVF
         MTguNzIwcC5IRFRWLlgyNjQtRElNRU5TSU9OLnNydFBLBQYAAAAAAQABAGUAAACyKAAAAAA=
     headers:
-      Accept-Ranges: [bytes]
-      Connection: [keep-alive]
-      Content-Disposition: [attachment; filename="e638ea178f406cb584f48051501e2cb4db4fce1d.zip"]
-      Content-Length: ['10541']
-      Content-Type: [application/octet-stream]
-      Date: ['Sun, 24 Feb 2019 11:52:04 GMT']
-      ETag: ['"4f497ffb-292d"']
-      Last-Modified: ['Sun, 26 Feb 2012 00:42:35 GMT']
-      Server: [nginx/1.8.0]
-    status: {code: 200, message: OK}
+      Accept-Ranges:
+      - bytes
+      Connection:
+      - keep-alive
+      Content-Disposition:
+      - attachment; filename="e638ea178f406cb584f48051501e2cb4db4fce1d.zip"
+      Content-Length:
+      - '10541'
+      Content-Type:
+      - application/octet-stream
+      Date:
+      - Mon, 06 Jan 2025 20:53:38 GMT
+      ETag:
+      - '"4f497ffb-292d"'
+      Last-Modified:
+      - Sun, 26 Feb 2012 00:42:35 GMT
+      Server:
+      - nginx
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [Subliminal/2.1]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - Subliminal/2.2
     method: GET
     uri: https://www.podnapisi.net/subtitles/search/advanced?keywords=The+Big+Bang+Theory&language=hu&seasons=5&episodes=18&movie_type=tv-series&movie_type=mini-series
   response:
-    body: {string: "{\n  \"all_pages\": 1, \n  \"data\": [\n    {\n      \"audited\"\
-        : true, \n      \"contributions\": [\n        {\n          \"contributor\"\
-        : {\n            \"id\": 40156, \n            \"name\": \"kvrle\", \n    \
-        \        \"type\": \"user\"\n          }, \n          \"role\": \"uploader\"\
-        , \n          \"share\": 0.0\n        }\n      ], \n      \"contributor\"\
-        : {\n        \"id\": 40156, \n        \"name\": \"kvrle\", \n        \"type\"\
-        : \"user\"\n      }, \n      \"created\": \"2012-02-26T00:42:49+00:00\", \n\
-        \      \"custom_releases\": [\n        \"The.Big.Bang.Theory.S05E18.HDTV-LOL\"\
-        , \n        \"The.Big.Bang.Theory.S05E18.720p.HDTV.x264-DIMENSION\"\n    \
-        \  ], \n      \"download\": \"/en/subtitles/hu-the-big-bang-theory-2007-S05E18-O/ZtAW/download\"\
-        , \n      \"flags\": [\n        \"high_definition\"\n      ], \n      \"fps\"\
-        : \"23.976\", \n      \"id\": \"ZtAW\", \n      \"language\": \"hu\", \n \
-        \     \"movie\": {\n        \"aliases\": [\n          \"Veliki pokovci\"\n\
-        \        ], \n        \"episode_info\": {\n          \"episode\": 18, \n \
-        \         \"id\": null, \n          \"season\": 5, \n          \"slug\": \"\
-        S05E18-O\", \n          \"title\": \"\", \n          \"type\": \"ordinary\"\
-        , \n          \"year\": null\n        }, \n        \"id\": \"uJE\", \n   \
-        \     \"posters\": {\n          \"inline\": \"/thumbnails/moviedb/inline/2c/9c/f5/c9/ae/30/0df660438f29fcf6bef8/uJE.jpg\"\
-        , \n          \"normal\": \"/thumbnails/moviedb/normal/2c/9c/f5/c9/ae/30/0df660438f29fcf6bef8/uJE.jpg\"\
-        , \n          \"small\": \"/thumbnails/moviedb/small/2c/9c/f5/c9/ae/30/0df660438f29fcf6bef8/uJE.jpg\"\
-        , \n          \"title\": \"/thumbnails/moviedb/title/2c/9c/f5/c9/ae/30/0df660438f29fcf6bef8/uJE.jpg\"\
-        \n        }, \n        \"providers\": [\n          \"omdb:sY0G\"\n       \
-        \ ], \n        \"slug\": \"the-big-bang-theory-2007-S05E18-O\", \n       \
-        \ \"title\": \"The Big Bang Theory\", \n        \"type\": \"tv-series\", \n\
-        \        \"year\": 2007\n      }, \n      \"notes\": \"\", \n      \"num_cds\"\
-        : 1, \n      \"rejected\": null, \n      \"releases\": [], \n      \"state\"\
-        : \"migration\", \n      \"stats\": {\n        \"downloads\": 4118, \n   \
-        \     \"lines\": 323\n      }, \n      \"url\": \"/en/subtitles/hu-the-big-bang-theory-2007-S05E18-O/ZtAW\"\
-        \n    }, \n    {\n      \"audited\": false, \n      \"contributions\": [\n\
-        \        {\n          \"contributor\": {\n            \"id\": 1, \n      \
-        \      \"name\": \"Anonymous\", \n            \"type\": \"user\"\n       \
-        \   }, \n          \"role\": \"uploader\", \n          \"share\": 0.0\n  \
-        \      }\n      ], \n      \"contributor\": {\n        \"id\": 1, \n     \
-        \   \"name\": \"Anonymous\", \n        \"type\": \"user\"\n      }, \n   \
-        \   \"created\": \"2012-02-25T02:49:35+00:00\", \n      \"custom_releases\"\
-        : [\n        \"The.Big.Bang.Theory.S05E18.HDTV.XviD-FQM\"\n      ], \n   \
-        \   \"download\": \"/en/subtitles/hu-the-big-bang-theory-2007-S05E18-O/ONAW/download\"\
-        , \n      \"flags\": [], \n      \"fps\": \"\", \n      \"id\": \"ONAW\",\
-        \ \n      \"language\": \"hu\", \n      \"movie\": {\n        \"aliases\"\
-        : [\n          \"Veliki pokovci\"\n        ], \n        \"episode_info\":\
-        \ {\n          \"episode\": 18, \n          \"id\": null, \n          \"season\"\
-        : 5, \n          \"slug\": \"S05E18-O\", \n          \"title\": \"\", \n \
-        \         \"type\": \"ordinary\", \n          \"year\": null\n        }, \n\
-        \        \"id\": \"uJE\", \n        \"posters\": {\n          \"inline\":\
-        \ \"/thumbnails/moviedb/inline/2c/9c/f5/c9/ae/30/0df660438f29fcf6bef8/uJE.jpg\"\
-        , \n          \"normal\": \"/thumbnails/moviedb/normal/2c/9c/f5/c9/ae/30/0df660438f29fcf6bef8/uJE.jpg\"\
-        , \n          \"small\": \"/thumbnails/moviedb/small/2c/9c/f5/c9/ae/30/0df660438f29fcf6bef8/uJE.jpg\"\
-        , \n          \"title\": \"/thumbnails/moviedb/title/2c/9c/f5/c9/ae/30/0df660438f29fcf6bef8/uJE.jpg\"\
-        \n        }, \n        \"providers\": [\n          \"omdb:sY0G\"\n       \
-        \ ], \n        \"slug\": \"the-big-bang-theory-2007-S05E18-O\", \n       \
-        \ \"title\": \"The Big Bang Theory\", \n        \"type\": \"tv-series\", \n\
-        \        \"year\": 2007\n      }, \n      \"notes\": null, \n      \"num_cds\"\
-        : 1, \n      \"rejected\": null, \n      \"releases\": [], \n      \"state\"\
-        : \"migration\", \n      \"stats\": {\n        \"downloads\": 421, \n    \
-        \    \"lines\": 323\n      }, \n      \"url\": \"/en/subtitles/hu-the-big-bang-theory-2007-S05E18-O/ONAW\"\
-        \n    }\n  ], \n  \"page\": 1, \n  \"per_page\": 50, \n  \"status\": \"ok\"\
-        \n}"}
+    body:
+      string: "{\n  \"all_pages\": 1, \n  \"data\": [\n    {\n      \"audited\": true,
+        \n      \"contributions\": [\n        {\n          \"contributor\": {\n            \"id\":
+        40156, \n            \"name\": \"kvrle\", \n            \"type\": \"user\"\n
+        \         }, \n          \"role\": \"uploader\", \n          \"share\": 0.0\n
+        \       }\n      ], \n      \"contributor\": {\n        \"id\": 40156, \n
+        \       \"name\": \"kvrle\", \n        \"type\": \"user\"\n      }, \n      \"created\":
+        \"2012-02-26T00:42:49+00:00\", \n      \"custom_releases\": [\n        \"The.Big.Bang.Theory.S05E18.HDTV-LOL\",
+        \n        \"The.Big.Bang.Theory.S05E18.720p.HDTV.x264-DIMENSION\"\n      ],
+        \n      \"download\": \"/en/subtitles/hu-the-big-bang-theory-2007-S05E18-O/ZtAW/download\",
+        \n      \"flags\": [\n        \"high_definition\"\n      ], \n      \"fps\":
+        \"23.976\", \n      \"id\": \"ZtAW\", \n      \"language\": \"hu\", \n      \"movie\":
+        {\n        \"aliases\": [\n          \"Veliki pokovci\"\n        ], \n        \"episode_info\":
+        {\n          \"episode\": 18, \n          \"id\": null, \n          \"season\":
+        5, \n          \"slug\": \"S05E18-O\", \n          \"title\": \"\", \n          \"type\":
+        \"ordinary\", \n          \"year\": null\n        }, \n        \"id\": \"uJE\",
+        \n        \"posters\": {\n          \"inline\": \"/thumbnails/moviedb/inline/2c/9c/f5/c9/ae/30/0df660438f29fcf6bef8/uJE.jpg\",
+        \n          \"normal\": \"/thumbnails/moviedb/normal/2c/9c/f5/c9/ae/30/0df660438f29fcf6bef8/uJE.jpg\",
+        \n          \"small\": \"/thumbnails/moviedb/small/2c/9c/f5/c9/ae/30/0df660438f29fcf6bef8/uJE.jpg\",
+        \n          \"title\": \"/thumbnails/moviedb/title/2c/9c/f5/c9/ae/30/0df660438f29fcf6bef8/uJE.jpg\"\n
+        \       }, \n        \"providers\": [\n          \"omdb:sY0G\"\n        ],
+        \n        \"slug\": \"the-big-bang-theory-2007-S05E18-O\", \n        \"title\":
+        \"The Big Bang Theory\", \n        \"type\": \"tv-series\", \n        \"year\":
+        2007\n      }, \n      \"notes\": \"\", \n      \"num_cds\": 1, \n      \"rejected\":
+        null, \n      \"releases\": [], \n      \"state\": \"migration\", \n      \"stats\":
+        {\n        \"downloads\": 4431, \n        \"lines\": 323\n      }, \n      \"url\":
+        \"/en/subtitles/hu-the-big-bang-theory-2007-S05E18-O/ZtAW\"\n    }, \n    {\n
+        \     \"audited\": false, \n      \"contributions\": [\n        {\n          \"contributor\":
+        {\n            \"id\": 1, \n            \"name\": \"Anonymous\", \n            \"type\":
+        \"user\"\n          }, \n          \"role\": \"uploader\", \n          \"share\":
+        0.0\n        }\n      ], \n      \"contributor\": {\n        \"id\": 1, \n
+        \       \"name\": \"Anonymous\", \n        \"type\": \"user\"\n      }, \n
+        \     \"created\": \"2012-02-25T02:49:35+00:00\", \n      \"custom_releases\":
+        [\n        \"The.Big.Bang.Theory.S05E18.HDTV.XviD-FQM\"\n      ], \n      \"download\":
+        \"/en/subtitles/hu-the-big-bang-theory-2007-S05E18-O/ONAW/download\", \n      \"flags\":
+        [], \n      \"fps\": \"\", \n      \"id\": \"ONAW\", \n      \"language\":
+        \"hu\", \n      \"movie\": {\n        \"aliases\": [\n          \"Veliki pokovci\"\n
+        \       ], \n        \"episode_info\": {\n          \"episode\": 18, \n          \"id\":
+        null, \n          \"season\": 5, \n          \"slug\": \"S05E18-O\", \n          \"title\":
+        \"\", \n          \"type\": \"ordinary\", \n          \"year\": null\n        },
+        \n        \"id\": \"uJE\", \n        \"posters\": {\n          \"inline\":
+        \"/thumbnails/moviedb/inline/2c/9c/f5/c9/ae/30/0df660438f29fcf6bef8/uJE.jpg\",
+        \n          \"normal\": \"/thumbnails/moviedb/normal/2c/9c/f5/c9/ae/30/0df660438f29fcf6bef8/uJE.jpg\",
+        \n          \"small\": \"/thumbnails/moviedb/small/2c/9c/f5/c9/ae/30/0df660438f29fcf6bef8/uJE.jpg\",
+        \n          \"title\": \"/thumbnails/moviedb/title/2c/9c/f5/c9/ae/30/0df660438f29fcf6bef8/uJE.jpg\"\n
+        \       }, \n        \"providers\": [\n          \"omdb:sY0G\"\n        ],
+        \n        \"slug\": \"the-big-bang-theory-2007-S05E18-O\", \n        \"title\":
+        \"The Big Bang Theory\", \n        \"type\": \"tv-series\", \n        \"year\":
+        2007\n      }, \n      \"notes\": null, \n      \"num_cds\": 1, \n      \"rejected\":
+        null, \n      \"releases\": [], \n      \"state\": \"migration\", \n      \"stats\":
+        {\n        \"downloads\": 426, \n        \"lines\": 323\n      }, \n      \"url\":
+        \"/en/subtitles/hu-the-big-bang-theory-2007-S05E18-O/ONAW\"\n    }\n  ], \n
+        \ \"page\": 1, \n  \"per_page\": 50, \n  \"status\": \"ok\"\n}"
     headers:
-      Connection: [keep-alive]
-      Content-Length: ['3982']
-      Content-Type: [application/json]
-      Date: ['Sun, 24 Feb 2019 11:52:05 GMT']
-      Server: [nginx/1.8.0]
-    status: {code: 200, message: OK}
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '3982'
+      Content-Type:
+      - application/json
+      Date:
+      - Mon, 06 Jan 2025 20:53:39 GMT
+      Server:
+      - nginx
+    status:
+      code: 200
+      message: OK
 - request:
     body: null
     headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [Subliminal/2.1]
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - Subliminal/2.2
     method: GET
     uri: https://www.podnapisi.net/subtitles/ZtAW/download?container=zip
   response:
@@ -553,14 +586,25 @@ interactions:
         CllAZeWzQ10oAAAjXwAANwAAAAAAAAAAACAAAAAAAAAAVGhlLkJpZy5CYW5nLlRoZW9yeS5TMDVF
         MTguNzIwcC5IRFRWLlgyNjQtRElNRU5TSU9OLnNydFBLBQYAAAAAAQABAGUAAACyKAAAAAA=
     headers:
-      Accept-Ranges: [bytes]
-      Connection: [keep-alive]
-      Content-Disposition: [attachment; filename="e638ea178f406cb584f48051501e2cb4db4fce1d.zip"]
-      Content-Length: ['10541']
-      Content-Type: [application/octet-stream]
-      Date: ['Sun, 24 Feb 2019 11:52:05 GMT']
-      ETag: ['"4f497ffb-292d"']
-      Last-Modified: ['Sun, 26 Feb 2012 00:42:35 GMT']
-      Server: [nginx/1.8.0]
-    status: {code: 200, message: OK}
+      Accept-Ranges:
+      - bytes
+      Connection:
+      - keep-alive
+      Content-Disposition:
+      - attachment; filename="e638ea178f406cb584f48051501e2cb4db4fce1d.zip"
+      Content-Length:
+      - '10541'
+      Content-Type:
+      - application/octet-stream
+      Date:
+      - Mon, 06 Jan 2025 20:53:39 GMT
+      ETag:
+      - '"4f497ffb-292d"'
+      Last-Modified:
+      - Sun, 26 Feb 2012 00:42:35 GMT
+      Server:
+      - nginx
+    status:
+      code: 200
+      message: OK
 version: 1

--- a/docs/user/usage.rst
+++ b/docs/user/usage.rst
@@ -5,57 +5,17 @@ CLI
 
     .. testsetup::
 
-        from importlib import import_module
+        import os
 
-        from babelfish import Language
-        from subliminal import provider_manager
-        from subliminal.providers.mock import mock_subtitle_provider
+        from vcr import VCR
 
-        subtitle_pool = [
-            {
-                "language": Language.fromietf('en'),
-                "subtitle_id": 'ZQo4',
-                "fake_content": (
-                    b'1\n00:00:04,254 --> 00:00:07,214\n'
-                    b'I\'m gonna run to the store.\nI\'ll pick you up when you\'re done.\n\n'
-                    b'2\n00:00:07,424 --> 00:00:10,968\n'
-                    b'Okay. L like it a little better\nwhen you stay, but all right.\n\n'
-                    b'3\n00:00:11,511 --> 00:00:12,803\n'
-                    b'- Hey, Sheldon.\n- Hello.\n\n'
-                ),
-                "video_name": 'The.Big.Bang.Theory.S05E18.HDTV.x264-LOL.mp4',
-                "matches": {'country', 'episode', 'season', 'series', 'video_codec', 'year'},
-            },
-            {
-                "language": Language.fromietf('hu'),
-                "subtitle_id": 'ZtAW',
-                "fake_content": (
-                    b'1\n00:00:02,090 --> 00:00:03,970\n'
-                    b'Elszaladok a boltba\nn\xe9h\xe1ny apr\xf3s\xe1g\xe9rt.\n\n'
-                    b'2\n00:00:04,080 --> 00:00:05,550\n'
-                    b'\xc9rted j\xf6v\xf6k, mikor v\xe9gezt\xe9l.\n\n'
-                    b'3\n00:00:05,650 --> 00:00:08,390\n'
-                    b'J\xf3l van. \xc9n jobb szeretem,\nmikor itt maradsz, de j\xf3l van...\n\n'
-                ),
-                "video_name": 'The.Big.Bang.Theory.S05E18.HDTV.x264-LOL.mp4',
-                "matches": {'country', 'episode', 'release_group', 'season', 'series', 'source', 'video_codec', 'year'},
-            },
-            {
-                "language": Language.fromietf('hu'),
-                "subtitle_id": 'ONAW',
-                "fake_content": (
-                    b'1\n00:00:02,090 --> 00:00:03,970\n'
-                    b'Elszaladok a boltba\nn\xe9h\xe1ny apr\xf3s\xe1g\xe9rt.\n\n'
-                    b'2\n00:00:04,080 --> 00:00:05,550\n'
-                    b'\xc9rted j\xf6v\xf6k, mikor v\xe9gezt\xe9l.\n\n'
-                ),
-                "video_name": 'The.Big.Bang.Theory.S05E18.HDTV.x264-LOL.mp4',
-                "matches": {'country', 'episode', 'season', 'series', 'source', 'year'},
-            },
-        ]
-
-        ep = mock_subtitle_provider("Custom", subtitle_pool)
-        provider_manager.register(ep)
+        vcr = VCR(
+            path_transformer=lambda path: path + '.yaml',
+            record_mode=os.environ.get('VCR_RECORD_MODE', 'once'),
+            match_on=['method', 'scheme', 'host', 'port', 'path', 'query', 'body'],
+            cassette_library_dir=os.path.realpath(os.path.join('docs', 'cassettes')),
+        )
+        vcr.use_cassette('test_usage')
 
 
 Download English subtitles::
@@ -150,9 +110,9 @@ Listing
 To list subtitles, subliminal provides a :func:`~subliminal.core.list_subtitles` function that will return all found
 subtitles:
 
-    >>> subtitles = list_subtitles([video], {Language('hun')}, providers=['custom'])
+    >>> subtitles = list_subtitles([video], {Language('hun')}, providers=['podnapisi'])
     >>> subtitles[video]
-    [<CustomSubtitle 'ZtAW' [hu]>, <CustomSubtitle 'ONAW' [hu]>]
+    [<PodnapisiSubtitle 'ZtAW' [hu]>, <PodnapisiSubtitle 'ONAW' [hu]>]
 
 .. note::
 
@@ -174,8 +134,8 @@ And then compute a score with those matches with :func:`~subliminal.score.comput
 
     >>> for s in subtitles[video]:
     ...     {s: compute_score(s, video)}
-    {<CustomSubtitle 'ZtAW' [hu]>: 789}
-    {<CustomSubtitle 'ONAW' [hu]>: 772}
+    {<PodnapisiSubtitle 'ZtAW' [hu]>: 789}
+    {<PodnapisiSubtitle 'ONAW' [hu]>: 772}
 
 Now you should have a better idea about which one you should choose.
 
@@ -201,9 +161,9 @@ Downloading best subtitles
 Downloading best subtitles is what you want to do in almost all cases, as a shortcut for listing, scoring and
 downloading you can use :func:`~subliminal.core.download_best_subtitles`:
 
-    >>> best_subtitles = download_best_subtitles([video], {Language('hun')}, providers=['custom'])
+    >>> best_subtitles = download_best_subtitles([video], {Language('hun')}, providers=['podnapisi'])
     >>> best_subtitles[video]
-    [<CustomSubtitle 'ZtAW' [hu]>]
+    [<PodnapisiSubtitle 'ZtAW' [hu]>]
     >>> best_subtitle = best_subtitles[video][0]
     >>> best_subtitle.content.split(b'\n')[2]
     b'Elszaladok a boltba'
@@ -215,7 +175,7 @@ Save
 We got ourselves a nice subtitle, now we can save it on the file system using :func:`~subliminal.core.save_subtitles`:
 
     >>> save_subtitles(video, [best_subtitle])
-    [<CustomSubtitle 'ZtAW' [hu]>]
+    [<PodnapisiSubtitle 'ZtAW' [hu]>]
     >>> 'The.Big.Bang.Theory.S05E18.HDTV.x264-LOL.hu.srt' in os.listdir()
     True
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,8 +42,7 @@ dependencies = [
     "click-option-group>=0.5.6",
     "dogpile.cache>=1.0",
     "guessit>=3.0.0",
-    "knowit>=0.5.2; python_version <= '3.8'",
-    "knowit>=0.5.5; python_version > '3.8'",
+    "knowit>=0.5.5",
     "platformdirs>=3",
     "pysubs2>=1.7",
     "rarfile>=2.7",
@@ -61,6 +60,7 @@ docs = [
     "sphinx_rtd_theme>=2",
     "sphinxcontrib-programoutput",
     "sphinx_autodoc_typehints",
+    "vcrpy>=5",  # keep synchronized with tests dependencies
     "towncrier",
 ]
 tests = [
@@ -69,7 +69,7 @@ tests = [
     "pytest-cov",
     "pytest-xdist",
     "sympy",
-    "vcrpy>=5",
+    "vcrpy>=5",  # keep synchronized with docs dependencies
     "importlib_metadata>=4.6; python_version<'3.10'",
 ]
 types = [
@@ -125,7 +125,6 @@ source = "vcs"
 # https://docs.pytest.org/en/6.2.x/customize.html
 [tool.pytest.ini_options]
 minversion = "6.0"
-testpaths = ["tests"]
 addopts = "--import-mode=importlib --doctest-glob='*.rst'"
 markers = [
     "integration",
@@ -314,8 +313,10 @@ extend-ignore-re = [
     "(?Rm)^.*#\\s*spellchecker:\\s*disable-line$",
     "#\\s*spellchecker:off\\s*\\n.*\\n\\s*#\\s*spellchecker:on"
 ]
+
 [tool.typos.default.extend-words]
 fo = "fo"
+
 [tool.typos.default.extend-identifiers]
 tha = "tha"
 bre = "bre"


### PR DESCRIPTION
Partially reverts #1185.

No need to use mock provider for the doctest in `usage.rst`, we can use a cassette, the code was already there but it was working only with `pytest`. Revert to using Podnapisi with a cassette in doctest and make it work with sphinx doctest.

Running tests may be slower because all the folder are searched, not only `tests`.