### PR TITLE
Convert subtitles to another format

### DIFF
--- a/changelog.d/536.change.rst
+++ b/changelog.d/536.change.rst
@@ -1,0 +1,1 @@
+Add a --subtitle-format CLI option to force converting subtitles to another format

--- a/src/subliminal/cli.py
+++ b/src/subliminal/cli.py
@@ -452,6 +452,14 @@ def cache(ctx: click.Context, clear_subliminal: bool) -> None:
     help='Force subtitle file encoding, set to an empty string to preserve the original encoding. Default is utf-8.',
 )
 @click.option(
+    '-F',
+    '--subtitle-format',
+    type=click.STRING,
+    metavar='FORMAT',
+    default='',
+    help="Force subtitle format, set to an empty string to preserve the original format. Default is ''.",
+)
+@click.option(
     '-s',
     '--single',
     is_flag=True,
@@ -551,6 +559,7 @@ def download(
     use_ctime: bool,
     directory: str | None,
     encoding: str | None,
+    subtitle_format: str | None,
     single: bool,
     force: bool,
     hearing_impaired: tuple[bool | None, ...],
@@ -762,6 +771,7 @@ def download(
             single=single,
             directory=directory,
             encoding=encoding,
+            subtitle_format=subtitle_format,
             language_type_suffix=language_type_suffix,
             language_format=language_format,
         )

--- a/src/subliminal/core.py
+++ b/src/subliminal/core.py
@@ -833,7 +833,9 @@ def save_subtitles(
 
         # convert subtitle to a new format
         if subtitle_format:
-            subtitle.convert(subtitle_format, output_encoding=encoding)
+            # Use the video FPS if the FPS of the subtitle is not defined
+            fps = video.frame_rate if subtitle.fps is None else None
+            subtitle.convert(subtitle_format, output_encoding=encoding, fps=fps)
 
         # create subtitle path
         subtitle_path = subtitle.get_path(

--- a/src/subliminal/core.py
+++ b/src/subliminal/core.py
@@ -791,6 +791,7 @@ def save_subtitles(
     single: bool = False,
     directory: str | os.PathLike | None = None,
     encoding: str | None = None,
+    subtitle_format: str | None = None,
     extension: str | None = None,
     language_type_suffix: bool = False,
     language_format: str = 'alpha2',
@@ -810,6 +811,7 @@ def save_subtitles(
     :param bool single: save a single subtitle, default is to save one subtitle per language.
     :param str directory: path to directory where to save the subtitles, default is next to the video.
     :param str encoding: encoding in which to save the subtitles, default is to keep original encoding.
+    :param str subtitle_format: format in which to save the subtitles, default is to keep original format.
     :param (str | None) extension: the subtitle extension, default is to match to the subtitle format.
     :param bool language_type_suffix: add a suffix 'hi' or 'fo' if needed. Default to False.
     :param str language_format: format of the language suffix. Default to 'alpha2'.
@@ -828,6 +830,10 @@ def save_subtitles(
         if subtitle.language in {s.language for s in saved_subtitles}:
             logger.debug('Skipping subtitle %r: language already saved', subtitle)
             continue
+
+        # convert subtitle to a new format
+        if subtitle_format:
+            subtitle.convert(subtitle_format, output_encoding=encoding)
 
         # create subtitle path
         subtitle_path = subtitle.get_path(


### PR DESCRIPTION
closes #536 

Add a `--subtitle-format` CLI option to force the conversion of the subtitles to another format, for instance srt.
By default `--subtitle-format=''`, so the subtitles are not converted.

@ptrcnull  it would be good to test this on Napiprojekt subtitles that were in the MicroDVD format.