### PR TITLE
Re-add CLI options with a deprecation warning

### DIFF
--- a/changelog.d/1228.misc.rst
+++ b/changelog.d/1228.misc.rst
@@ -1,0 +1,1 @@
+add deprecation warning for CLI options --addic7ed, --opensubtitles and --opensubtitlescom

--- a/src/subliminal/cli.py
+++ b/src/subliminal/cli.py
@@ -354,6 +354,9 @@ def subliminal(
     debug: bool,
     logfile: os.PathLike[str] | None,
     logfile_level: str,
+    addic7ed: tuple[str, str],
+    opensubtitles: tuple[str, str],
+    opensubtitlescom: tuple[str, str],
     **kwargs: Any,
 ) -> None:
     """Subtitles, faster than your thoughts."""
@@ -430,10 +433,14 @@ def subliminal(
     ctx.obj['refiner_configs'] = refiner_configs
 
     # Deprecated options
-    deprecated_options = ['addic7ed', 'opensubtitles', 'opensubtitlescom']
-    for provider in deprecated_options:
-        option_value = kwargs.get(provider)
-        if option_value is not None:
+    # To be remove in next version
+    deprecated_options = {
+        'addic7ed': addic7ed,
+        'opensubtitles': opensubtitles,
+        'opensubtitlescom': opensubtitlescom,
+    }
+    for provider, option_value in deprecated_options.items():
+        if option_value is not None:  # pragma: no cover
             msg = (
                 f'option --{provider} is deprecated, use --provider.{provider}.username and '
                 f'--provider.{provider}.password'

--- a/src/subliminal/cli.py
+++ b/src/subliminal/cli.py
@@ -8,6 +8,7 @@ import os
 import pathlib
 import re
 import traceback
+import warnings
 from collections import defaultdict
 from collections.abc import Mapping
 from datetime import timedelta
@@ -305,6 +306,27 @@ options_from_refiners = options_from_managers('refiner', refiner_options, group=
     expose_value=True,
     help='Path to the cache directory.',
 )
+@providers_config.option(
+    '--addic7ed',
+    type=click.STRING,
+    nargs=2,
+    metavar='USERNAME PASSWORD',
+    help='DEPRECATED: Addic7ed configuration.',
+)
+@providers_config.option(
+    '--opensubtitles',
+    type=click.STRING,
+    nargs=2,
+    metavar='USERNAME PASSWORD',
+    help='DEPRECATED: OpenSubtitles configuration.',
+)
+@providers_config.option(
+    '--opensubtitlescom',
+    type=click.STRING,
+    nargs=2,
+    metavar='USERNAME PASSWORD',
+    help='DEPRECATED: OpenSubtitlesCom configuration.',
+)
 @options_from_providers
 @options_from_refiners
 @click.option('--debug', is_flag=True, help='Print useful information for debugging subliminal and for reporting bugs.')
@@ -406,6 +428,20 @@ def subliminal(
 
     ctx.obj['provider_configs'] = provider_configs
     ctx.obj['refiner_configs'] = refiner_configs
+
+    # Deprecated options
+    deprecated_options = ['addic7ed', 'opensubtitles', 'opensubtitlescom']
+    for provider in deprecated_options:
+        option_value = kwargs.get(provider)
+        if option_value is not None:
+            msg = (
+                f'option --{provider} is deprecated, use --provider.{provider}.username and '
+                f'--provider.{provider}.password'
+            )
+            warnings.warn(msg, DeprecationWarning, stacklevel=2)
+
+            provider_configs[provider]['username'] = option_value[0]
+            provider_configs[provider]['password'] = option_value[1]
 
 
 @subliminal.command()


### PR DESCRIPTION
The `--addic7ed`, `--opensubtitles` and `--opensubtitlescom` CLI options were removed in #1180.
This PR re-adds them with a deprecation warning so the transition to #1180 is easier.

This PR will be reverted in a future release.