### PR TITLE
Decrease artifact retention and add timeout to rar command

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -149,6 +149,8 @@ jobs:
           path: tests/data/
           include-hidden-files: false
           if-no-files-found: error
+          # heavy artifact should be deleted asap
+          retention-days: 1
 
   test:
     name: Test

--- a/hatch.toml
+++ b/hatch.toml
@@ -43,7 +43,7 @@ dev-mode = false
 features = ["tests", "types"]
 
 [envs.types.scripts]
-run = "mypy --install-types --non-interactive --ignore-missing-imports --config-file={root}/pyproject.toml {args:src tests}"
+run = "mypy --install-types --non-interactive --ignore-missing-imports --config-file={root}/pyproject.toml {args:src tests scripts}"
 
 # ---------------------------------------------------------
 [envs.docs]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,7 +171,7 @@ relative_files = true
 # https://docs.astral.sh/ruff/
 [tool.ruff]
 line-length = 120
-src = ["src", "tests"]
+src = ["src", "tests", "scripts"]
 exclude = [
     "_version.py",
 ]

--- a/scripts/prepare_tests.py
+++ b/scripts/prepare_tests.py
@@ -92,7 +92,13 @@ def compress_to_rar(rar_dir_path: str | os.PathLike[str], mkv: dict[str, str]) -
         filename = os.fspath(rar_dir_path / (name + '.rar'))
         if not os.path.exists(filename):
             try:
-                subprocess.run(['rar', 'a', '-ep', filename, *existing_videos], check=True)  # noqa: S603, S607
+                subprocess.run(  # noqa: S603
+                    ['rar', 'a', '-ep', filename, *existing_videos],  # noqa: S607
+                    check=True,
+                    timeout=30,
+                )
+            except subprocess.TimeoutExpired:
+                warnings.warn('`rar` command took too long', UserWarning, stacklevel=2)
             except FileNotFoundError:
                 # rar command line is not installed
                 warnings.warn('rar is not installed', UserWarning, stacklevel=2)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -888,7 +888,13 @@ def rar(mkv: dict[str, str]) -> dict[str, str]:
         filename = os.path.join(data_path, name + '.rar')
         if not os.path.exists(filename):
             try:
-                subprocess.run(['rar', 'a', '-ep', filename, *existing_videos], check=True)
+                subprocess.run(
+                    ['rar', 'a', '-ep', filename, *existing_videos],
+                    check=True,
+                    timeout=30,
+                )
+            except subprocess.TimeoutExpired:
+                print('`rar` command took too long')  # noqa: T201
             except FileNotFoundError:
                 # rar command line is not installed
                 print('rar is not installed')  # noqa: T201

--- a/tox.ini
+++ b/tox.ini
@@ -50,7 +50,7 @@ commands = {[testenv:tests]commands}
 extras =
     types
     tests
-commands = mypy --install-types --non-interactive {posargs:src tests}
+commands = mypy --install-types --non-interactive {posargs:src tests scripts}
 
 
 [testenv:coverage]


### PR DESCRIPTION
Improvements for #1220 :

- the `test-data` artifact is big (~270MB), we should not keep it in storage after the workflow is run.
- add a 30s timeout to `subprocess.run` of the `rar` command
- make sure `ruff` and `mypy` are run in the `scripts` directory.
