### PR TITLE
Show guessit error without --debug

### DIFF
--- a/changelog.d/1164.change.rst
+++ b/changelog.d/1164.change.rst
@@ -1,0 +1,1 @@
+show "Insufficient data to process the guess" without debug, but with verbose

--- a/src/subliminal/cli.py
+++ b/src/subliminal/cli.py
@@ -44,6 +44,7 @@ from subliminal.core import (
     scan_video_or_archive,
     search_external_subtitles,
 )
+from subliminal.exceptions import GuessingError
 from subliminal.extensions import get_default_providers, get_default_refiners
 from subliminal.utils import get_parameters_from_signature, merge_extend_and_ignore_unions
 
@@ -679,6 +680,16 @@ def download(
                         video = scan_video_or_archive(filepath, name=name)
                     else:
                         video = scan_name(filepath, name=name)
+
+                except GuessingError as e:
+                    # Show a simple error message
+                    if verbose > 0:
+                        # new line was already added with debug
+                        if not debug:
+                            click.echo()
+                        click.secho(e, fg='yellow')
+                    errored_paths.append(filepath)
+                    continue
 
                 except ValueError:
                     logger.exception(

--- a/src/subliminal/cli.py
+++ b/src/subliminal/cli.py
@@ -36,10 +36,14 @@ from subliminal import (
     refiner_manager,
     region,
     save_subtitles,
-    scan_video,
-    scan_videos,
 )
-from subliminal.core import ARCHIVE_EXTENSIONS, scan_name, search_external_subtitles
+from subliminal.core import (
+    ARCHIVE_EXTENSIONS,
+    collect_video_filepaths,
+    scan_name,
+    scan_video_or_archive,
+    search_external_subtitles,
+)
 from subliminal.extensions import get_default_providers, get_default_refiners
 from subliminal.utils import get_parameters_from_signature, merge_extend_and_ignore_unions
 
@@ -654,39 +658,37 @@ def download(
             p = os.path.abspath(os.path.expanduser(p))
             logger.debug('Collecting path %s', p)
 
+            # collect files from directory
+            collected_filepaths = [p]
+            if os.path.isdir(p):
+                # collect video files
+                try:
+                    collected_filepaths = collect_video_filepaths(p, age=age, archives=archives)
+                except ValueError:
+                    logger.exception('Unexpected error while collecting directory path %s', p)
+                    errored_paths.append(p)
+                    continue
+
+            # scan videos
             video_candidates: list[Video] = []
-
-            # non-existing
-            if not os.path.exists(p):
+            for filepath in collected_filepaths:
+                exists = os.path.exists(p)
                 try:
-                    video = scan_name(p, name=name)
-                except ValueError:
-                    repl_p = f'{p} ({name})' if name else p
-                    logger.exception('Unexpected error while collecting non-existing path %s', repl_p)
-                    errored_paths.append(p)
-                    continue
-                video_candidates.append(video)
+                    # existing path
+                    if exists:  # noqa: SIM108
+                        video = scan_video_or_archive(filepath, name=name)
+                    else:
+                        video = scan_name(filepath, name=name)
 
-            # directories
-            elif os.path.isdir(p):
-                try:
-                    scanned_videos = scan_videos(p, age=age, archives=archives, name=name)
                 except ValueError:
-                    repl_p = f'{p} ({name})' if name else p
-                    logger.exception('Unexpected error while collecting directory path %s', repl_p)
-                    errored_paths.append(p)
+                    logger.exception(
+                        'Unexpected error while collecting %s %s',
+                        'path' if exists else 'non-existing path',
+                        f'{filepath} ({name})' if name else filepath,
+                    )
+                    errored_paths.append(filepath)
                     continue
-                video_candidates.extend(scanned_videos)
 
-            # other inputs
-            else:
-                try:
-                    video = scan_video(p, name=name)
-                except ValueError:
-                    repl_p = f'{p} ({name})' if name else p
-                    logger.exception('Unexpected error while collecting path %s', repl_p)
-                    errored_paths.append(p)
-                    continue
                 video_candidates.append(video)
 
             # check and refine videos
@@ -740,11 +742,12 @@ def download(
     # exit if no providers are used
     if len(use_providers) == 0:
         click.echo('No provider was selected to download subtitles.')
-        if 'ALL' in ignore_provider:
-            click.echo('All ignored from CLI argument: `--ignore-provider=ALL`')
-        elif 'ALL' in obj['provider_lists']['ignore']:
-            config_ignore = list(obj['provider_lists']['ignore'])
-            click.echo(f'All ignored from configuration: `ignore_provider={config_ignore}`')
+        if verbose > 0:
+            if 'ALL' in ignore_provider:
+                click.echo('All ignored from CLI argument: `--ignore-provider=ALL`')
+            elif 'ALL' in obj['provider_lists']['ignore']:
+                config_ignore = list(obj['provider_lists']['ignore'])
+                click.echo(f'All ignored from configuration: `ignore_provider={config_ignore}`')
         return
 
     # download best subtitles

--- a/src/subliminal/exceptions.py
+++ b/src/subliminal/exceptions.py
@@ -13,6 +13,12 @@ class ArchiveError(Error):
     pass
 
 
+class GuessingError(Error, ValueError):
+    """ValueError raised when guessit cannot guess a video."""
+
+    pass
+
+
 class ProviderError(Error):
     """Exception raised by providers."""
 

--- a/src/subliminal/video.py
+++ b/src/subliminal/video.py
@@ -9,6 +9,7 @@ from typing import TYPE_CHECKING, Any
 
 from guessit import guessit  # type: ignore[import-untyped]
 
+from subliminal.exceptions import GuessingError
 from subliminal.utils import ensure_list, get_age, matches_extended_title
 
 if TYPE_CHECKING:
@@ -258,7 +259,7 @@ class Video:
             return Movie.fromguess(name, guess)
 
         msg = 'The guess must be an episode or a movie guess'  # pragma: no-cover
-        raise ValueError(msg)
+        raise GuessingError(msg)
 
     @classmethod
     def fromname(cls, name: str) -> Video:
@@ -380,8 +381,8 @@ class Episode(Video):
             raise ValueError(msg)
 
         if 'title' not in guess or 'episode' not in guess:
-            msg = 'Insufficient data to process the guess'
-            raise ValueError(msg)
+            msg = f'Insufficient data to process the guess for {name!r}'
+            raise GuessingError(msg)
 
         return cls(
             name,
@@ -470,8 +471,8 @@ class Movie(Video):
             raise ValueError(msg)
 
         if 'title' not in guess:
-            msg = 'Insufficient data to process the guess'
-            raise ValueError(msg)
+            msg = f'Insufficient data to process the guess for {name!r}'
+            raise GuessingError(msg)
 
         return cls(
             name,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import os
+import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from textwrap import dedent
@@ -28,6 +29,11 @@ from subliminal.video import Episode, Movie
 
 # Core test
 pytestmark = pytest.mark.core
+
+unix_platform = pytest.mark.skipif(
+    not sys.platform.startswith('linux'),
+    reason='only on linux platform',
+)
 
 
 def ensure(path: str | os.PathLike[str], *, directory: bool = False) -> Path:
@@ -302,6 +308,7 @@ def test_scan_video_movie_name_path_does_not_exist(movies: dict[str, Movie]) -> 
     assert scanned_video.year == video.year
 
 
+@unix_platform
 def test_scan_archive_error(
     rar: dict[str, str],
 ) -> None:
@@ -313,6 +320,7 @@ def test_scan_archive_error(
         scan_video_or_archive(path)
 
 
+@unix_platform
 def test_scan_videos_error(
     rar: dict[str, str],
     caplog: pytest.LogCaptureFixture,

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -2,7 +2,6 @@
 from __future__ import annotations
 
 import os
-import sys
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from textwrap import dedent
@@ -29,11 +28,6 @@ from subliminal.video import Episode, Movie
 
 # Core test
 pytestmark = pytest.mark.core
-
-unix_platform = pytest.mark.skipif(
-    not sys.platform.startswith('linux'),
-    reason='only on linux platform',
-)
 
 
 def ensure(path: str | os.PathLike[str], *, directory: bool = False) -> Path:
@@ -308,10 +302,11 @@ def test_scan_video_movie_name_path_does_not_exist(movies: dict[str, Movie]) -> 
     assert scanned_video.year == video.year
 
 
-@unix_platform
 def test_scan_archive_error(
     rar: dict[str, str],
 ) -> None:
+    if 'pwd-protected' not in rar:
+        return
     path = rar['pwd-protected']
     with pytest.raises(ArchiveError):
         scan_archive(path)
@@ -320,11 +315,12 @@ def test_scan_archive_error(
         scan_video_or_archive(path)
 
 
-@unix_platform
 def test_scan_videos_error(
     rar: dict[str, str],
     caplog: pytest.LogCaptureFixture,
 ) -> None:
+    if 'pwd-protected' not in rar:
+        return
     folder = Path(rar['pwd-protected']).parent
     # Test return without error
     scan_videos(folder)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -17,6 +17,7 @@ from subliminal.core import (
     scan_archive,
     scan_name,
     scan_video,
+    scan_video_or_archive,
     scan_videos,
     search_external_subtitles,
 )
@@ -193,9 +194,12 @@ def test_scan_video_episode(episodes: dict[str, Episode], tmp_path: Path, monkey
 
 
 def test_scan_video_path_does_not_exist(movies: dict[str, Movie]) -> None:
-    with pytest.raises(ValueError) as excinfo:
-        scan_video(movies['man_of_steel'].name)
-    assert str(excinfo.value) == 'Path does not exist'
+    path = movies['man_of_steel'].name
+    with pytest.raises(ValueError, match='Path does not exist'):
+        scan_video(path)
+
+    with pytest.raises(ValueError, match='Path does not exist'):
+        scan_video_or_archive(path)
 
 
 def test_scan_video_invalid_extension(
@@ -206,9 +210,8 @@ def test_scan_video_invalid_extension(
     monkeypatch.chdir(tmp_path)
     movie_name = os.path.splitext(movies['man_of_steel'].name)[0] + '.mp3'
     ensure(tmp_path / movie_name)
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ValueError, match="'.mp3' is not a valid video extension"):
         scan_video(movie_name)
-    assert str(excinfo.value) == "'.mp3' is not a valid video extension"
 
 
 def test_scan_video_broken(mkv: dict[str, str], tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
@@ -297,6 +300,31 @@ def test_scan_video_movie_name_path_does_not_exist(movies: dict[str, Movie]) -> 
     assert scanned_video.subtitle_languages == set()
     assert scanned_video.title == video.title
     assert scanned_video.year == video.year
+
+
+def test_scan_archive_error(
+    rar: dict[str, str],
+) -> None:
+    path = rar['pwd-protected']
+    with pytest.raises(ArchiveError):
+        scan_archive(path)
+
+    with pytest.raises(ValueError, match='Error scanning archive'):
+        scan_video_or_archive(path)
+
+
+def test_scan_videos_error(
+    rar: dict[str, str],
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    folder = Path(rar['pwd-protected']).parent
+    # Test return without error
+    scan_videos(folder)
+
+    # But error was logged
+    for record in caplog.records:
+        assert record.levelname == 'ERROR'
+    assert 'Error scanning archive' in caplog.text
 
 
 def test_scan_archive_invalid_extension(

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -151,30 +151,26 @@ def test_episode_from_guess_multi_episode(episodes: dict[str, Episode]) -> None:
 
 def test_episode_fromguess_wrong_type(episodes: dict[str, Episode]) -> None:
     guess = {'type': 'subtitle'}
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ValueError, match='The guess must be an episode guess'):
         Episode.fromguess(episodes['bbt_s07e05'].name, guess)
-    assert str(excinfo.value) == 'The guess must be an episode guess'
 
 
 def test_episode_fromguess_insufficient_data(episodes: dict[str, Episode]) -> None:
     guess = {'type': 'episode'}
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ValueError, match='Insufficient data to process the guess'):
         Episode.fromguess(episodes['bbt_s07e05'].name, guess)
-    assert str(excinfo.value) == 'Insufficient data to process the guess'
 
 
 def test_movie_fromguess_wrong_type(movies: dict[str, Movie]) -> None:
     guess = {'type': 'subtitle'}
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ValueError, match='The guess must be a movie guess'):
         Movie.fromguess(movies['man_of_steel'].name, guess)
-    assert str(excinfo.value) == 'The guess must be a movie guess'
 
 
 def test_movie_fromguess_insufficient_data(movies: dict[str, Movie]) -> None:
     guess = {'type': 'movie'}
-    with pytest.raises(ValueError) as excinfo:
+    with pytest.raises(ValueError, match='Insufficient data to process the guess'):
         Movie.fromguess(movies['man_of_steel'].name, guess)
-    assert str(excinfo.value) == 'Insufficient data to process the guess'
 
 
 def test_movie_fromname(movies: dict[str, Movie]) -> None:


### PR DESCRIPTION
fixes #1164, #1059

Videos that are not guessed are shown with the verbose flag (`-v`), not only with `--debug`.

Refactor `scan_videos` and add a `GuessingError` exception, a `ValueError` subclass for compatibility reasons.