### PR TITLE
Fix coverage comment action

### DIFF
--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -248,7 +248,6 @@ jobs:
         with:
           name: html-report
           path: htmlcov
-        #if: ${{ failure() }}
 
       - name: Coverage comment
         id: coverage_comment
@@ -260,27 +259,10 @@ jobs:
         uses: actions/upload-artifact@v4
         if: steps.coverage_comment.outputs.COMMENT_FILE_WRITTEN == 'true'
         with:
+          # If you use a different name, update COMMENT_ARTIFACT_NAME accordingly
           name: python-coverage-comment-action
+          # If you use a different name, update COMMENT_FILENAME accordingly
           path: python-coverage-comment-action.txt
-
-
-  post-coverage-comment:
-    name: Display coverage comment
-    runs-on: ubuntu-latest
-    needs: coverage
-    if: github.event_name == 'pull_request'
-    permissions:
-      pull-requests: write
-      contents: write
-      actions: read
-    steps:
-      # DO NOT run actions/checkout here, for security reasons
-      # For details, refer to https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
-      - name: Post comment
-        uses: py-cov-action/python-coverage-comment-action@v3
-        with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
 
   core-coverage:
     name: Core Coverage

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -286,7 +286,6 @@ jobs:
     name: Core Coverage
     runs-on: ubuntu-latest
     needs: [build-package, prepare-test]
-    if: false
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -220,7 +220,8 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          persist-credentials: false
+          # py-cov-action/python-coverage-comment-action needs git credentials
+          persist-credentials: true
       - uses: actions/setup-python@v5
         with:
           python-version-file: .python-version-default
@@ -242,9 +243,6 @@ jobs:
           # Report and write to summary.
           coverage report --skip-covered --skip-empty --show-missing --format=markdown >> $GITHUB_STEP_SUMMARY
 
-          ## Report again and fail if under 100%.
-          #coverage report --fail-under=100
-
       - name: Upload HTML report if check failed.
         uses: actions/upload-artifact@v4
         with:
@@ -254,19 +252,34 @@ jobs:
 
       - name: Coverage comment
         id: coverage_comment
-        if: github.event_name == 'pull_request'
         uses: py-cov-action/python-coverage-comment-action@v3
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Store Pull Request comment to be posted
         uses: actions/upload-artifact@v4
-        if: |
-          github.event_name == 'pull_request'
-          && steps.coverage_comment.outputs.COMMENT_FILE_WRITTEN == 'true'
+        if: steps.coverage_comment.outputs.COMMENT_FILE_WRITTEN == 'true'
         with:
           name: python-coverage-comment-action
           path: python-coverage-comment-action.txt
+
+
+  post-coverage-comment:
+    name: Display coverage comment
+    runs-on: ubuntu-latest
+    needs: coverage
+    if: github.event_name == 'pull_request'
+    permissions:
+      pull-requests: write
+      contents: write
+      actions: read
+    steps:
+      # DO NOT run actions/checkout here, for security reasons
+      # For details, refer to https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+      - name: Post comment
+        uses: py-cov-action/python-coverage-comment-action@v3
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
 
   core-coverage:

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -297,6 +297,7 @@ jobs:
       - uses: actions/download-artifact@v4
         with:
           name: tests-data
+          path: tests/data/
           merge-multiple: true
       - name: Install hatch
         run: python -Im pip install hatch

--- a/.github/workflows/coverage.yaml
+++ b/.github/workflows/coverage.yaml
@@ -1,0 +1,39 @@
+name: Post coverage comment
+
+on:
+  workflow_run:
+    workflows: ["CI"]
+    types:
+      - completed
+
+permissions: {}
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  FORCE_COLOR: "1"
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+  PIP_NO_PYTHON_VERSION_WARNING: "1"
+
+jobs:
+  display-coverage:
+    name: Display coverage comment
+    runs-on: ubuntu-latest
+    if: github.event.workflow_run.event == 'pull_request' && github.event.workflow_run.conclusion == 'success'
+    permissions:
+      pull-requests: write
+      contents: write
+      actions: read
+    steps:
+      # DO NOT run actions/checkout here, for security reasons
+      # For details, refer to https://securitylab.github.com/research/github-actions-preventing-pwn-requests/
+      - name: Post comment
+        uses: py-cov-action/python-coverage-comment-action@v3
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_PR_RUN_ID: ${{ github.event.workflow_run.id }}
+          # Update those if you changed the default values:
+          # COMMENT_ARTIFACT_NAME: python-coverage-comment-action
+          # COMMENT_FILENAME: python-coverage-comment-action.txt


### PR DESCRIPTION
It stopped working with #1190

Also enable `core-coverage` job (but it is not required to pass yet)