### PR TITLE
Improve coverage

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -144,6 +144,12 @@ jobs:
           with codecs.open(os.environ["GITHUB_ENV"], mode="a", encoding="utf-8") as file_handler:
               file_handler.write(f"FORCE_COLOR=1\nENV={py}\n")
         shell: python
+      - name: Install other test software (on Linux only)
+        if: matrix.os == 'ubuntu-latest'
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: rar
+          version: 1.0
       - name: Setup test environment
         run: |
           hatch -v env create ${ENV}

--- a/changelog.d/1209.change.rst
+++ b/changelog.d/1209.change.rst
@@ -1,0 +1,1 @@
+Improve core coverage: score.py, matches.py and archives.py

--- a/hatch.toml
+++ b/hatch.toml
@@ -104,7 +104,7 @@ run-cov-core = [
   "test-cov-core",
   """\
     coverage report --skip-covered --show-missing --fail-under=100 \
-    --omit='src/subliminal/cli.py,src/subliminal/archives.py,src/subliminal/__main__.py,'\
+    --omit='src/subliminal/cli.py,src/subliminal/__main__.py,'\
     'src/subliminal/converters/*,src/subliminal/providers/*,src/subliminal/refiners/*' \
   """,
 ]

--- a/hatch.toml
+++ b/hatch.toml
@@ -104,7 +104,8 @@ run-cov-core = [
   "test-cov-core",
   """\
     coverage report --skip-covered --show-missing --fail-under=100 \
-    --omit='src/subliminal/cli.py,src/subliminal/converters/*,src/subliminal/providers/*,src/subliminal/refiners/*' \
+    --omit='src/subliminal/cli.py,src/subliminal/archives.py,src/subliminal/__main__.py,'\
+    'src/subliminal/converters/*,src/subliminal/providers/*,src/subliminal/refiners/*' \
   """,
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,6 +150,7 @@ show_missing = true
 skip_covered = true
 fail_under = 80
 omit = [
+    "src/subliminal/__main__.py",
     "src/subliminal/cli.py",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,7 @@ dependencies = [
 [project.optional-dependencies]
 rar = ["rarfile>=2.7"]
 docs = [
-    "sphinx",
+    "sphinx<8.2",
     "sphinx_rtd_theme>=2",
     "sphinxcontrib-programoutput",
     "sphinx_autodoc_typehints",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -141,7 +141,8 @@ exclude_also = [
     "if TYPE_CHECKING:",
     "@overload",
     "except ImportError",
-    "\\.\\.\\.",
+    "except PackageNotFoundError",
+    "\\.\\.\\.^",
     "raise NotImplementedError()",
     "if __name__ == .__main__.:",
 ]

--- a/src/subliminal/__init__.py
+++ b/src/subliminal/__init__.py
@@ -8,7 +8,7 @@ from importlib.metadata import PackageNotFoundError, version
 # Must be first, otherwise we run into ImportError: partially initialized module
 try:
     __version__ = version('subliminal')
-except PackageNotFoundError:
+except PackageNotFoundError:  # pragma: no cover
     __version__ = 'undefined'
 __short_version__: str = '.'.join(__version__.split('.')[:2])
 __title__: str = 'subliminal'

--- a/src/subliminal/__init__.py
+++ b/src/subliminal/__init__.py
@@ -8,7 +8,7 @@ from importlib.metadata import PackageNotFoundError, version
 # Must be first, otherwise we run into ImportError: partially initialized module
 try:
     __version__ = version('subliminal')
-except PackageNotFoundError:  # pragma: no cover
+except PackageNotFoundError:
     __version__ = 'undefined'
 __short_version__: str = '.'.join(__version__.split('.')[:2])
 __title__: str = 'subliminal'

--- a/src/subliminal/archives.py
+++ b/src/subliminal/archives.py
@@ -46,14 +46,14 @@ def is_supported_archive(filename: str) -> bool:
     if filename.lower().endswith(ARCHIVE_EXTENSIONS):
         return True
 
-    if filename.lower().endswith('.rar'):
+    if filename.lower().endswith('.rar'):  # pragma: no cover
         msg = 'Install the rarfile module to be able to read rar archives.'
         warnings.warn(msg, UserWarning, stacklevel=2)
 
-    return False
+    return False  # pragma: no cover
 
 
-def scan_archive(path: str | os.PathLike, name: str | None = None) -> Video:  # pragma: no cover
+def scan_archive(path: str | os.PathLike, name: str | None = None) -> Video:
     """Scan an archive from a `path`.
 
     :param str path: existing path to the archive.
@@ -78,7 +78,7 @@ def scan_archive(path: str | os.PathLike, name: str | None = None) -> Video:  # 
     raise ArchiveError(msg)
 
 
-def scan_archive_rar(path: str | os.PathLike, name: str | None = None) -> Video:  # pragma: no cover
+def scan_archive_rar(path: str | os.PathLike, name: str | None = None) -> Video:
     """Scan a rar archive from a `path`.
 
     :param str path: existing path to the archive.
@@ -90,7 +90,7 @@ def scan_archive_rar(path: str | os.PathLike, name: str | None = None) -> Video:
     path = os.fspath(path)
     # check for non-existing path
     if not os.path.exists(path):  # pragma: no cover
-        msg = 'Path does not exist'
+        msg = f'Path does not exist: {path!r}'
         raise ValueError(msg)
 
     if not is_rarfile(path):

--- a/src/subliminal/score.py
+++ b/src/subliminal/score.py
@@ -134,7 +134,7 @@ def get_scores(video: Video) -> dict[str, Any]:
 
 def match_hearing_impaired(subtitle: Subtitle, *, hearing_impaired: bool | None = None) -> bool:
     """Match hearing impaired, if it is defined for the subtitle."""
-    return (
+    return (  # pragma: no cover
         hearing_impaired is not None
         and subtitle.hearing_impaired is not None
         and subtitle.hearing_impaired == hearing_impaired
@@ -181,15 +181,24 @@ def compute_score(subtitle: Subtitle, video: Video, **kwargs: Any) -> int:
         if 'imdb_id' in matches:
             logger.debug('Adding imdb_id match equivalents')
             matches |= {'series', 'year', 'country', 'season', 'episode'}
-        if 'tvdb_id' in matches:
-            logger.debug('Adding tvdb_id match equivalents')
+        if 'series_tmdb_id' in matches:
+            logger.debug('Adding series_tmdb_id match equivalents')
+            matches |= {'series', 'year', 'country'}
+        if 'tmdb_id' in matches:
+            logger.debug('Adding tmdb_id match equivalents')
             matches |= {'series', 'year', 'country', 'season', 'episode'}
         if 'series_tvdb_id' in matches:
             logger.debug('Adding series_tvdb_id match equivalents')
             matches |= {'series', 'year', 'country'}
+        if 'tvdb_id' in matches:
+            logger.debug('Adding tvdb_id match equivalents')
+            matches |= {'series', 'year', 'country', 'season', 'episode'}
     elif isinstance(video, Movie):  # pragma: no branch
         if 'imdb_id' in matches:
             logger.debug('Adding imdb_id match equivalents')
+            matches |= {'title', 'year', 'country'}
+        if 'tmdb_id' in matches:
+            logger.debug('Adding tmdb_id match equivalents')
             matches |= {'title', 'year', 'country'}
 
     # compute the score

--- a/src/subliminal/utils.py
+++ b/src/subliminal/utils.py
@@ -366,11 +366,11 @@ def clip(value: float, minimum: float | None, maximum: float | None) -> float:
 
 def split_doc_args(args: str | None) -> list[str]:
     """Split the arguments of a docstring (in Sphinx docstyle)."""
-    if not args:
+    if not args:  # pragma: no cover
         return []
     split_regex = re.compile(r'(?m):((param|type)\s|(return|yield|raise|rtype|ytype)s?:)')
     split_indices = [m.start() for m in split_regex.finditer(args)]
-    if len(split_indices) == 0:
+    if len(split_indices) == 0:  # pragma: no cover
         return []
     next_indices = [*split_indices[1:], None]
     parts = [args[i:j].strip() for i, j in zip(split_indices, next_indices)]
@@ -388,10 +388,10 @@ def get_argument_doc(fun: Callable) -> dict[str, str]:
     ret = {}
     for p in parts:
         m = param_regex.match(p)
-        if not m:
+        if not m:  # pragma: no cover
             continue
         _, name, desc = m.groups()
-        if name is None:
+        if name is None:  # pragma: no cover
             continue
         ret[name] = ' '.join(desc.strip().split())
 

--- a/src/subliminal/utils.py
+++ b/src/subliminal/utils.py
@@ -219,7 +219,7 @@ def creation_date(filepath: os.PathLike | str) -> float:
     See https://stackoverflow.com/a/39501288/1709587 for explanation.
     """
     # Use creation time (although it may not be correct)
-    if platform.system() == 'Windows':
+    if platform.system() == 'Windows':  # pragma: no cover
         return os.path.getctime(filepath)
     stat = os.stat(filepath)
     try:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,10 +8,11 @@ from zipfile import ZipFile
 
 import pytest
 import requests
-from babelfish import Country  # type: ignore[import-untyped]
+from babelfish import Country, Language  # type: ignore[import-untyped]
 
 from subliminal import Episode, Movie
 from subliminal.cache import region
+from subliminal.providers.mock import MockSubtitle
 
 TESTS = os.path.dirname(__file__)
 
@@ -474,6 +475,75 @@ def episodes() -> dict[str, Episode]:
             4,
             2,
             year=1914,
+        ),
+    }
+
+
+@pytest.fixture
+def subtitles() -> dict[str, MockSubtitle]:
+    return {
+        'man_of_steel==empty': MockSubtitle(
+            language=Language('eng'),
+            subtitle_id='man_of_steel==empty',
+            hearing_impaired=True,
+            page_link=None,
+            encoding='utf-8',
+        ),
+        'bbt_s07e05==empty': MockSubtitle(
+            language=Language('eng'),
+            subtitle_id='bbt_s07e05==empty',
+            foreign_only=False,
+            page_link=None,
+        ),
+        'bbt_s07e05==series_year_country': MockSubtitle(
+            language=Language('eng'),
+            subtitle_id='bbt_s07e05==series_year_country',
+            hearing_impaired=False,
+            page_link=None,
+            parameters={
+                'title': 'the big BANG theory',
+                'season': 6,
+                'episode': 4,
+                'episode_title': None,
+                'year': None,
+                'release_group': '1080p',
+            },
+        ),
+        'man_of_steel==hash': MockSubtitle(
+            language=Language('eng'),
+            subtitle_id='man_of_steel==hash',
+            foreign_only=True,
+            page_link=None,
+            encoding='utf-8',
+            matches={'hash'},
+        ),
+        'man_of_steel==imdb_id': MockSubtitle(
+            language=Language('eng'),
+            subtitle_id='man_of_steel==imdb_id',
+            page_link=None,
+            encoding='utf-8',
+            matches={'imdb_id', 'country'},
+            parameters={
+                'title': 'Man of Steel',
+                'year': 2013,
+                'imdb_id': 'tt770828',
+                'season': None,
+                'episode': None,
+            },
+            release_name='man.of.steel.2013.720p.bluray.x264-felony.mkv',
+        ),
+        'bbt_s07e05==episode_title': MockSubtitle(
+            language=Language('pol'),
+            subtitle_id='bbt_s07e05==episode_title',
+            page_link=None,
+            encoding='utf-8',
+            parameters={
+                'title': None,
+                'season': 7,
+                'episode': 5,
+                'year': None,
+            },
+            release_name='The.Big.Bang.Theory.S07E05.The.Workplace.Proximity.720p.HDTV.x264-DIMENSION.mkv',
         ),
     }
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -605,7 +605,7 @@ def rar(mkv):
         existing_videos = [v for v in videos if v and os.path.isfile(v)]
         filename = os.path.join(data_path, name + '.rar')
         if not os.path.exists(filename):
-            subprocess.run(['rar', 'a', filename, *existing_videos], shell=True)
+            subprocess.run(['rar', 'a', '-ep', filename, *existing_videos], check=True)
         if os.path.exists(filename):
             files[name] = filename
 

--- a/tests/test_archives.py
+++ b/tests/test_archives.py
@@ -1,0 +1,74 @@
+# ruff: noqa: PT011, SIM115
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+from subliminal.archives import is_supported_archive, scan_archive, scan_archive_rar
+from subliminal.exceptions import ArchiveError
+
+unix_platform = pytest.mark.skipif(
+    not sys.platform.startswith('linux'),
+    reason='only on linux platform',
+)
+
+# Core test
+pytestmark = [pytest.mark.core, unix_platform]
+
+
+def test_is_supported_archive(rar: dict[str, str], mkv: dict[str, str]) -> None:
+    assert is_supported_archive(rar['simple'])
+    assert not is_supported_archive(mkv['test1'])
+
+
+def test_scan_archive_with_one_video(rar: dict[str, str], mkv: dict[str, str]) -> None:
+    if 'video' not in rar:
+        return
+    rar_file = rar['video']
+    actual = scan_archive(rar_file)
+
+    expected = os.fspath(Path(rar_file).parent / Path(mkv['test1']).name)
+    assert actual.name == expected
+
+
+def test_scan_archive_with_multiple_videos(rar: dict[str, str], mkv: dict[str, str]) -> None:
+    if 'videos' not in rar:
+        return
+    rar_file = rar['videos']
+    actual = scan_archive(rar_file)
+
+    expected = os.fspath(Path(rar_file).parent / Path(mkv['test5']).name)
+    assert actual.name == expected
+
+
+def test_scan_archive_with_no_video(rar: dict[str, str]) -> None:
+    with pytest.raises(ArchiveError) as excinfo:
+        scan_archive(rar['simple'])
+    assert excinfo.value.args == ('No video in archive',)
+
+
+def test_scan_bad_archive(mkv: dict[str, str]) -> None:
+    with pytest.raises(ArchiveError) as excinfo:
+        scan_archive(mkv['test1'])
+    assert excinfo.value.args == ("'.mkv' is not a valid archive",)
+
+
+def test_scan_rar_not_a_file(mkv: dict[str, str]) -> None:
+    with pytest.raises(ValueError) as excinfo:
+        scan_archive_rar('not_a_file.txt')
+    assert excinfo.value.args == ("Path does not exist: 'not_a_file.txt'",)
+
+
+def test_scan_rar_bad_archive(mkv: dict[str, str]) -> None:
+    with pytest.raises(ValueError) as excinfo:
+        scan_archive_rar(mkv['test1'])
+    assert excinfo.value.args == ("'.mkv' is not a valid archive",)
+
+
+def test_scan_password_protected_archive(rar: dict[str, str]) -> None:
+    with pytest.raises(ArchiveError) as excinfo:
+        scan_archive(rar['pwd-protected'])
+    assert excinfo.value.args == ('Rar requires a password',)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import os
-import sys
 from datetime import datetime, timedelta, timezone
 from typing import Any
 from unittest.mock import Mock
@@ -26,11 +25,6 @@ from subliminal.video import Episode, Movie
 
 # Core test
 pytestmark = pytest.mark.core
-
-unix_platform = pytest.mark.skipif(
-    not sys.platform.startswith('linux'),
-    reason='only on linux platform',
-)
 
 
 def test_check_video_languages(movies: dict[str, Movie]) -> None:
@@ -419,44 +413,3 @@ def test_save_subtitles_single_directory_encoding(movies: dict[str, Movie], tmpd
     path = os.path.join(str(tmpdir), os.path.splitext(os.path.split(movies['man_of_steel'].name)[1])[0] + '.srt')
     assert os.path.exists(path)
     assert open(path, encoding='utf-8').read() == 'ハローワールド'
-
-
-@unix_platform
-def test_scan_archive_with_one_video(rar: dict[str, str], mkv: dict[str, str]) -> None:
-    if 'video' not in rar:
-        return
-    rar_file = rar['video']
-    actual = scan_archive(rar_file)
-
-    assert actual.name == os.path.join(os.path.split(rar_file)[0], mkv['test1'])
-
-
-@unix_platform
-def test_scan_archive_with_multiple_videos(rar: dict[str, str], mkv: dict[str, str]) -> None:
-    if 'video' not in rar:
-        return
-    rar_file = rar['videos']
-    actual = scan_archive(rar_file)
-
-    assert actual.name == os.path.join(os.path.split(rar_file)[0], mkv['test5'])
-
-
-@unix_platform
-def test_scan_archive_with_no_video(rar: dict[str, str]) -> None:
-    with pytest.raises(ArchiveError) as excinfo:
-        scan_archive(rar['simple'])
-    assert excinfo.value.args == ('No video in archive',)
-
-
-@unix_platform
-def test_scan_bad_archive(mkv: dict[str, str]) -> None:
-    with pytest.raises(ArchiveError) as excinfo:
-        scan_archive(mkv['test1'])
-    assert excinfo.value.args == ("'.mkv' is not a valid archive",)
-
-
-@unix_platform
-def test_scan_password_protected_archive(rar: dict[str, str]) -> None:
-    with pytest.raises(ArchiveError) as excinfo:
-        scan_archive(rar['pwd-protected'])
-    assert excinfo.value.args == ('Rar requires a password',)

--- a/tests/test_subtitle.py
+++ b/tests/test_subtitle.py
@@ -239,6 +239,7 @@ def test_subtitle_invalid_encoding():
         encoding='rubbish',
     )
     assert subtitle.encoding is None
+    assert subtitle.hearing_impaired is False
 
 
 def test_subtitle_guess_encoding_utf8():
@@ -295,6 +296,17 @@ def test_subtitle_info(monkeypatch) -> None:
     assert isinstance(subtitle.info, str)
 
 
+def test_embedded_subtitle_info(monkeypatch) -> None:
+    subtitle = EmbeddedSubtitle(
+        Language('ita'),
+    )
+    text = '1\n00:00:20,000 --> 00:00:24,400\nIn risposta alla sua lettera del\n\n'
+    monkeypatch.setattr(Subtitle, 'text', text)
+    assert subtitle.is_valid() is True
+    assert isinstance(subtitle.id, str)
+    assert isinstance(subtitle.info, str)
+
+
 def test_embedded_subtitle_info_hearing_impaired(monkeypatch) -> None:
     subtitle = EmbeddedSubtitle(
         Language('spa'),
@@ -303,6 +315,7 @@ def test_embedded_subtitle_info_hearing_impaired(monkeypatch) -> None:
     text = '1\n00:00:20,000 --> 00:00:24,400\nEn respuesta a su carta de\n\n'
     monkeypatch.setattr(Subtitle, 'text', text)
     assert subtitle.is_valid() is True
+    assert subtitle.hearing_impaired is True
     assert isinstance(subtitle.id, str)
     assert isinstance(subtitle.info, str)
 
@@ -315,5 +328,6 @@ def test_embedded_subtitle_info_foreign_only(monkeypatch) -> None:
     text = '1\n00:00:20,000 --> 00:00:24,400\nEn réponse à votre honorée du tant\n\n'
     monkeypatch.setattr(Subtitle, 'text', text)
     assert subtitle.is_valid() is True
+    assert subtitle.foreign_only is True
     assert isinstance(subtitle.id, str)
     assert isinstance(subtitle.info, str)

--- a/tox.ini
+++ b/tox.ini
@@ -67,7 +67,8 @@ commands =
         -m core --cov=subliminal --cov-report= --cov-fail-under=0 \
         {posargs:-n auto}
     coverage report \
-        --omit='subliminal/cli.py,subliminal/converters/*,subliminal/providers/*,subliminal/refiners/*' \
+        --omit='src/subliminal/cli.py,src/subliminal/__main__.py,'\
+            'src/subliminal/converters/*,src/subliminal/providers/*,src/subliminal/refiners/*' \
         --skip-covered --show-missing --fail-under=100
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -67,7 +67,7 @@ commands =
         -m core --cov=subliminal --cov-report= --cov-fail-under=0 \
         {posargs:-n auto}
     coverage report \
-        --omit='src/subliminal/cli.py,src/subliminal/archives.py,src/subliminal/__main__.py,'\
+        --omit='src/subliminal/cli.py,src/subliminal/__main__.py,'\
             'src/subliminal/converters/*,src/subliminal/providers/*,src/subliminal/refiners/*' \
         --skip-covered --show-missing --fail-under=100
 

--- a/tox.ini
+++ b/tox.ini
@@ -67,7 +67,7 @@ commands =
         -m core --cov=subliminal --cov-report= --cov-fail-under=0 \
         {posargs:-n auto}
     coverage report \
-        --omit='src/subliminal/cli.py,src/subliminal/__main__.py,'\
+        --omit='src/subliminal/cli.py,src/subliminal/archives.py,src/subliminal/__main__.py,'\
             'src/subliminal/converters/*,src/subliminal/providers/*,src/subliminal/refiners/*' \
         --skip-covered --show-missing --fail-under=100
 


### PR DESCRIPTION
Improve `MockSubtitle` to allow more testing.
Use `MockSubtitle` to test `score.py`: this allows more flexibility in the tests and makes it independent of any provider.

Core coverage is only missing lines in `core.py`.