### PR TITLE
Discard providers only for specific errors

### DIFF
--- a/src/subliminal/exceptions.py
+++ b/src/subliminal/exceptions.py
@@ -31,25 +31,31 @@ class NotInitializedProviderError(ProviderError):
     pass
 
 
-class ConfigurationError(ProviderError):
+class DiscardingError(ProviderError):
+    """Exception raised by providers that should lead to discard this provider."""
+
+    pass
+
+
+class ConfigurationError(DiscardingError):
     """Exception raised by providers when badly configured."""
 
     pass
 
 
-class AuthenticationError(ProviderError):
+class AuthenticationError(DiscardingError):
     """Exception raised by providers when authentication failed."""
 
     pass
 
 
-class ServiceUnavailable(ProviderError):
+class ServiceUnavailable(DiscardingError):
     """Exception raised when status is '503 Service Unavailable'."""
 
     pass
 
 
-class DownloadLimitExceeded(ProviderError):
+class DownloadLimitExceeded(DiscardingError):
     """Exception raised by providers when download limit is exceeded."""
 
     pass

--- a/src/subliminal/providers/mock.py
+++ b/src/subliminal/providers/mock.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Any, ClassVar
 from babelfish import LANGUAGES, Language  # type: ignore[import-untyped]
 from guessit import guessit  # type: ignore[import-untyped]
 
-from subliminal.exceptions import NotInitializedProviderError, ProviderError
+from subliminal.exceptions import DiscardingError, NotInitializedProviderError
 from subliminal.matches import guess_matches
 from subliminal.subtitle import Subtitle
 from subliminal.video import Episode, Movie, Video
@@ -130,7 +130,7 @@ class MockProvider(Provider):
         """Query the provider for subtitles."""
         if self.is_broken:
             msg = f'Mock provider {self.__class__.__name__} query raised an error'
-            raise ProviderError(msg)
+            raise DiscardingError(msg)
 
         subtitles = []
         for lang in languages:
@@ -149,7 +149,7 @@ class MockProvider(Provider):
         """List all the subtitles for the video."""
         if self.is_broken:
             msg = f'Mock provider {self.__class__.__name__} list_subtitles raised an error'
-            raise ProviderError(msg)
+            raise DiscardingError(msg)
 
         subtitles = [
             subtitle
@@ -169,7 +169,7 @@ class MockProvider(Provider):
         """Download the content of the subtitle."""
         if self.is_broken:
             msg = f'Mock provider {self.__class__.__name__} download_subtitle raised an error'
-            raise ProviderError(msg)
+            raise DiscardingError(msg)
 
         logger.info(
             'Mock provider %s download subtitle %s',


### PR DESCRIPTION
After #1211, any provider that gives an error is discarded and not called again for the next files (if specifying a directory or several files in the CLI).
However, sometimes an error occurs if the query for a file gave an error, so the provider should not be discarded. 
This PR restricts the errors that lead to the provider be discarded to `ConfigurationError`, `AuthenticationError`, `ServiceUnavailable` and `DownloadLimitExceeded`, by creating a superclass called `DiscardingError`.