### PR TITLE
Use fps for scoring and add skip-wrong-fps CLI option

### DIFF
--- a/changelog.d/748.change.rst
+++ b/changelog.d/748.change.rst
@@ -1,0 +1,2 @@
+Use the subtitle FPS for scoring and add a skip-wrong-fps cli option
+to completely skip subtitles with FPS different from the video FPS (if detected)

--- a/docs/user/usage.rst
+++ b/docs/user/usage.rst
@@ -140,8 +140,8 @@ And then compute a score with those matches with :func:`~subliminal.score.comput
 
     >>> for s in subtitles[video]:
     ...     {s: compute_score(s, video)}
-    {<PodnapisiSubtitle 'ZtAW' [hu]>: 789}
-    {<PodnapisiSubtitle 'ONAW' [hu]>: 772}
+    {<PodnapisiSubtitle 'ZtAW' [hu]>: 941}
+    {<PodnapisiSubtitle 'ONAW' [hu]>: 922}
 
 Now you should have a better idea about which one you should choose.
 

--- a/src/subliminal/cli.py
+++ b/src/subliminal/cli.py
@@ -463,6 +463,13 @@ def cache(ctx: click.Context, clear_subliminal: bool) -> None:
 )
 @click.option('-f', '--force', is_flag=True, default=False, help='Force download even if a subtitle already exist.')
 @click.option(
+    '-w',
+    '--skip-wrong-fps',
+    is_flag=True,
+    default=False,
+    help='Skip subtitles with an FPS that do not match the video (if it can be detected).',
+)
+@click.option(
     '-fo',
     '--foreign-only',
     'foreign_only',
@@ -553,6 +560,7 @@ def download(
     encoding: str | None,
     single: bool,
     force: bool,
+    skip_wrong_fps: bool,
     hearing_impaired: tuple[bool | None, ...],
     foreign_only: tuple[bool | None, ...],
     min_score: int,
@@ -742,6 +750,7 @@ def download(
                     min_score=scores['hash'] * min_score // 100,
                     hearing_impaired=hearing_impaired_flag,
                     foreign_only=foreign_only_flag,
+                    skip_wrong_fps=skip_wrong_fps,
                     only_one=single,
                     ignore_subtitles=ignore_subtitles,
                 )

--- a/src/subliminal/matches.py
+++ b/src/subliminal/matches.py
@@ -145,6 +145,29 @@ def country_matches(video: Video, *, country: Country | None = None, partial: bo
     return False  # pragma: no cover
 
 
+def fps_matches(video: Video, *, fps: float | None = None, **kwargs: Any) -> bool:
+    """Whether the video matches the `fps`.
+
+    Frame rates are considered equal if the relative difference is less than 0.1 percent.
+
+    :param video: the video.
+    :type video: :class:`~subliminal.video.Video`
+    :param str fps: the video frame rate.
+    :return: whether there's a match
+    :rtype: bool
+
+    """
+    # make the difference a bit more than 0.1% to be sure
+    relative_diff = 0.0011
+    return (
+        video.frame_rate is not None
+        and video.frame_rate > 0
+        and fps is not None
+        and fps > 0
+        and abs(video.frame_rate - fps) / video.frame_rate < relative_diff
+    )
+
+
 def release_group_matches(video: Video, *, release_group: str | None = None, **kwargs: Any) -> bool:
     """Whether the video matches the `release_group`.
 
@@ -238,6 +261,7 @@ matches_manager: dict[str, MatchingFunc] = {
     'episode': episode_matches,
     'year': year_matches,
     'country': country_matches,
+    'fps': fps_matches,
     'release_group': release_group_matches,
     'streaming_service': streaming_service_matches,
     'resolution': resolution_matches,

--- a/src/subliminal/providers/opensubtitlescom.py
+++ b/src/subliminal/providers/opensubtitlescom.py
@@ -172,6 +172,7 @@ class OpenSubtitlesComSubtitle(Subtitle):
     moviehash_match: bool
     file_id: int
     file_name: str
+    fps: float | None
 
     def __init__(
         self,
@@ -194,6 +195,7 @@ class OpenSubtitlesComSubtitle(Subtitle):
         series_tmdb_id: str | None = None,
         download_count: int | None = None,
         machine_translated: bool | None = None,
+        fps: float | None = None,
         imdb_match: bool = False,
         tmdb_match: bool = False,
         moviehash_match: bool = False,
@@ -205,6 +207,7 @@ class OpenSubtitlesComSubtitle(Subtitle):
             subtitle_id,
             hearing_impaired=hearing_impaired,
             foreign_only=foreign_only,
+            fps=fps,
             page_link=None,
             encoding='utf-8',
         )
@@ -248,7 +251,7 @@ class OpenSubtitlesComSubtitle(Subtitle):
         moviehash_match = bool(attributes.get('moviehash_match', False))
         download_count = int(attributes.get('download_count'))
         machine_translated = bool(int(attributes.get('machine_translated')))
-        # fps = float(attributes.get('fps'))
+        fps: float | None = float(attributes.get('fps')) or None
         # from_trusted = bool(int(attributes.get('from_trusted')))
         # uploader_rank = str(attributes.get('uploader', {}).get("rank"))
         # foreign_parts_only = bool(int(attributes.get('foreign_parts_only')))
@@ -290,6 +293,7 @@ class OpenSubtitlesComSubtitle(Subtitle):
             series_tmdb_id=series_tmdb_id,
             download_count=download_count,
             machine_translated=machine_translated,
+            fps=fps,
             imdb_match=imdb_match,
             tmdb_match=tmdb_match,
             moviehash_match=moviehash_match,
@@ -322,6 +326,7 @@ class OpenSubtitlesComSubtitle(Subtitle):
                 'year': self.movie_year,
                 'season': self.series_season,
                 'episode': self.series_episode,
+                'fps': self.fps,
             },
         )
 

--- a/src/subliminal/score.py
+++ b/src/subliminal/score.py
@@ -60,15 +60,15 @@ logger = logging.getLogger(__name__)
 
 #: Scores for episodes
 episode_scores: dict[str, int] = {
-    'hash': 809,
-    'series': 405,
-    'year': 135,
-    'country': 135,
-    'season': 45,
-    'episode': 45,
-    'fps': 18,
-    'release_group': 9,
-    'streaming_service': 9,
+    'hash': 971,
+    'series': 486,
+    'country': 162,
+    'year': 162,
+    'episode': 54,
+    'season': 54,
+    'release_group': 18,
+    'streaming_service': 18,
+    'fps': 9,
     'source': 4,
     'audio_codec': 2,
     'resolution': 1,
@@ -77,13 +77,13 @@ episode_scores: dict[str, int] = {
 
 #: Scores for movies
 movie_scores: dict[str, int] = {
-    'hash': 269,
-    'title': 135,
-    'year': 45,
-    'country': 45,
-    'fps': 18,
-    'release_group': 9,
-    'streaming_service': 9,
+    'hash': 323,
+    'title': 162,
+    'country': 54,
+    'year': 54,
+    'release_group': 18,
+    'streaming_service': 18,
+    'fps': 9,
     'source': 4,
     'audio_codec': 2,
     'resolution': 1,
@@ -214,7 +214,7 @@ if WITH_SYMPY:  # pragma: no cover
         For testing purposes.
         """
         hash, series, year, country, season, episode = symbols('hash series year country season episode')  # noqa: A001
-        fps, release_group, streaming_service, source = symbols('fps release_group streaming_service source')
+        release_group, streaming_service, fps, source = symbols('release_group streaming_service fps source')
         audio_codec, resolution, video_codec = symbols('audio_codec resolution video_codec')
 
         equations = [
@@ -226,9 +226,9 @@ if WITH_SYMPY:  # pragma: no cover
                 + country
                 + season
                 + episode
-                + fps
                 + release_group
                 + streaming_service
+                + fps
                 + source
                 + audio_codec
                 + resolution
@@ -241,9 +241,9 @@ if WITH_SYMPY:  # pragma: no cover
                 + country
                 + season
                 + episode
-                + fps
                 + release_group
                 + streaming_service
+                + fps
                 + source
                 + audio_codec
                 + resolution
@@ -255,9 +255,9 @@ if WITH_SYMPY:  # pragma: no cover
                 year,
                 season
                 + episode
-                + fps
                 + release_group
                 + streaming_service
+                + fps
                 + source
                 + audio_codec
                 + resolution
@@ -267,15 +267,15 @@ if WITH_SYMPY:  # pragma: no cover
             # year counts as much as country
             Eq(year, country),
             # season is important too
-            Eq(season, fps + release_group + streaming_service + source + audio_codec + resolution + video_codec + 1),
+            Eq(season, release_group + streaming_service + fps + source + audio_codec + resolution + video_codec + 1),
             # episode is equally important to season
             Eq(episode, season),
-            # fps is the next most wanted match
-            Eq(fps, release_group + source + audio_codec + resolution + video_codec + 1),
             # release group is the next most wanted match
-            Eq(release_group, source + audio_codec + resolution + video_codec + 1),
+            Eq(release_group, fps + source + audio_codec + resolution + video_codec + 1),
             # streaming service counts as much as release group
             Eq(release_group, streaming_service),
+            # fps is the next most wanted match
+            Eq(fps, source + audio_codec + resolution + video_codec + 1),
             # source counts as much as audio_codec, resolution and video_codec
             Eq(source, audio_codec + resolution + video_codec),
             # audio_codec is more valuable than video_codec
@@ -295,9 +295,9 @@ if WITH_SYMPY:  # pragma: no cover
                 country,
                 season,
                 episode,
-                fps,
                 release_group,
                 streaming_service,
+                fps,
                 source,
                 audio_codec,
                 resolution,
@@ -310,9 +310,9 @@ if WITH_SYMPY:  # pragma: no cover
 
         For testing purposes.
         """
-        hash, title, year, country, fps, release_group = symbols('hash title year country fps release_group')  # noqa: A001
-        streaming_service, source, audio_codec, resolution = symbols('streaming_service source audio_codec resolution')
-        video_codec, hearing_impaired = symbols('video_codec hearing_impaired')
+        hash, title, year, country, release_group = symbols('hash title year country release_group')  # noqa: A001
+        streaming_service, fps, source, audio_codec = symbols('streaming_service fps source audio_codec')
+        resolution, video_codec, hearing_impaired = symbols('resolution video_codec hearing_impaired')
 
         equations = [
             # hash is best
@@ -321,9 +321,9 @@ if WITH_SYMPY:  # pragma: no cover
                 title
                 + year
                 + country
-                + fps
                 + release_group
                 + streaming_service
+                + fps
                 + source
                 + audio_codec
                 + resolution
@@ -334,9 +334,9 @@ if WITH_SYMPY:  # pragma: no cover
                 title,
                 year
                 + country
-                + fps
                 + release_group
                 + streaming_service
+                + fps
                 + source
                 + audio_codec
                 + resolution
@@ -344,15 +344,15 @@ if WITH_SYMPY:  # pragma: no cover
                 + 1,
             ),
             # year is the second most important part
-            Eq(year, fps + release_group + streaming_service + source + audio_codec + resolution + video_codec + 1),
+            Eq(year, release_group + streaming_service + fps + source + audio_codec + resolution + video_codec + 1),
             # year counts as much as country
             Eq(year, country),
-            # fps is the next most wanted match
-            Eq(fps, release_group + source + audio_codec + resolution + video_codec + 1),
             # release group is the next most wanted match
-            Eq(release_group, source + audio_codec + resolution + video_codec + 1),
+            Eq(release_group, fps + source + audio_codec + resolution + video_codec + 1),
             # streaming service counts as much as release group
             Eq(release_group, streaming_service),
+            # fps is the next most wanted match
+            Eq(fps, source + audio_codec + resolution + video_codec + 1),
             # source counts as much as audio_codec, resolution and video_codec
             Eq(source, audio_codec + resolution + video_codec),
             # audio_codec is more valuable than video_codec
@@ -370,9 +370,9 @@ if WITH_SYMPY:  # pragma: no cover
                 title,
                 year,
                 country,
-                fps,
                 release_group,
                 streaming_service,
+                fps,
                 source,
                 audio_codec,
                 resolution,

--- a/src/subliminal/subtitle.py
+++ b/src/subliminal/subtitle.py
@@ -166,7 +166,7 @@ class Subtitle:
         self.subtitle_id = subtitle_id
         self.page_link = page_link
         self.subtitle_format = subtitle_format
-        self.fps = fps
+        self.fps = fps if fps is not None and fps > 0 else None
         self.embedded = embedded
 
         self.language_type = LanguageType.from_flags(hearing_impaired=hearing_impaired, foreign_only=foreign_only)


### PR DESCRIPTION
closes #748

Use FPS to score the subtitles. A matching FPS counts less than a release group match, but more than source match (or resolution and codecs.)
This will increase the score of the subtitles with the same FPS (with a relative error of 1%) as the video.

On top of that, this PR adds a `skip-wrong-fps` CLI option to just ignore the subtitles with a known FPS that is different from the video FPS (if it could be detected).

Also `hearing_impaired` is not contributing anymore to the score.
This is a breaking change as the scores of all the subtitles will change.

The only provider that provides an FPS for (some of) the subtitles is `opensubtitlescom`
