### PR TITLE
CI: only download mkv and rar once before running tests

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -165,7 +165,7 @@ jobs:
         with:
           python-version: ${{ matrix.py }}
           allow-prereleases: true
-      - uses: actions/download-artifact
+      - uses: actions/download-artifact@v4
         with:
           name: tests-data
           merge-multiple: true
@@ -276,6 +276,10 @@ jobs:
         id: setup
         with:
           python-version-file: .python-version-default
+      - uses: actions/download-artifact@v4
+        with:
+          name: tests-data
+          merge-multiple: true
       - name: Install hatch
         run: python -Im pip install hatch
 

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -5,6 +5,8 @@ on:
     branches: [main]
   pull_request: {}
 
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -115,10 +115,34 @@ jobs:
       # packaging metadata (trove classifiers).
       supported-python-versions: ${{ steps.baipp.outputs.supported_python_classifiers_json_array }}
 
+  prepare-test:
+    name: Build & verify package
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+
+      - name: Install other test software (on Linux only)
+        uses: awalsh128/cache-apt-pkgs-action@v1
+        with:
+          packages: rar
+          version: 1.0
+
+      - name: Upload files for test
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-${{ matrix.os }}-${{ matrix.py }}
+          path: .coverage*
+          include-hidden-files: true
+          if-no-files-found: error
+
   test:
     name: Test
     runs-on: ${{ matrix.os }}
-    needs: build-package
+    needs: [build-package, prepare-test]
     strategy:
       fail-fast: false
       matrix:
@@ -236,7 +260,7 @@ jobs:
   core-coverage:
     name: Core Coverage
     runs-on: ubuntu-latest
-    needs: build-package
+    needs: [build-package, prepare-test]
     if: false
     steps:
       - uses: actions/checkout@v4
@@ -248,12 +272,6 @@ jobs:
           python-version-file: .python-version-default
       - name: Install hatch
         run: python -Im pip install hatch
-
-      - name: Install other test software (on Linux only)
-        uses: awalsh128/cache-apt-pkgs-action@v1
-        with:
-          packages: rar
-          version: 1.0
 
       - name: Pick environment to run
         env:

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -172,6 +172,8 @@ jobs:
         with:
           name: tests-data
           merge-multiple: true
+      - name: Display structure of downloaded files
+        run: ls -R tests
 
       - name: Install hatch
         run: python -Im pip install hatch

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -147,7 +147,8 @@ jobs:
               file_handler.write(f"FORCE_COLOR=1\nENV={py}\n")
         shell: python
       - name: Install other test software (on Linux only)
-        if: matrix.os == 'ubuntu-latest'
+        # Keep python version to latest release
+        if: matrix.os == 'ubuntu-latest' && matrix.py == 3.13
         uses: awalsh128/cache-apt-pkgs-action@v1
         with:
           packages: rar

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -118,7 +118,7 @@ jobs:
       supported-python-versions: ${{ steps.baipp.outputs.supported_python_classifiers_json_array }}
 
   prepare-test:
-    name: Build & verify package
+    name: Download data for tests
     runs-on: ubuntu-latest
 
     steps:
@@ -138,9 +138,10 @@ jobs:
       - name: Install dependencies
         run: |
           python -Im pip install --upgrade pip
+          python -Im pip install tox requests
       - name: Download tests data
         run: |
-          python scripts/prepare_tests.py
+          tox -e prepare-tests
       - name: Upload files for test
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -124,19 +124,27 @@ jobs:
         with:
           persist-credentials: false
           fetch-depth: 0
-
       - name: Install other test software (on Linux only)
         uses: awalsh128/cache-apt-pkgs-action@v1
         with:
           packages: rar
           version: 1.0
-
+      - uses: actions/setup-python@v5
+        with:
+          python-version-file: .python-version-default
+          cache: pip
+      - name: Install dependencies
+        run: |
+          python -Im pip install --upgrade pip
+      - name: Download tests data
+        run: |
+          python scripts/prepare_tests.py
       - name: Upload files for test
         uses: actions/upload-artifact@v4
         with:
-          name: coverage-${{ matrix.os }}-${{ matrix.py }}
-          path: .coverage*
-          include-hidden-files: true
+          name: tests-data
+          path: tests/data/
+          include-hidden-files: false
           if-no-files-found: error
 
   test:
@@ -157,6 +165,11 @@ jobs:
         with:
           python-version: ${{ matrix.py }}
           allow-prereleases: true
+      - uses: actions/download-artifact
+        with:
+          name: tests-data
+          merge-multiple: true
+
       - name: Install hatch
         run: python -Im pip install hatch
 
@@ -170,13 +183,6 @@ jobs:
           with codecs.open(os.environ["GITHUB_ENV"], mode="a", encoding="utf-8") as file_handler:
               file_handler.write(f"FORCE_COLOR=1\nENV={py}\n")
         shell: python
-      - name: Install other test software (on Linux only)
-        # Keep python version to latest release
-        if: matrix.os == 'ubuntu-latest' && matrix.py == 3.13
-        uses: awalsh128/cache-apt-pkgs-action@v1
-        with:
-          packages: rar
-          version: 1.0
       - name: Setup test environment
         run: |
           hatch -v env create ${ENV}

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -171,9 +171,10 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: tests-data
+          path: tests/data/
           merge-multiple: true
-      - name: Display structure of downloaded files
-        run: ls -R tests
+      - name: Display downloaded files
+        run: ls -R tests/data
 
       - name: Install hatch
         run: python -Im pip install hatch

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -8,6 +8,8 @@ on:
     types:
       - published
 
+permissions: {}
+
 env:
   FORCE_COLOR: "1"
   PIP_DISABLE_PIP_VERSION_CHECK: "1"

--- a/.github/workflows/scheduled-tests.yaml
+++ b/.github/workflows/scheduled-tests.yaml
@@ -5,6 +5,8 @@ on:
     - cron: "12 12 12 * *" # run once a month on the 12th at 12:12
   workflow_dispatch:
 
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/changelog.d/1220.change.rst
+++ b/changelog.d/1220.change.rst
@@ -1,0 +1,1 @@
+create a prepare_tests.py script to download the tests data beforehand and avoid repeated downloads

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -220,6 +220,7 @@ unfixable = [
 "docs/conf*.py" = ["A001", "D"]
 "src/subliminal/__init__.py" = ["E402"]
 "tests/*.py" = ["D", "S", "RUF012", "FBT"]
+"scripts/*.py" = ["T201"]
 
 # https://docs.astral.sh/ruff/formatter/
 [tool.ruff.format]

--- a/scripts/prepare_tests.py
+++ b/scripts/prepare_tests.py
@@ -1,0 +1,112 @@
+"""Download files to be used in tests."""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from io import BytesIO
+from pathlib import Path
+from zipfile import ZipFile
+
+import requests
+
+TESTS = Path(__file__).parent / 'tests'
+
+
+def download_mkvs(data_path: str | os.PathLike[str]) -> dict[str, str]:
+    """Download mkv files to be used in tests."""
+    # data_path = TESTS / 'data' / 'mkv'
+    data_path = Path(data_path)
+    if not data_path.is_dir():
+        os.makedirs(data_path)
+
+    wanted_files = [f'test{i}.mkv' for i in range(1, 9)]
+
+    # check for missing files
+    missing_files = [f for f in wanted_files if not (data_path / f).is_file()]
+    if missing_files:
+        # download matroska test suite
+        r = requests.get(
+            'https://downloads.sourceforge.net/project/matroska/test_files/matroska_test_w1_1.zip',
+            timeout=20,
+        )
+        with ZipFile(BytesIO(r.content), 'r') as f:
+            for missing_file in missing_files:
+                f.extract(missing_file, data_path)
+
+    # populate a dict with mkv files
+    files = {}
+    for path in os.listdir(data_path):
+        if path not in wanted_files:
+            continue
+        name, _ = os.path.splitext(path)
+        files[name] = os.fspath(data_path / path)
+
+    return files
+
+
+def download_rars(data_path: str | os.PathLike[str]) -> dict[str, str]:
+    """Download rar files to be used in tests."""
+    # data_path = TESTS / 'data' / 'rar'
+    data_path = Path(data_path)
+    if not data_path.is_dir():
+        os.makedirs(data_path)
+
+    downloaded_files = {
+        'pwd-protected': 'https://github.com/markokr/rarfile/blob/master/test/files/rar5-psw.rar?raw=true',
+        'simple': 'https://github.com/markokr/rarfile/blob/master/test/files/rar5-quick-open.rar?raw=true',
+    }
+
+    files = {}
+    # Add downloaded files
+    for name, download_url in downloaded_files.items():
+        filename = data_path / (name + '.rar')
+        if not filename.is_file():
+            r = requests.get(download_url, timeout=20)
+            with filename.open('wb') as f:
+                f.write(r.content)
+        files[name] = os.fspath(filename)
+
+    return files
+
+
+def compress_to_rar(data_path: str | os.PathLike[str], mkv: dict[str, str]) -> dict[str, str]:
+    """Compress mkv files to rar files to be used in tests."""
+    data_path = TESTS / 'data' / 'rar'
+    if not data_path.is_dir():
+        os.makedirs(data_path)
+
+    downloaded_files = {
+        'pwd-protected': 'https://github.com/markokr/rarfile/blob/master/test/files/rar5-psw.rar?raw=true',
+        'simple': 'https://github.com/markokr/rarfile/blob/master/test/files/rar5-quick-open.rar?raw=true',
+    }
+
+    generated_files = {
+        'video': [mkv.get('test1')],
+        'videos': [mkv.get('test3'), mkv.get('test4'), mkv.get('test5')],
+    }
+
+    files = {}
+    # Add downloaded files
+    for name, download_url in downloaded_files.items():
+        filename = os.path.join(data_path, name + '.rar')
+        if not os.path.exists(filename):
+            r = requests.get(download_url, timeout=20)
+            with open(filename, 'wb') as f:
+                f.write(r.content)
+        files[name] = filename
+
+    # Add generated files
+    for name, videos in generated_files.items():
+        existing_videos = [v for v in videos if v and os.path.isfile(v)]
+        filename = os.path.join(data_path, name + '.rar')
+        if not os.path.exists(filename):
+            try:
+                subprocess.run(['rar', 'a', '-ep', filename, *existing_videos], check=True)  # noqa: S603, S607
+            except FileNotFoundError:
+                # rar command line is not installed
+                print('rar is not installed')
+        if os.path.exists(filename):
+            files[name] = filename
+
+    return files

--- a/scripts/prepare_tests.py
+++ b/scripts/prepare_tests.py
@@ -2,28 +2,31 @@
 
 from __future__ import annotations
 
+import argparse
 import os
 import subprocess
+import warnings
 from io import BytesIO
 from pathlib import Path
 from zipfile import ZipFile
 
 import requests
 
-TESTS = Path(__file__).parent / 'tests'
+TESTS = Path(__file__).parent.parent / 'tests'
+TESTS_DATA_DIR = TESTS / 'data'
 
 
-def download_mkvs(data_path: str | os.PathLike[str]) -> dict[str, str]:
+def download_mkv(mkv_dir_path: str | os.PathLike[str]) -> dict[str, str]:
     """Download mkv files to be used in tests."""
     # data_path = TESTS / 'data' / 'mkv'
-    data_path = Path(data_path)
-    if not data_path.is_dir():
-        os.makedirs(data_path)
+    mkv_dir_path = Path(mkv_dir_path)
+    if not mkv_dir_path.is_dir():
+        os.makedirs(mkv_dir_path)
 
     wanted_files = [f'test{i}.mkv' for i in range(1, 9)]
 
     # check for missing files
-    missing_files = [f for f in wanted_files if not (data_path / f).is_file()]
+    missing_files = [f for f in wanted_files if not (mkv_dir_path / f).is_file()]
     if missing_files:
         # download matroska test suite
         r = requests.get(
@@ -32,25 +35,25 @@ def download_mkvs(data_path: str | os.PathLike[str]) -> dict[str, str]:
         )
         with ZipFile(BytesIO(r.content), 'r') as f:
             for missing_file in missing_files:
-                f.extract(missing_file, data_path)
+                f.extract(missing_file, mkv_dir_path)
 
     # populate a dict with mkv files
     files = {}
-    for path in os.listdir(data_path):
+    for path in os.listdir(mkv_dir_path):
         if path not in wanted_files:
             continue
         name, _ = os.path.splitext(path)
-        files[name] = os.fspath(data_path / path)
+        files[name] = os.fspath(mkv_dir_path / path)
 
     return files
 
 
-def download_rars(data_path: str | os.PathLike[str]) -> dict[str, str]:
+def download_rar(rar_dir_path: str | os.PathLike[str]) -> dict[str, str]:
     """Download rar files to be used in tests."""
     # data_path = TESTS / 'data' / 'rar'
-    data_path = Path(data_path)
-    if not data_path.is_dir():
-        os.makedirs(data_path)
+    rar_dir_path = Path(rar_dir_path)
+    if not rar_dir_path.is_dir():
+        os.makedirs(rar_dir_path)
 
     downloaded_files = {
         'pwd-protected': 'https://github.com/markokr/rarfile/blob/master/test/files/rar5-psw.rar?raw=true',
@@ -60,7 +63,7 @@ def download_rars(data_path: str | os.PathLike[str]) -> dict[str, str]:
     files = {}
     # Add downloaded files
     for name, download_url in downloaded_files.items():
-        filename = data_path / (name + '.rar')
+        filename = rar_dir_path / (name + '.rar')
         if not filename.is_file():
             r = requests.get(download_url, timeout=20)
             with filename.open('wb') as f:
@@ -70,16 +73,12 @@ def download_rars(data_path: str | os.PathLike[str]) -> dict[str, str]:
     return files
 
 
-def compress_to_rar(data_path: str | os.PathLike[str], mkv: dict[str, str]) -> dict[str, str]:
+def compress_to_rar(rar_dir_path: str | os.PathLike[str], mkv: dict[str, str]) -> dict[str, str]:
     """Compress mkv files to rar files to be used in tests."""
-    data_path = TESTS / 'data' / 'rar'
-    if not data_path.is_dir():
-        os.makedirs(data_path)
-
-    downloaded_files = {
-        'pwd-protected': 'https://github.com/markokr/rarfile/blob/master/test/files/rar5-psw.rar?raw=true',
-        'simple': 'https://github.com/markokr/rarfile/blob/master/test/files/rar5-quick-open.rar?raw=true',
-    }
+    # data_path = TESTS / 'data' / 'rar'
+    rar_dir_path = Path(rar_dir_path)
+    if not rar_dir_path.is_dir():
+        os.makedirs(rar_dir_path)
 
     generated_files = {
         'video': [mkv.get('test1')],
@@ -87,26 +86,49 @@ def compress_to_rar(data_path: str | os.PathLike[str], mkv: dict[str, str]) -> d
     }
 
     files = {}
-    # Add downloaded files
-    for name, download_url in downloaded_files.items():
-        filename = os.path.join(data_path, name + '.rar')
-        if not os.path.exists(filename):
-            r = requests.get(download_url, timeout=20)
-            with open(filename, 'wb') as f:
-                f.write(r.content)
-        files[name] = filename
-
     # Add generated files
     for name, videos in generated_files.items():
         existing_videos = [v for v in videos if v and os.path.isfile(v)]
-        filename = os.path.join(data_path, name + '.rar')
+        filename = os.fspath(rar_dir_path / (name + '.rar'))
         if not os.path.exists(filename):
             try:
                 subprocess.run(['rar', 'a', '-ep', filename, *existing_videos], check=True)  # noqa: S603, S607
             except FileNotFoundError:
                 # rar command line is not installed
-                print('rar is not installed')
+                warnings.warn('rar is not installed', UserWarning, stacklevel=2)
         if os.path.exists(filename):
             files[name] = filename
 
     return files
+
+
+def prepare_files(data_path: str | os.PathLike[str]) -> dict[str, dict[str, str]]:
+    """Download and prepare files for tests."""
+    data_path = Path(data_path)
+    if not data_path.is_dir():
+        os.makedirs(data_path)
+
+    # Download mkv files
+    mkv = download_mkv(data_path / 'mkv')
+
+    # Download rar files
+    rar = download_rar(data_path / 'rar')
+
+    # Compress mkv to rar
+    rar.update(compress_to_rar(data_path / 'rar', mkv))
+
+    return {'mkv': mkv, 'rar': rar}
+
+
+def main() -> None:
+    """Main script."""
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--dir', default=TESTS_DATA_DIR)
+
+    args = parser.parse_args()
+
+    prepare_files(args.dir)
+
+
+if __name__ == '__main__':
+    main()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -875,7 +875,7 @@ def rar(mkv: dict[str, str]) -> dict[str, str]:
         existing_videos = [v for v in videos if v and os.path.isfile(v)]
         filename = os.path.join(data_path, name + '.rar')
         if not os.path.exists(filename):
-            subprocess.run(['rar', 'a', '-ep', filename, *existing_videos], check=True)
+            subprocess.run(['rar', 'a', '-ep', filename, *existing_videos])
         if os.path.exists(filename):
             files[name] = filename
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import os
 import subprocess
 from io import BytesIO
+from pathlib import Path
 from typing import TYPE_CHECKING
 from unittest.mock import Mock
 from zipfile import ZipFile
@@ -22,7 +23,7 @@ from subliminal.providers.mock import MockSubtitle, mock_subtitle_provider
 if TYPE_CHECKING:
     from collections.abc import Generator
 
-TESTS = os.path.dirname(__file__)
+TESTS_DIR = Path(__file__).parent
 
 
 @pytest.fixture(autouse=True, scope='session')
@@ -820,7 +821,12 @@ def disabled_providers(monkeypatch: pytest.MonkeyPatch) -> Generator[list[str], 
 
 @pytest.fixture(scope='session')
 def mkv() -> dict[str, str]:
-    data_path = os.path.join(TESTS, 'data', 'mkv')
+    """Collect a dict of mkv paths.
+
+    Run scripts/prepare_tests.py to download the files before if tests are run
+    in parallel or if they are repeated to avoid multiple downloads.
+    """
+    data_path = TESTS_DIR / 'data' / 'mkv'
 
     wanted_files = [f'test{i}.mkv' for i in range(1, 9)]
 
@@ -842,16 +848,19 @@ def mkv() -> dict[str, str]:
         if path not in wanted_files:
             continue
         name, _ = os.path.splitext(path)
-        files[name] = os.path.join(data_path, path)
+        files[name] = os.fspath(data_path / path)
 
     return files
 
 
 @pytest.fixture(scope='session')
 def rar(mkv: dict[str, str]) -> dict[str, str]:
-    data_path = os.path.join(TESTS, 'data', 'rar')
-    if not os.path.exists(data_path):
-        os.makedirs(data_path)
+    """Collect a dict of rar paths.
+
+    Run scripts/prepare_tests.py to download the files before if tests are run
+    in parallel or if they are repeated to avoid multiple downloads.
+    """
+    data_path = TESTS_DIR / 'data' / 'rar'
 
     downloaded_files = {
         'pwd-protected': 'https://github.com/markokr/rarfile/blob/master/test/files/rar5-psw.rar?raw=true',

--- a/tox.ini
+++ b/tox.ini
@@ -28,6 +28,16 @@ commands =
     false
 
 
+[testenv:prepare-tests]
+description = download data for tests
+basepython = python3
+usedevelop = True
+passenv = *
+deps =
+    requests
+commands = python scripts/prepare_tests.py {posargs}
+
+
 [testenv:tests]
 commands = pytest {posargs:-n auto}
 


### PR DESCRIPTION
Using `rar` is giving a lot of errors, ~~so let's use it only on Linux (that was already the case) and the latest python version (3.13 at the time).~~

A `scripts/prepare_tests.py` is created to download the tests data before the tests are run in parallel or in the CI.
