### PR TITLE
Test provider pool

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -234,6 +234,7 @@ jobs:
     name: Core Coverage
     runs-on: ubuntu-latest
     needs: build-package
+    if: false
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -230,12 +230,68 @@ jobs:
           path: python-coverage-comment-action.txt
 
 
+  core-coverage:
+    name: Core Coverage
+    runs-on: ubuntu-latest
+    needs: build-package
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - uses: actions/setup-python@v5
+        id: setup
+        with:
+          python-version-file: .python-version-default
+      - name: Install hatch
+        run: python -Im pip install hatch
+
+      - name: Install other test software (on Linux only)
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: rar
+          version: 1.0
+
+      - name: Pick environment to run
+        env:
+          PYTHON_VERSION: ${{ steps.setup.outputs.python-version }}
+        run: |
+          import codecs; import os
+          py = os.environ.get('PYTHON_VERSION')
+          py = ".".join(py.split(".")[:2])
+          test_env = f"tests.py{py}"
+          print(f"Picked {test_env}")
+          with codecs.open(os.environ["GITHUB_ENV"], mode="a", encoding="utf-8") as file_handler:
+              file_handler.write(f"ENV={test_env}\n")
+        shell: python
+      - name: Setup test environment
+        run: |
+          hatch -v env create ${ENV}
+        shell: bash
+      - name: Run test suite
+        env:
+          # Make sure to add `passenv=COVERAGE_FILE` to `[testenv]` in tox.ini
+          # Make sure to add `overrides = { env.COVERAGE_FILE.env-vars = "COVERAGE_FILE" }` to `[tests]` in hatch.toml
+          COVERAGE_FILE: ".core-coverage"
+          CI_RUN: "yes"
+        run: hatch -v run ${ENV}:run-cov-core
+        shell: bash
+
+      - name: Store coverage file
+        uses: actions/upload-artifact@v4
+        with:
+          name: core-coverage
+          path: .core-coverage
+          include-hidden-files: true
+          if-no-files-found: error
+
+
   # Ensure everything required is passing for branch protection.
   required-checks-pass:
     if: always()
 
     needs:
       - coverage
+      - core-coverage
       - docs
       - install-dev
       - typing

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -278,6 +278,7 @@ jobs:
 
       - name: Store coverage file
         uses: actions/upload-artifact@v4
+        if: ${{ failure() }}
         with:
           name: core-coverage
           path: .core-coverage

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -293,7 +293,7 @@ jobs:
 
     needs:
       - coverage
-      - core-coverage
+      # - core-coverage
       - docs
       - install-dev
       - typing

--- a/changelog.d/1211.change.rst
+++ b/changelog.d/1211.change.rst
@@ -1,0 +1,1 @@
+Improve core coverage: test ProviderPool

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,6 +77,7 @@ types = [
     "mypy",
     "types-requests",
     "types-beautifulsoup4",
+    "types-decorator",
 ]
 dev = [
     "pre-commit>=2.9.3",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -126,13 +126,14 @@ source = "vcs"
 # https://docs.pytest.org/en/6.2.x/customize.html
 [tool.pytest.ini_options]
 minversion = "6.0"
-addopts = "--import-mode=importlib --doctest-glob='*.rst'"
+addopts = "--import-mode=importlib --doctest-modules --doctest-glob='*.rst' --doctest-glob='*.md'"
 markers = [
     "integration",
     "converter",
     "core",
 ]
 doctest_optionflags = ["NORMALIZE_WHITESPACE", "IGNORE_EXCEPTION_DETAIL"]
+
 
 # https://coverage.readthedocs.io/en/latest/config.html
 [tool.coverage.report]

--- a/src/subliminal/core.py
+++ b/src/subliminal/core.py
@@ -274,12 +274,12 @@ class ProviderPool:
                 break
 
             # check downloaded languages
-            if subtitle.language in {s.language for s in downloaded_subtitles}:
+            if subtitle.language in {s.language for s in downloaded_subtitles}:  # pragma: no cover
                 logger.debug('Skipping subtitle: %r already downloaded', subtitle.language)
                 continue
 
             # download
-            if self.download_subtitle(subtitle):
+            if self.download_subtitle(subtitle):  # pragma: no branch
                 downloaded_subtitles.append(subtitle)
 
             # stop when all languages are downloaded
@@ -332,7 +332,7 @@ class AsyncProviderPool(ProviderPool):
         subtitles: list[Subtitle] = []
 
         # Avoid raising a ValueError with `ThreadPoolExecutor(self.max_workers)`
-        if self.max_workers == 0:
+        if self.max_workers == 0:  # pragma: no cover
             return subtitles
 
         with ThreadPoolExecutor(self.max_workers) as executor:

--- a/src/subliminal/core.py
+++ b/src/subliminal/core.py
@@ -114,7 +114,7 @@ class ProviderPool:
     def __iter__(self) -> Iterator[str]:
         return iter(self.initialized_providers)
 
-    def list_subtitles_provider(self, provider: str, video: Video, languages: Set[Language]) -> list[Subtitle]:
+    def list_subtitles_provider(self, provider: str, video: Video, languages: Set[Language]) -> list[Subtitle] | None:
         """List subtitles with a single provider.
 
         The video and languages are checked against the provider.
@@ -124,7 +124,7 @@ class ProviderPool:
         :type video: :class:`~subliminal.video.Video`
         :param languages: languages to search for.
         :type languages: set of :class:`~babelfish.language.Language`
-        :return: found subtitles.
+        :return: found subtitles or None if there was an error and the provider should be discarded.
         :rtype: list of :class:`~subliminal.subtitle.Subtitle` or None
 
         """
@@ -146,7 +146,8 @@ class ProviderPool:
         except Exception as e:  # noqa: BLE001
             handle_exception(e, f'Provider {provider}')
 
-        return []
+        # return None to discard this provider
+        return None
 
     def list_subtitles(self, video: Video, languages: Set[Language]) -> list[Subtitle]:
         """List subtitles.
@@ -322,7 +323,7 @@ class AsyncProviderPool(ProviderPool):
         provider: str,
         video: Video,
         languages: Set[Language],
-    ) -> tuple[str, list[Subtitle]]:
+    ) -> tuple[str, list[Subtitle] | None]:
         """List subtitles with a single provider, multi-threaded."""
         return provider, super().list_subtitles_provider(provider, video, languages)
 

--- a/src/subliminal/providers/__init__.py
+++ b/src/subliminal/providers/__init__.py
@@ -64,7 +64,7 @@ class TimeoutSafeTransport(SafeTransport):
     ) -> None:
         super().__init__(*args, **kwargs)
         self.timeout = timeout
-        if user_agent is not None:
+        if user_agent is not None:  # pragma: no branch
             self.user_agent = user_agent
 
     def make_connection(self, host: Any) -> HTTPSConnection:

--- a/src/subliminal/providers/mock.py
+++ b/src/subliminal/providers/mock.py
@@ -103,7 +103,7 @@ class MockProvider(Provider):
     def __init__(self, subtitle_pool: Sequence[MockSubtitle] | None = None) -> None:
         self.logged_in = False
         self.subtitle_pool = list(self.internal_subtitle_pool)
-        if subtitle_pool is not None:
+        if subtitle_pool is not None:  # pragma: no cover
             self.subtitle_pool.extend(list(subtitle_pool))
         self.is_broken = False
 
@@ -114,7 +114,7 @@ class MockProvider(Provider):
 
     def terminate(self) -> None:
         """Terminate the provider."""
-        if not self.logged_in:
+        if not self.logged_in:  # pragma: no cover
             logger.info('Mock provider %s was not terminated', self.__class__.__name__)
             raise NotInitializedProviderError
 
@@ -126,7 +126,7 @@ class MockProvider(Provider):
         languages: Set[Language],
         video: Video | None = None,
         matches: Set[str] | None = None,
-    ) -> list[MockSubtitle]:
+    ) -> list[MockSubtitle]:  # pragma: no cover
         """Query the provider for subtitles."""
         if self.is_broken:
             msg = f'Mock provider {self.__class__.__name__} query raised an error'

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -12,6 +12,8 @@ import requests
 from babelfish import Country, Language  # type: ignore[import-untyped]
 
 import subliminal
+import subliminal.cli
+import subliminal.refiners.hash
 from subliminal import Episode, Movie
 from subliminal.cache import region
 from subliminal.extensions import RegistrableExtensionManager
@@ -47,8 +49,10 @@ def movies() -> dict[str, Movie]:
                 'napiprojekt': '6303e7ee6a835e9fcede9fb2fb00cb36',
                 'bsplayer': '5b8f8f4e41ccb21e',
                 'opensubtitles': '5b8f8f4e41ccb21e',
-                'shooter': '314f454ab464775498ae6f1f5ad813a9;fdaa8b702d8936feba2122e93ba5c44f;'
-                '0a6935e3436aa7db5597ef67a2c494e3;4d269733f36ddd49f71e92732a462fe5',
+                'shooter': (
+                    '314f454ab464775498ae6f1f5ad813a9;fdaa8b702d8936feba2122e93ba5c44f;'
+                    '0a6935e3436aa7db5597ef67a2c494e3;4d269733f36ddd49f71e92732a462fe5'
+                ),
                 'thesubdb': 'ad32876133355929d814457537e12dc2',
             },
         ),
@@ -115,8 +119,10 @@ def episodes() -> dict[str, Episode]:
                 'napiprojekt': '6303e7ee6a835e9fcede9fb2fb00cb36',
                 'bsplayer': '6878b3ef7c1bd19e',
                 'opensubtitles': '6878b3ef7c1bd19e',
-                'shooter': 'c13e0e5243c56d280064d344676fff94;cd4184d1c0c623735f6db90841ce15fc;'
-                '3faefd72f92b63f2504269b4f484a377;8c68d1ef873afb8ba0cc9f97cbac41c1',
+                'shooter': (
+                    'c13e0e5243c56d280064d344676fff94;cd4184d1c0c623735f6db90841ce15fc;'
+                    '3faefd72f92b63f2504269b4f484a377;8c68d1ef873afb8ba0cc9f97cbac41c1'
+                ),
                 'thesubdb': '9dbbfb7ba81c9a6237237dae8589fccc',
             },
         ),
@@ -160,8 +166,10 @@ def episodes() -> dict[str, Episode]:
                 'napiprojekt': '6303e7ee6a835e9fcede9fb2fb00cb36',
                 'bsplayer': 'b850baa096976c22',
                 'opensubtitles': 'b850baa096976c22',
-                'shooter': 'b02d992c04ad74b31c252bd5a097a036;ef1b32f873b2acf8f166fc266bdf011a;'
-                '82ce34a3bcee0c66ed3b26d900d31cca;78113770551f3efd1e2d4ec45898c59c',
+                'shooter': (
+                    'b02d992c04ad74b31c252bd5a097a036;ef1b32f873b2acf8f166fc266bdf011a;'
+                    '82ce34a3bcee0c66ed3b26d900d31cca;78113770551f3efd1e2d4ec45898c59c'
+                ),
                 'thesubdb': 'b1f899c77f4c960b84b8dbf840d4e42d',
             },
         ),
@@ -761,6 +769,7 @@ def provider_manager(monkeypatch: pytest.MonkeyPatch) -> Generator[RegistrableEx
     subtitle_pool_tvsubtitles = [
         {
             'language': Language.fromietf('en'),
+            'hearing_impaired': True,
             'subtitle_id': '23329',
             'fake_content': (
                 b'1\n00:00:04,254 --> 00:00:07,214\n'

--- a/tests/providers/test_providers.py
+++ b/tests/providers/test_providers.py
@@ -345,6 +345,7 @@ def test_download_best_subtitles_only_one(episodes):
 def test_download_bad_subtitle(movies):
     pool = ProviderPool()
     subtitles = pool.list_subtitles_provider('opensubtitles', movies['man_of_steel'], {Language('eng')})
+    assert subtitles is not None
     assert len(subtitles) >= 1
     subtitle = subtitles[0]
     subtitle.subtitle_id = ''

--- a/tests/test_provider_pool.py
+++ b/tests/test_provider_pool.py
@@ -103,6 +103,8 @@ def test_provider_pool_iter():
     pool = ProviderPool()
     assert len(list(pool)) == 0
     pool['tvsubtitles']
+    # test printing
+    print(pool['tvsubtitles'])  # noqa: T201
     assert len(list(pool)) == 1
 
 

--- a/tests/test_provider_pool.py
+++ b/tests/test_provider_pool.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import logging
-import sys
 from typing import TYPE_CHECKING, cast
 from unittest.mock import Mock, call
 
@@ -33,15 +31,6 @@ pytestmark = [
     pytest.mark.usefixtures('provider_manager'),
     pytest.mark.usefixtures('disabled_providers'),
 ]
-
-root = logging.getLogger('subliminal')
-root.setLevel(logging.DEBUG)
-
-handler = logging.StreamHandler(sys.stdout)
-handler.setLevel(logging.DEBUG)
-formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
-handler.setFormatter(formatter)
-root.addHandler(handler)
 
 
 @pytest.fixture


### PR DESCRIPTION
Add tests for `ProviderPool` using `MockProvider`s.
Coverage of core files is 100%

Fix a regression introduced when adding the type hints, so that a provider that gives an error will be discarded in the future.

Add testing of doctest in the module.