### PR TITLE
Add a CLI option --logfile to log to file

### DIFF
--- a/changelog.d/1223.change.rst
+++ b/changelog.d/1223.change.rst
@@ -1,0 +1,1 @@
+add a CLI option --logfile to log to file. Level can be specified with --logfile-level, default to DEBUG

--- a/src/subliminal/cli.py
+++ b/src/subliminal/cli.py
@@ -40,8 +40,7 @@ from subliminal import (
 from subliminal.core import (
     ARCHIVE_EXTENSIONS,
     collect_video_filepaths,
-    scan_name,
-    scan_video_or_archive,
+    scan_path,
     search_external_subtitles,
 )
 from subliminal.exceptions import GuessingError
@@ -675,14 +674,16 @@ def download(
             video_candidates: list[Video] = []
             for filepath in collected_filepaths:
                 exists = os.path.exists(p)
+                filepath_or_name = f'{filepath} ({name})' if name else filepath
                 try:
-                    # existing path
-                    if exists:  # noqa: SIM108
-                        video = scan_video_or_archive(filepath, name=name)
-                    else:
-                        video = scan_name(filepath, name=name)
+                    video = scan_path(filepath, name=name)
 
                 except GuessingError as e:
+                    logger.exception(
+                        'Cannot guess information about %s %s',
+                        'path' if exists else 'non-existing path',
+                        filepath_or_name,
+                    )
                     # Show a simple error message
                     if verbose > 0:
                         # new line was already added with debug
@@ -696,7 +697,7 @@ def download(
                     logger.exception(
                         'Unexpected error while collecting %s %s',
                         'path' if exists else 'non-existing path',
-                        f'{filepath} ({name})' if name else filepath,
+                        filepath_or_name,
                     )
                     errored_paths.append(filepath)
                     continue

--- a/src/subliminal/core.py
+++ b/src/subliminal/core.py
@@ -548,6 +548,20 @@ def scan_video_or_archive(path: str | os.PathLike, name: str | None = None) -> V
     raise ValueError(msg)  # pragma: no cover
 
 
+def scan_path(filepath: str | os.PathLike[str], *, name: str | None = None) -> Video:
+    """Scan a video or an archive from a `path`, maybe non-existing.
+
+    :param str path: path to the video or archive, may be an existing path or not.
+    :param str name: if defined, name to use with guessit instead of the path.
+    :return: the scanned video.
+    :rtype: :class:`~subliminal.video.Video`
+    :raises: :class:`ValueError`: video path is not well defined.
+    """
+    if not os.path.isfile(filepath):
+        return scan_name(filepath, name=name)
+    return scan_video_or_archive(filepath, name=name)
+
+
 def collect_video_filepaths(
     path: str | os.PathLike,
     *,


### PR DESCRIPTION
closes #1223 

The level can be specified with `--logfile-level`, defaults to 'DEBUG'.

Add a `scan_path` function to simplify the code for the CLI and add a log message in case of a GuessingError, otherwise it was only shown in the output with `verbose > 0`.