### PR TITLE
Fix no abs path

### DIFF
--- a/changelog.d/1216.change.rst
+++ b/changelog.d/1216.change.rst
@@ -1,0 +1,1 @@
+do not convert path to absolute path

--- a/docs/user/usage.rst
+++ b/docs/user/usage.rst
@@ -98,8 +98,8 @@ Here video information was guessed based on the name of the video, you can acces
 
 Video information is guessed using the path, not only the file name. This helps guessing episodes such as:
 
-    >>> video = Video.fromname('Mrs.America/01x01.mp4')
-    >>> video
+    >>> episode = Video.fromname('Mrs.America/01x01.mp4')
+    >>> episode
     <Episode [Mrs America s01e01]>
 
 Configuration

--- a/docs/user/usage.rst
+++ b/docs/user/usage.rst
@@ -81,8 +81,9 @@ Video
 ^^^^^
 The :class:`~subliminal.video.Movie` and :class:`~subliminal.video.Episode` classes represent a video,
 existing or not. You can create a video by name (or path) with :meth:`Video.fromname <subliminal.video.Video.fromname>`,
-use :func:`~subliminal.core.scan_video` on an existing file path to get even more information about the video or
-use :func:`~subliminal.core.scan_videos` on an existing directory path to scan a whole directory for videos.
+use :func:`~subliminal.core.scan_video` on an existing file path, or :func:`~subliminal.core.scan_name`
+on a non-existing file path, to get even more information about the video or use :func:`~subliminal.core.scan_videos`
+on an existing directory path to scan a whole directory for videos.
 
     >>> video = Video.fromname('The.Big.Bang.Theory.S05E18.HDTV.x264-LOL.mp4')
     >>> video
@@ -94,6 +95,12 @@ Here video information was guessed based on the name of the video, you can acces
     'H.264'
     >>> video.release_group
     'LOL'
+
+Video information is guessed using the path, not only the file name. This helps guessing episodes such as:
+
+    >>> video = Video.fromname('Mrs.America/01x01.mp4')
+    >>> video
+    <Episode [Mrs America s01e01]>
 
 Configuration
 ^^^^^^^^^^^^^

--- a/src/subliminal/cli.py
+++ b/src/subliminal/cli.py
@@ -651,7 +651,8 @@ def download(
             if debug:
                 # print a new line, so the logs appear below the progressbar
                 click.echo()
-            p = os.path.abspath(os.path.expanduser(p))
+            # expand user in case an absolute path is provided
+            p = os.path.expanduser(p)
             logger.debug('Collecting path %s', p)
 
             video_candidates: list[Video] = []

--- a/src/subliminal/core.py
+++ b/src/subliminal/core.py
@@ -466,20 +466,25 @@ def search_external_subtitles(
 
 
 def scan_name(path: str | os.PathLike, name: str | None = None) -> Video:
-    """Scan a video from a `path` that does not exist.
+    """Scan a video from a `path`.
 
-    :param str path: non-existing path to the video.
+    :param str path: path to the video.
     :param str name: if defined, name to use with guessit instead of the path.
     :return: the scanned video.
     :rtype: :class:`~subliminal.video.Video`
     """
     path = os.fspath(path)
     repl = name if name else path
+    if name:
+        logger.info('Scanning video %r, with replacement name %r', path, repl)
+    else:
+        logger.info('Scanning video %r', path)
+
     return Video.fromguess(path, guessit(repl))
 
 
 def scan_video(path: str | os.PathLike, name: str | None = None) -> Video:
-    """Scan a video from a `path`.
+    """Scan a video from an existing `path`.
 
     :param str path: existing path to the video.
     :param str name: if defined, name to use with guessit instead of the path.
@@ -498,15 +503,8 @@ def scan_video(path: str | os.PathLike, name: str | None = None) -> Video:
         msg = f'{os.path.splitext(path)[1]!r} is not a valid video extension'
         raise ValueError(msg)
 
-    dirpath, filename = os.path.split(path)
-    repl = name if name else path
-    if name:
-        logger.info('Scanning video %r in %r, with replacement name %r', filename, dirpath, repl)
-    else:
-        logger.info('Scanning video %r in %r', filename, dirpath)
-
     # guess
-    video = Video.fromguess(path, guessit(repl))
+    video = scan_name(path, name=name)
 
     # size
     video.size = os.path.getsize(path)


### PR DESCRIPTION
fixes #1216 

Document the fact that `guessit` is using the path and not only the file name to guess the video information.