### PR TITLE
Add tests for CLI

### DIFF
--- a/changelog.d/1125.breaking.rst
+++ b/changelog.d/1125.breaking.rst
@@ -1,1 +1,1 @@
-Remove the original-encoding CLI option, pass --encoding="" for the same effect.
+Remove the original-encoding CLI option, pass `--encoding=` for the same effect.

--- a/changelog.d/1229.misc.rst
+++ b/changelog.d/1229.misc.rst
@@ -1,0 +1,1 @@
+add tests for CLI

--- a/hatch.toml
+++ b/hatch.toml
@@ -104,8 +104,8 @@ run-cov-core = [
   "test-cov-core",
   """\
     coverage report --skip-covered --show-missing --fail-under=100 \
-    --omit='src/subliminal/cli.py,src/subliminal/__main__.py,'\
-    'src/subliminal/converters/*,src/subliminal/providers/*,src/subliminal/refiners/*' \
+    --omit='src/subliminal/__main__.py,'\
+    'src/subliminal/converters/*,src/subliminal/providers/*,src/subliminal/refiners/*'
   """,
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,7 +153,6 @@ skip_covered = true
 fail_under = 80
 omit = [
     "src/subliminal/__main__.py",
-    "src/subliminal/cli.py",
 ]
 
 [tool.coverage.paths]

--- a/src/subliminal/cli.py
+++ b/src/subliminal/cli.py
@@ -686,9 +686,12 @@ def download(
     # process parameters
     language_set = set(language)
 
-    # no encoding specified, default to None
-    if not encoding:
+    # no encoding specified, default to None. Also convert to None --encoding=''
+    if not encoding or encoding in ['""', "''"]:
         encoding = None
+    # no subtitle_format specified, default to None Also convert to None --subtitle_format=''
+    if not subtitle_format or subtitle_format in ['""', "''"]:
+        subtitle_format = None
 
     # language_type
     hearing_impaired_flag: bool | None = None

--- a/src/subliminal/cli.py
+++ b/src/subliminal/cli.py
@@ -816,7 +816,8 @@ def download(
             msg = f'{video_name!r} ignored'
             if video.exists:
                 langs = ', '.join(str(s) for s in video.subtitle_languages) or 'none'
-                days = f"{video.age.days:d} day{'s' if video.age.days > 1 else ''}"
+                video_age = video.get_age(use_ctime=use_ctime)
+                days = f"{video_age.days:d} day{'s' if video_age.days > 1 else ''}"
                 msg += f' - subtitles: {langs} / age: {days}'
             else:
                 msg += ' - not a video file'
@@ -876,7 +877,7 @@ def download(
                 )
                 downloaded_subtitles[v] = subtitles
 
-        if pp.discarded_providers:
+        if pp.discarded_providers:  # pragma: no cover
             click.secho(
                 f"Some providers have been discarded due to unexpected errors: {', '.join(pp.discarded_providers)}",
                 fg='yellow',

--- a/src/subliminal/cli.py
+++ b/src/subliminal/cli.py
@@ -50,15 +50,8 @@ from subliminal.utils import get_parameters_from_signature, merge_extend_and_ign
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence
-    from typing import TypedDict
 
     from subliminal.utils import Parameter
-
-    class ConfigResultDict(TypedDict):
-        """Information got from the configuration file."""
-
-        obj: dict[str, Any]
-        default_map: dict[str, Any]
 
 
 logger = logging.getLogger(__name__)
@@ -137,7 +130,7 @@ PROVIDERS_OPTIONS_CLI_TEMPLATE = '--{ext}.{plugin}.{key}'
 PROVIDERS_OPTIONS_ENVVAR_TEMPLATE = 'SUBLIMINAL_{ext}_{plugin}_{key}'
 
 
-def read_configuration(filename: str | os.PathLike) -> ConfigResultDict:
+def read_configuration(filename: str | os.PathLike) -> dict[str, dict[str, Any]]:
     """Read a configuration file."""
     filename = pathlib.Path(filename).expanduser()
     msg = ''

--- a/src/subliminal/cli.py
+++ b/src/subliminal/cli.py
@@ -607,7 +607,7 @@ def cache(ctx: click.Context, clear_subliminal: bool) -> None:
     help='Minimum score for a subtitle to be downloaded (0 to 100).',
 )
 @click.option(
-    '--language-type-suffix',
+    '--language-type-suffix/--no-language-type-suffix',
     is_flag=True,
     default=False,
     help='Add a suffix to the saved subtitle name to indicate a hearing impaired or foreign only subtitle.',
@@ -748,7 +748,7 @@ def download(
                 # collect video files
                 try:
                     collected_filepaths = collect_video_filepaths(p, age=age, archives=archives)
-                except ValueError:
+                except ValueError:  # pragma: no cover
                     logger.exception('Unexpected error while collecting directory path %s', p)
                     errored_paths.append(p)
                     continue
@@ -768,7 +768,7 @@ def download(
                         filepath_or_name,
                     )
                     # Show a simple error message
-                    if verbose > 0:
+                    if verbose > 0:  # pragma: no cover
                         # new line was already added with debug
                         if not debug:
                             click.echo()
@@ -776,7 +776,7 @@ def download(
                     errored_paths.append(filepath)
                     continue
 
-                except ValueError:
+                except ValueError:  # pragma: no cover
                     logger.exception(
                         'Unexpected error while collecting %s %s',
                         'path' if exists else 'non-existing path',
@@ -838,7 +838,7 @@ def download(
     # exit if no providers are used
     if len(use_providers) == 0:
         click.echo('No provider was selected to download subtitles.')
-        if verbose > 0:
+        if verbose > 0:  # pragma: no cover
             if 'ALL' in ignore_provider:
                 click.echo('All ignored from CLI argument: `--ignore-provider=ALL`')
             elif 'ALL' in obj['provider_lists']['ignore']:
@@ -908,14 +908,14 @@ def download(
                 # score color
                 score_color = None
                 scores = get_scores(v)
-                if isinstance(v, Movie):
+                if isinstance(v, Movie):  # pragma: no cover
                     if score < scores['title']:
                         score_color = 'red'
                     elif score < scores['title'] + scores['year'] + scores['release_group']:
                         score_color = 'yellow'
                     else:
                         score_color = 'green'
-                elif isinstance(v, Episode):
+                elif isinstance(v, Episode):  # pragma: no cover
                     if score < scores['series'] + scores['season'] + scores['episode']:
                         score_color = 'red'
                     elif score < scores['series'] + scores['season'] + scores['episode'] + scores['release_group']:

--- a/src/subliminal/cli.py
+++ b/src/subliminal/cli.py
@@ -55,7 +55,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class MutexLock(AbstractFileLock):
+class MutexLock(AbstractFileLock):  # pragma: no cover
     """:class:`MutexLock` is a thread-based rw lock based on :class:`dogpile.core.ReadWriteMutex`."""
 
     def __init__(self, filename: str) -> None:
@@ -407,7 +407,7 @@ def cache(ctx: click.Context, clear_subliminal: bool) -> None:
     """Cache management."""
     if clear_subliminal and ctx.parent and 'cache_dir' in ctx.parent.params:
         cache_dir_path = Path(ctx.parent.params['cache_dir'])
-        for file in (cache_dir_path / cache_file).glob('*'):
+        for file in (cache_dir_path / cache_file).glob('*'):  # pragma: no cover
             file.unlink()
         click.echo("Subliminal's cache cleared.")
     else:
@@ -940,6 +940,6 @@ def download(
         click.echo(f"Downloaded {plural(total_subtitles, 'subtitle')}")
 
 
-def cli() -> None:
+def cli() -> None:  # pragma: no cover
     """CLI that recognizes environment variables."""
     subliminal(auto_envvar_prefix='SUBLIMINAL')

--- a/src/subliminal/cli.py
+++ b/src/subliminal/cli.py
@@ -90,7 +90,7 @@ class LanguageParamType(click.ParamType):
         try:
             return Language.fromietf(value)
         except BabelfishError:
-            self.fail(f'{value} is not a valid language', param, ctx)
+            self.fail(f'{value} is not a valid language', param, ctx)  # pragma: no cover
 
 
 LANGUAGE = LanguageParamType()
@@ -328,7 +328,7 @@ def subliminal(
     # create cache directory
     try:
         cache_dir_path.mkdir(parents=True)
-    except OSError:
+    except OSError:  # pragma: no cover
         if not cache_dir_path.is_dir():
             raise
 
@@ -350,7 +350,7 @@ def subliminal(
         try:
             # make sure the parent directories exist
             logfile_path.parent.mkdir(parents=True)
-        except OSError:
+        except OSError:  # pragma: no cover
             if not logfile_path.parent.is_dir():
                 raise
 

--- a/src/subliminal/providers/mock.py
+++ b/src/subliminal/providers/mock.py
@@ -154,7 +154,7 @@ class MockProvider(Provider):
         subtitles = [
             subtitle
             for subtitle in self.subtitle_pool
-            if subtitle.language in languages and subtitle.video_name == video.name
+            if subtitle.language in languages and video.name.endswith(subtitle.video_name)
         ]
         logger.info(
             'Mock provider %s list subtitles for video %r and languages %s: %d',

--- a/src/subliminal/providers/mock.py
+++ b/src/subliminal/providers/mock.py
@@ -100,7 +100,7 @@ class MockProvider(Provider):
     subtitle_pool: list[MockSubtitle]
     is_broken: bool
 
-    def __init__(self, subtitle_pool: Sequence[MockSubtitle] | None = None) -> None:
+    def __init__(self, subtitle_pool: Sequence[MockSubtitle] | None = None, **kwargs: Any) -> None:
         self.logged_in = False
         self.subtitle_pool = list(self.internal_subtitle_pool)
         if subtitle_pool is not None:  # pragma: no cover

--- a/tests/cassettes/cli/test_cli_download.yaml
+++ b/tests/cassettes/cli/test_cli_download.yaml
@@ -1,0 +1,767 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - Subliminal/2.2
+    method: GET
+    uri: https://www.omdbapi.com/?r=json&v=1&apikey=44d5b275&s=The+Big+Bang+Theory&page=1&type=series
+  response:
+    body:
+      string: "{\"Search\":[{\"Title\":\"The Big Bang Theory\",\"Year\":\"2007\u20132019\",\"imdbID\":\"tt0898266\",\"Type\":\"series\",\"Poster\":\"https://m.media-amazon.com/images/M/MV5BZjgzY2QyNzItNDhhYi00ZWIwLWFjN2UtZDJkN2MxYWNjMmJjXkEyXkFqcGc@._V1_SX300.jpg\"},{\"Title\":\"The
+        Big Bang Theory After Show\",\"Year\":\"2015\u2013\",\"imdbID\":\"tt5612894\",\"Type\":\"series\",\"Poster\":\"N/A\"}],\"totalResults\":\"2\",\"Response\":\"True\"}"
+    headers:
+      Age:
+      - '1692'
+      CF-Cache-Status:
+      - HIT
+      CF-RAY:
+      - 912166cce9c750e0-BOD
+      Cache-Control:
+      - public, max-age=86400
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sat, 15 Feb 2025 01:07:31 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-allow-origin:
+      - '*'
+      expires:
+      - Sat, 15 Feb 2025 01:39:19 GMT
+      last-modified:
+      - Sat, 15 Feb 2025 00:39:19 GMT
+      vary:
+      - '*, Accept-Encoding'
+      x-aspnet-version:
+      - 4.0.30319
+      x-powered-by:
+      - ASP.NET
+    status:
+      code: 200
+      message: OK
+- request:
+    body: '{"apikey": "5EC930FB90DA1ADA", "username": null, "password": null}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Accept-Language:
+      - en
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '66'
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Subliminal/2.2
+    method: POST
+    uri: https://api.thetvdb.com/login
+  response:
+    body:
+      string: '{"token":"eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3NDAxODY0NTIsImlkIjoic3VibGltaW5hbCIsIm9yaWdfaWF0IjoxNzM5NTgxNjUyfQ.VQmr3wI-orZA3CGTqKfPtnMalEAGT5zv_HDqQ2WY8UgMFkYhuqV4crX_oefrN1mbqjhvbC8Fuvww8A0sQBZ7aPqQ0K4D6EZT-Fnd24BDay9Wg1U7PyB1AZ6fv4Tv4lI_hkYRPlDatKRQNPSFCM-L06IURgMc853JCNlDa-zLF9hM-EcJ-gpSTdx3mcPiGRgERDY2qUVpGz_2ZegAJEjj1oGCYxF-_3izPDeq1gX03MfFlPa7Kvth0iERpUp1cV00fGEx7lx80NILF5p5g_x_1JaXokGxKdQl0fK3zKC-xJGLFBj6gkSxtu4z-zS_EO0DTfK0KWkmxFONc376uL5n3g"}'
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '470'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sat, 15 Feb 2025 01:07:32 GMT
+      Vary:
+      - Accept-Language
+      Via:
+      - 1.1 42c937f806e6e43029a719b83b9a8612.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - VOiLNhCTzuQeu-dmwputLnW_x6BXVUdT3iphe21C2eBPSlrVUT5Jbg==
+      X-Amz-Cf-Pop:
+      - LIS50-P1
+      X-Cache:
+      - Miss from cloudfront
+      X-Powered-By:
+      - Thundar!
+      X-Thetvdb-Api-Version:
+      - 3.0.0
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Accept-Language:
+      - en
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3NDAxODY0NTIsImlkIjoic3VibGltaW5hbCIsIm9yaWdfaWF0IjoxNzM5NTgxNjUyfQ.VQmr3wI-orZA3CGTqKfPtnMalEAGT5zv_HDqQ2WY8UgMFkYhuqV4crX_oefrN1mbqjhvbC8Fuvww8A0sQBZ7aPqQ0K4D6EZT-Fnd24BDay9Wg1U7PyB1AZ6fv4Tv4lI_hkYRPlDatKRQNPSFCM-L06IURgMc853JCNlDa-zLF9hM-EcJ-gpSTdx3mcPiGRgERDY2qUVpGz_2ZegAJEjj1oGCYxF-_3izPDeq1gX03MfFlPa7Kvth0iERpUp1cV00fGEx7lx80NILF5p5g_x_1JaXokGxKdQl0fK3zKC-xJGLFBj6gkSxtu4z-zS_EO0DTfK0KWkmxFONc376uL5n3g
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Subliminal/2.2
+    method: GET
+    uri: https://api.thetvdb.com/search/series?name=the+big+bang+theory
+  response:
+    body:
+      string: "{\"data\":[{\"aliases\":[\"La teoria del Big Bang\",\"The Big Bang
+        Theory\",\"\u56E7\u7537\u5927\u7206\u70B8\"],\"banner\":\"/banners/graphical/80379-g23.jpg\",\"firstAired\":\"2007-09-24\",\"id\":80379,\"image\":\"/banners/posters/80379-18.jpg\",\"network\":\"CBS\",\"overview\":\"A
+        woman who moves into an apartment across the hall from two brilliant but socially
+        awkward physicists shows them how little they know about life outside of the
+        laboratory.\",\"poster\":\"/banners/posters/80379-18.jpg\",\"seriesName\":\"The
+        Big Bang Theory\",\"slug\":\"the-big-bang-theory\",\"status\":\"Ended\"}]}"
+    headers:
+      Cache-Control:
+      - private, max-age=86400
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '534'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sat, 15 Feb 2025 01:07:32 GMT
+      Vary:
+      - Accept-Language
+      Via:
+      - 1.1 2c1fa76ea6af6e9212cf3e52e166c4ce.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - blBg7bhvjj0Nb4kP9oDVZFMolz-moWcGCWhFgidZG_Du3KpZ4F-oJQ==
+      X-Amz-Cf-Pop:
+      - LIS50-P1
+      X-Cache:
+      - Miss from cloudfront
+      X-Powered-By:
+      - Thundar!
+      X-Thetvdb-Api-Version:
+      - 3.0.0
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Accept-Language:
+      - en
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3NDAxODY0NTIsImlkIjoic3VibGltaW5hbCIsIm9yaWdfaWF0IjoxNzM5NTgxNjUyfQ.VQmr3wI-orZA3CGTqKfPtnMalEAGT5zv_HDqQ2WY8UgMFkYhuqV4crX_oefrN1mbqjhvbC8Fuvww8A0sQBZ7aPqQ0K4D6EZT-Fnd24BDay9Wg1U7PyB1AZ6fv4Tv4lI_hkYRPlDatKRQNPSFCM-L06IURgMc853JCNlDa-zLF9hM-EcJ-gpSTdx3mcPiGRgERDY2qUVpGz_2ZegAJEjj1oGCYxF-_3izPDeq1gX03MfFlPa7Kvth0iERpUp1cV00fGEx7lx80NILF5p5g_x_1JaXokGxKdQl0fK3zKC-xJGLFBj6gkSxtu4z-zS_EO0DTfK0KWkmxFONc376uL5n3g
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Subliminal/2.2
+    method: GET
+    uri: https://api.thetvdb.com/series/80379
+  response:
+    body:
+      string: '{"data":{"id":80379,"seriesId":"","seriesName":"The Big Bang Theory","aliases":[],"season":"12","poster":"posters/80379-18.jpg","banner":"graphical/80379-g23.jpg","fanart":"fanart/original/80379-38.jpg","status":"Ended","firstAired":"2007-09-24","network":"CBS","networkId":"57","runtime":"25","language":"en","genre":["Comedy","Romance"],"overview":"A
+        woman who moves into an apartment across the hall from two brilliant but socially
+        awkward physicists shows them how little they know about life outside of the
+        laboratory.","lastUpdated":1735806730,"airsDayOfWeek":"Thursday","airsTime":"8:00
+        PM","rating":"TV-14","imdbId":"tt0898266","zap2itId":"","added":"2008-02-04
+        00:00:00","addedBy":1,"siteRating":8.8,"siteRatingCount":41886,"slug":"the-big-bang-theory"}}'
+    headers:
+      Age:
+      - '1602'
+      Cache-Control:
+      - private, max-age=86400
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '763'
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Sat, 15 Feb 2025 00:40:50 GMT
+      Last-Modified:
+      - Thu, 02 Jan 2025 08:32:10 GMT
+      Vary:
+      - Accept-Language
+      Via:
+      - 1.1 9bc25d3cccecc51547f094bc2aa70ef4.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - 5NkCENOZUJQYwp8BoP8tN-VnK_Cxvyz0lhHfdzz4u0c1jx9mp5c5HQ==
+      X-Amz-Cf-Pop:
+      - LIS50-P1
+      X-Cache:
+      - Hit from cloudfront
+      X-Powered-By:
+      - Thundar!
+      X-Thetvdb-Api-Version:
+      - 3.0.0
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Accept-Language:
+      - en
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3NDAxODY0NTIsImlkIjoic3VibGltaW5hbCIsIm9yaWdfaWF0IjoxNzM5NTgxNjUyfQ.VQmr3wI-orZA3CGTqKfPtnMalEAGT5zv_HDqQ2WY8UgMFkYhuqV4crX_oefrN1mbqjhvbC8Fuvww8A0sQBZ7aPqQ0K4D6EZT-Fnd24BDay9Wg1U7PyB1AZ6fv4Tv4lI_hkYRPlDatKRQNPSFCM-L06IURgMc853JCNlDa-zLF9hM-EcJ-gpSTdx3mcPiGRgERDY2qUVpGz_2ZegAJEjj1oGCYxF-_3izPDeq1gX03MfFlPa7Kvth0iERpUp1cV00fGEx7lx80NILF5p5g_x_1JaXokGxKdQl0fK3zKC-xJGLFBj6gkSxtu4z-zS_EO0DTfK0KWkmxFONc376uL5n3g
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Subliminal/2.2
+    method: GET
+    uri: https://api.thetvdb.com/series/80379/episodes/query?airedSeason=5&airedEpisode=18&page=1
+  response:
+    body:
+      string: "{\"links\":{\"first\":1,\"last\":1,\"next\":null,\"prev\":null},\"data\":[{\"id\":4261649,\"airedSeason\":5,\"airedSeasonID\":468774,\"airedEpisodeNumber\":18,\"episodeName\":\"The
+        Werewolf Transformation\",\"firstAired\":\"2012-02-23\",\"guestStars\":[\"Peter
+        Onorati\",\"Vern\xE9e Watson\"],\"directors\":[\"Mark Cendrowski\"],\"writers\":[\"Bill
+        Prady\",\"Jim Reynolds\",\"Maria Ferrari\",\"Steven Molaro\"],\"overview\":\"Sheldon
+        becomes agitated when his regular barber is out sick. Astronaut training causes
+        Howard to reconsider wanting to go into space. Penny beats Leonard in chess,
+        the first time she plays.\",\"language\":{\"episodeName\":\"en\",\"overview\":\"en\"},\"productionCode\":\"3X6868\",\"showUrl\":\"\",\"lastUpdated\":1592062060,\"dvdDiscid\":\"\",\"dvdSeason\":5,\"dvdEpisodeNumber\":18,\"dvdChapter\":null,\"absoluteNumber\":105,\"filename\":\"series/80379/episodes/5eb1e0579354c.jpg\",\"seriesId\":80379,\"lastUpdatedBy\":198416,\"airsAfterSeason\":null,\"airsBeforeSeason\":null,\"airsBeforeEpisode\":null,\"imdbId\":\"tt2238153\",\"contentRating\":\"TV-14\",\"thumbAuthor\":198416,\"thumbAdded\":\"2020-05-05
+        21:53:26\",\"thumbWidth\":\"640\",\"thumbHeight\":\"360\",\"siteRating\":7.8,\"siteRatingCount\":8802,\"isMovie\":0}]}"
+    headers:
+      Age:
+      - '79552'
+      Cache-Control:
+      - private, max-age=86400
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 14 Feb 2025 03:01:40 GMT
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding,Accept-Language
+      Via:
+      - 1.1 4ccea9891122bbc59cea4168a401fd44.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - RM9p5gOB-55uB7ZqJf6-UuzLgL8Iri3OEXeZOOg1LrWqYvyYpiOEpw==
+      X-Amz-Cf-Pop:
+      - LIS50-P1
+      X-Cache:
+      - Hit from cloudfront
+      X-Powered-By:
+      - Thundar!
+      X-Thetvdb-Api-Version:
+      - 3.0.0
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Accept-Language:
+      - en
+      Authorization:
+      - Bearer eyJhbGciOiJSUzI1NiIsInR5cCI6IkpXVCJ9.eyJleHAiOjE3NDAxODY0NTIsImlkIjoic3VibGltaW5hbCIsIm9yaWdfaWF0IjoxNzM5NTgxNjUyfQ.VQmr3wI-orZA3CGTqKfPtnMalEAGT5zv_HDqQ2WY8UgMFkYhuqV4crX_oefrN1mbqjhvbC8Fuvww8A0sQBZ7aPqQ0K4D6EZT-Fnd24BDay9Wg1U7PyB1AZ6fv4Tv4lI_hkYRPlDatKRQNPSFCM-L06IURgMc853JCNlDa-zLF9hM-EcJ-gpSTdx3mcPiGRgERDY2qUVpGz_2ZegAJEjj1oGCYxF-_3izPDeq1gX03MfFlPa7Kvth0iERpUp1cV00fGEx7lx80NILF5p5g_x_1JaXokGxKdQl0fK3zKC-xJGLFBj6gkSxtu4z-zS_EO0DTfK0KWkmxFONc376uL5n3g
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json
+      User-Agent:
+      - Subliminal/2.2
+    method: GET
+    uri: https://api.thetvdb.com/episodes/4261649
+  response:
+    body:
+      string: "{\"data\":{\"id\":4261649,\"airedSeason\":5,\"airedSeasonID\":468774,\"airedEpisodeNumber\":18,\"episodeName\":\"The
+        Werewolf Transformation\",\"firstAired\":\"2012-02-23\",\"guestStars\":[\"Peter
+        Onorati\",\"Vern\xE9e Watson\"],\"directors\":[\"Mark Cendrowski\"],\"writers\":[\"Bill
+        Prady\",\"Jim Reynolds\",\"Maria Ferrari\",\"Steven Molaro\"],\"overview\":\"Sheldon
+        becomes agitated when his regular barber is out sick. Astronaut training causes
+        Howard to reconsider wanting to go into space. Penny beats Leonard in chess,
+        the first time she plays.\",\"language\":{\"episodeName\":\"en\",\"overview\":\"en\"},\"productionCode\":\"3X6868\",\"showUrl\":\"\",\"lastUpdated\":1592062060,\"dvdDiscid\":\"\",\"dvdSeason\":5,\"dvdEpisodeNumber\":18,\"dvdChapter\":null,\"absoluteNumber\":105,\"filename\":\"series/80379/episodes/5eb1e0579354c.jpg\",\"seriesId\":80379,\"lastUpdatedBy\":198416,\"airsAfterSeason\":null,\"airsBeforeSeason\":null,\"airsBeforeEpisode\":null,\"imdbId\":\"tt2238153\",\"contentRating\":\"TV-14\",\"thumbAuthor\":198416,\"thumbAdded\":\"2020-05-05
+        21:53:26\",\"thumbWidth\":\"640\",\"thumbHeight\":\"360\",\"siteRating\":7.8,\"siteRatingCount\":8802,\"isMovie\":0}}"
+    headers:
+      Age:
+      - '79553'
+      Cache-Control:
+      - private, max-age=86400
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 14 Feb 2025 03:01:40 GMT
+      Last-Modified:
+      - Thu, 01 Jan 1970 00:00:00 GMT
+      Transfer-Encoding:
+      - chunked
+      Vary:
+      - Accept-Encoding,Accept-Language
+      Via:
+      - 1.1 a48f09960f130cb6049f12b379cf591e.cloudfront.net (CloudFront)
+      X-Amz-Cf-Id:
+      - gIBmVz2P-FLE-AhdRt8E9diA8NJhsYg7YD-ntoHVsUqxloyOzHhnRA==
+      X-Amz-Cf-Pop:
+      - LIS50-P1
+      X-Cache:
+      - Hit from cloudfront
+      X-Powered-By:
+      - Thundar!
+      X-Thetvdb-Api-Version:
+      - 3.0.0
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - Subliminal/2.2
+    method: GET
+    uri: https://www.podnapisi.net/subtitles/search/advanced?keywords=The+Big+Bang+Theory&language=en&seasons=5&episodes=18&movie_type=tv-series&movie_type=mini-series&year=2007
+  response:
+    body:
+      string: "{\n  \"all_pages\": 1, \n  \"data\": [\n    {\n      \"audited\": true,
+        \n      \"contributions\": [\n        {\n          \"contributor\": {\n            \"id\":
+        23329, \n            \"name\": \"jane\", \n            \"type\": \"user\"\n
+        \         }, \n          \"role\": \"uploader\", \n          \"share\": 0.0\n
+        \       }\n      ], \n      \"contributor\": {\n        \"id\": 23329, \n
+        \       \"name\": \"jane\", \n        \"type\": \"user\"\n      }, \n      \"created\":
+        \"2014-11-26T07:04:58+00:00\", \n      \"custom_releases\": [\n        \"The.Big.Bang.Theory.S05E18.720p.BluRay.x264-PublicHD\"\n
+        \     ], \n      \"download\": \"/en/subtitles/en-the-big-bang-theory-2007-S05E18-O-the-werewolf-transformation/ZQo4/download\",
+        \n      \"flags\": [\n        \"high_definition\"\n      ], \n      \"fps\":
+        \"23.976\", \n      \"id\": \"ZQo4\", \n      \"language\": \"en\", \n      \"movie\":
+        {\n        \"aliases\": [\n          \"Veliki pokovci\"\n        ], \n        \"episode_info\":
+        {\n          \"episode\": 18, \n          \"id\": null, \n          \"season\":
+        5, \n          \"slug\": \"S05E18-O-the-werewolf-transformation\", \n          \"title\":
+        \"The Werewolf Transformation\", \n          \"type\": \"ordinary\", \n          \"year\":
+        null\n        }, \n        \"id\": \"uJE\", \n        \"posters\": {\n          \"inline\":
+        \"/thumbnails/moviedb/inline/2c/9c/f5/c9/ae/30/0df660438f29fcf6bef8/uJE.jpg\",
+        \n          \"normal\": \"/thumbnails/moviedb/normal/2c/9c/f5/c9/ae/30/0df660438f29fcf6bef8/uJE.jpg\",
+        \n          \"small\": \"/thumbnails/moviedb/small/2c/9c/f5/c9/ae/30/0df660438f29fcf6bef8/uJE.jpg\",
+        \n          \"title\": \"/thumbnails/moviedb/title/2c/9c/f5/c9/ae/30/0df660438f29fcf6bef8/uJE.jpg\"\n
+        \       }, \n        \"providers\": [\n          \"omdb:sY0G\"\n        ],
+        \n        \"slug\": \"the-big-bang-theory-2007-S05E18-O-the-werewolf-transformation\",
+        \n        \"title\": \"The Big Bang Theory\", \n        \"type\": \"tv-series\",
+        \n        \"year\": 2007\n      }, \n      \"notes\": \"\", \n      \"num_cds\":
+        1, \n      \"rejected\": null, \n      \"releases\": [], \n      \"state\":
+        \"migration\", \n      \"stats\": {\n        \"downloads\": 31318, \n        \"lines\":
+        296\n      }, \n      \"url\": \"/en/subtitles/en-the-big-bang-theory-2007-S05E18-O-the-werewolf-transformation/ZQo4\"\n
+        \   }, \n    {\n      \"audited\": true, \n      \"contributions\": [\n        {\n
+        \         \"contributor\": {\n            \"id\": 7718, \n            \"name\":
+        \"jdinic3\", \n            \"type\": \"user\"\n          }, \n          \"role\":
+        \"uploader\", \n          \"share\": 0.0\n        }\n      ], \n      \"contributor\":
+        {\n        \"id\": 7718, \n        \"name\": \"jdinic3\", \n        \"type\":
+        \"user\"\n      }, \n      \"created\": \"2012-03-04T01:26:57+00:00\", \n
+        \     \"custom_releases\": [\n        \"The.Big.Bang.Theory.S05E18.480p.WEB-DL.x264-mSD\"\n
+        \     ], \n      \"download\": \"/en/subtitles/en-the-big-bang-theory-2007-S05E18-O/YAMX/download\",
+        \n      \"flags\": [], \n      \"fps\": \"23.976\", \n      \"id\": \"YAMX\",
+        \n      \"language\": \"en\", \n      \"movie\": {\n        \"aliases\": [\n
+        \         \"Veliki pokovci\"\n        ], \n        \"episode_info\": {\n          \"episode\":
+        18, \n          \"id\": null, \n          \"season\": 5, \n          \"slug\":
+        \"S05E18-O\", \n          \"title\": \"\", \n          \"type\": \"ordinary\",
+        \n          \"year\": null\n        }, \n        \"id\": \"uJE\", \n        \"posters\":
+        {\n          \"inline\": \"/thumbnails/moviedb/inline/2c/9c/f5/c9/ae/30/0df660438f29fcf6bef8/uJE.jpg\",
+        \n          \"normal\": \"/thumbnails/moviedb/normal/2c/9c/f5/c9/ae/30/0df660438f29fcf6bef8/uJE.jpg\",
+        \n          \"small\": \"/thumbnails/moviedb/small/2c/9c/f5/c9/ae/30/0df660438f29fcf6bef8/uJE.jpg\",
+        \n          \"title\": \"/thumbnails/moviedb/title/2c/9c/f5/c9/ae/30/0df660438f29fcf6bef8/uJE.jpg\"\n
+        \       }, \n        \"providers\": [\n          \"omdb:sY0G\"\n        ],
+        \n        \"slug\": \"the-big-bang-theory-2007-S05E18-O\", \n        \"title\":
+        \"The Big Bang Theory\", \n        \"type\": \"tv-series\", \n        \"year\":
+        2007\n      }, \n      \"notes\": \"\", \n      \"num_cds\": 1, \n      \"rejected\":
+        null, \n      \"releases\": [], \n      \"state\": \"migration\", \n      \"stats\":
+        {\n        \"downloads\": 27919, \n        \"lines\": 419\n      }, \n      \"url\":
+        \"/en/subtitles/en-the-big-bang-theory-2007-S05E18-O/YAMX\"\n    }, \n    {\n
+        \     \"audited\": true, \n      \"contributions\": [\n        {\n          \"contributor\":
+        {\n            \"id\": 40156, \n            \"name\": \"kvrle\", \n            \"type\":
+        \"user\"\n          }, \n          \"role\": \"uploader\", \n          \"share\":
+        0.0\n        }\n      ], \n      \"contributor\": {\n        \"id\": 40156,
+        \n        \"name\": \"kvrle\", \n        \"type\": \"user\"\n      }, \n      \"created\":
+        \"2012-02-24T05:56:07+00:00\", \n      \"custom_releases\": [\n        \"The.Big.Bang.Theory.S05E18.HDTV.XviD-FQM\"\n
+        \     ], \n      \"download\": \"/en/subtitles/en-the-big-bang-theory-2007-S05E18-O/s8oW/download\",
+        \n      \"flags\": [\n        \"hearing_impaired\"\n      ], \n      \"fps\":
+        \"23.976\", \n      \"id\": \"s8oW\", \n      \"language\": \"en\", \n      \"movie\":
+        {\n        \"aliases\": [\n          \"Veliki pokovci\"\n        ], \n        \"episode_info\":
+        {\n          \"episode\": 18, \n          \"id\": null, \n          \"season\":
+        5, \n          \"slug\": \"S05E18-O\", \n          \"title\": \"\", \n          \"type\":
+        \"ordinary\", \n          \"year\": null\n        }, \n        \"id\": \"uJE\",
+        \n        \"posters\": {\n          \"inline\": \"/thumbnails/moviedb/inline/2c/9c/f5/c9/ae/30/0df660438f29fcf6bef8/uJE.jpg\",
+        \n          \"normal\": \"/thumbnails/moviedb/normal/2c/9c/f5/c9/ae/30/0df660438f29fcf6bef8/uJE.jpg\",
+        \n          \"small\": \"/thumbnails/moviedb/small/2c/9c/f5/c9/ae/30/0df660438f29fcf6bef8/uJE.jpg\",
+        \n          \"title\": \"/thumbnails/moviedb/title/2c/9c/f5/c9/ae/30/0df660438f29fcf6bef8/uJE.jpg\"\n
+        \       }, \n        \"providers\": [\n          \"omdb:sY0G\"\n        ],
+        \n        \"slug\": \"the-big-bang-theory-2007-S05E18-O\", \n        \"title\":
+        \"The Big Bang Theory\", \n        \"type\": \"tv-series\", \n        \"year\":
+        2007\n      }, \n      \"notes\": \"\", \n      \"num_cds\": 1, \n      \"rejected\":
+        null, \n      \"releases\": [], \n      \"state\": \"migration\", \n      \"stats\":
+        {\n        \"downloads\": 26858, \n        \"lines\": 433\n      }, \n      \"url\":
+        \"/en/subtitles/en-the-big-bang-theory-2007-S05E18-O/s8oW\"\n    }, \n    {\n
+        \     \"audited\": true, \n      \"contributions\": [\n        {\n          \"contributor\":
+        {\n            \"id\": 40156, \n            \"name\": \"kvrle\", \n            \"type\":
+        \"user\"\n          }, \n          \"role\": \"uploader\", \n          \"share\":
+        0.0\n        }\n      ], \n      \"contributor\": {\n        \"id\": 40156,
+        \n        \"name\": \"kvrle\", \n        \"type\": \"user\"\n      }, \n      \"created\":
+        \"2012-02-24T05:54:31+00:00\", \n      \"custom_releases\": [\n        \"The.Big.Bang.Theory.S05E18.HDTV.XviD-FQM\"\n
+        \     ], \n      \"download\": \"/en/subtitles/en-the-big-bang-theory-2007-S05E18-O/zsoW/download\",
+        \n      \"flags\": [], \n      \"fps\": \"23.976\", \n      \"id\": \"zsoW\",
+        \n      \"language\": \"en\", \n      \"movie\": {\n        \"aliases\": [\n
+        \         \"Veliki pokovci\"\n        ], \n        \"episode_info\": {\n          \"episode\":
+        18, \n          \"id\": null, \n          \"season\": 5, \n          \"slug\":
+        \"S05E18-O\", \n          \"title\": \"\", \n          \"type\": \"ordinary\",
+        \n          \"year\": null\n        }, \n        \"id\": \"uJE\", \n        \"posters\":
+        {\n          \"inline\": \"/thumbnails/moviedb/inline/2c/9c/f5/c9/ae/30/0df660438f29fcf6bef8/uJE.jpg\",
+        \n          \"normal\": \"/thumbnails/moviedb/normal/2c/9c/f5/c9/ae/30/0df660438f29fcf6bef8/uJE.jpg\",
+        \n          \"small\": \"/thumbnails/moviedb/small/2c/9c/f5/c9/ae/30/0df660438f29fcf6bef8/uJE.jpg\",
+        \n          \"title\": \"/thumbnails/moviedb/title/2c/9c/f5/c9/ae/30/0df660438f29fcf6bef8/uJE.jpg\"\n
+        \       }, \n        \"providers\": [\n          \"omdb:sY0G\"\n        ],
+        \n        \"slug\": \"the-big-bang-theory-2007-S05E18-O\", \n        \"title\":
+        \"The Big Bang Theory\", \n        \"type\": \"tv-series\", \n        \"year\":
+        2007\n      }, \n      \"notes\": \"\", \n      \"num_cds\": 1, \n      \"rejected\":
+        null, \n      \"releases\": [], \n      \"state\": \"migration\", \n      \"stats\":
+        {\n        \"downloads\": 29466, \n        \"lines\": 419\n      }, \n      \"url\":
+        \"/en/subtitles/en-the-big-bang-theory-2007-S05E18-O/zsoW\"\n    }, \n    {\n
+        \     \"audited\": true, \n      \"contributions\": [\n        {\n          \"contributor\":
+        {\n            \"id\": 40156, \n            \"name\": \"kvrle\", \n            \"type\":
+        \"user\"\n          }, \n          \"role\": \"uploader\", \n          \"share\":
+        0.0\n        }\n      ], \n      \"contributor\": {\n        \"id\": 40156,
+        \n        \"name\": \"kvrle\", \n        \"type\": \"user\"\n      }, \n      \"created\":
+        \"2012-02-24T05:53:40+00:00\", \n      \"custom_releases\": [\n        \"The.Big.Bang.Theory.S05E18.HDTV-LOL\",
+        \n        \"The.Big.Bang.Theory.S05E18.720p.HDTV.x264-DIMENSION\"\n      ],
+        \n      \"download\": \"/en/subtitles/en-the-big-bang-theory-2007-S05E18-O/1coW/download\",
+        \n      \"flags\": [\n        \"high_definition\"\n      ], \n      \"fps\":
+        \"23.976\", \n      \"id\": \"1coW\", \n      \"language\": \"en\", \n      \"movie\":
+        {\n        \"aliases\": [\n          \"Veliki pokovci\"\n        ], \n        \"episode_info\":
+        {\n          \"episode\": 18, \n          \"id\": null, \n          \"season\":
+        5, \n          \"slug\": \"S05E18-O\", \n          \"title\": \"\", \n          \"type\":
+        \"ordinary\", \n          \"year\": null\n        }, \n        \"id\": \"uJE\",
+        \n        \"posters\": {\n          \"inline\": \"/thumbnails/moviedb/inline/2c/9c/f5/c9/ae/30/0df660438f29fcf6bef8/uJE.jpg\",
+        \n          \"normal\": \"/thumbnails/moviedb/normal/2c/9c/f5/c9/ae/30/0df660438f29fcf6bef8/uJE.jpg\",
+        \n          \"small\": \"/thumbnails/moviedb/small/2c/9c/f5/c9/ae/30/0df660438f29fcf6bef8/uJE.jpg\",
+        \n          \"title\": \"/thumbnails/moviedb/title/2c/9c/f5/c9/ae/30/0df660438f29fcf6bef8/uJE.jpg\"\n
+        \       }, \n        \"providers\": [\n          \"omdb:sY0G\"\n        ],
+        \n        \"slug\": \"the-big-bang-theory-2007-S05E18-O\", \n        \"title\":
+        \"The Big Bang Theory\", \n        \"type\": \"tv-series\", \n        \"year\":
+        2007\n      }, \n      \"notes\": \"\", \n      \"num_cds\": 1, \n      \"rejected\":
+        null, \n      \"releases\": [], \n      \"state\": \"migration\", \n      \"stats\":
+        {\n        \"downloads\": 51885, \n        \"lines\": 419\n      }, \n      \"url\":
+        \"/en/subtitles/en-the-big-bang-theory-2007-S05E18-O/1coW\"\n    }, \n    {\n
+        \     \"audited\": true, \n      \"contributions\": [\n        {\n          \"contributor\":
+        {\n            \"id\": 40156, \n            \"name\": \"kvrle\", \n            \"type\":
+        \"user\"\n          }, \n          \"role\": \"uploader\", \n          \"share\":
+        0.0\n        }\n      ], \n      \"contributor\": {\n        \"id\": 40156,
+        \n        \"name\": \"kvrle\", \n        \"type\": \"user\"\n      }, \n      \"created\":
+        \"2012-02-24T05:52:26+00:00\", \n      \"custom_releases\": [\n        \"The.Big.Bang.Theory.S05E18.HDTV-LOL\",
+        \n        \"The.Big.Bang.Theory.S05E18.720p.HDTV.x264-DIMENSION\", \n        \"The.Big.Bang.Theory.S05E18.Mini.720p.HDTV.X264-VisionX\"\n
+        \     ], \n      \"download\": \"/en/subtitles/en-the-big-bang-theory-2007-S05E18-O/28oW/download\",
+        \n      \"flags\": [\n        \"hearing_impaired\", \n        \"high_definition\"\n
+        \     ], \n      \"fps\": \"23.976\", \n      \"id\": \"28oW\", \n      \"language\":
+        \"en\", \n      \"movie\": {\n        \"aliases\": [\n          \"Veliki pokovci\"\n
+        \       ], \n        \"episode_info\": {\n          \"episode\": 18, \n          \"id\":
+        null, \n          \"season\": 5, \n          \"slug\": \"S05E18-O\", \n          \"title\":
+        \"\", \n          \"type\": \"ordinary\", \n          \"year\": null\n        },
+        \n        \"id\": \"uJE\", \n        \"posters\": {\n          \"inline\":
+        \"/thumbnails/moviedb/inline/2c/9c/f5/c9/ae/30/0df660438f29fcf6bef8/uJE.jpg\",
+        \n          \"normal\": \"/thumbnails/moviedb/normal/2c/9c/f5/c9/ae/30/0df660438f29fcf6bef8/uJE.jpg\",
+        \n          \"small\": \"/thumbnails/moviedb/small/2c/9c/f5/c9/ae/30/0df660438f29fcf6bef8/uJE.jpg\",
+        \n          \"title\": \"/thumbnails/moviedb/title/2c/9c/f5/c9/ae/30/0df660438f29fcf6bef8/uJE.jpg\"\n
+        \       }, \n        \"providers\": [\n          \"omdb:sY0G\"\n        ],
+        \n        \"slug\": \"the-big-bang-theory-2007-S05E18-O\", \n        \"title\":
+        \"The Big Bang Theory\", \n        \"type\": \"tv-series\", \n        \"year\":
+        2007\n      }, \n      \"notes\": \"\", \n      \"num_cds\": 1, \n      \"rejected\":
+        null, \n      \"releases\": [], \n      \"state\": \"migration\", \n      \"stats\":
+        {\n        \"downloads\": 37747, \n        \"lines\": 433\n      }, \n      \"url\":
+        \"/en/subtitles/en-the-big-bang-theory-2007-S05E18-O/28oW\"\n    }\n  ], \n
+        \ \"page\": 1, \n  \"per_page\": 50, \n  \"status\": \"ok\"\n}"
+    headers:
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '12017'
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 15 Feb 2025 01:07:33 GMT
+      Server:
+      - nginx
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept:
+      - application/json
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - Subliminal/2.2
+    method: GET
+    uri: https://www.podnapisi.net/subtitles/1coW/download?container=zip
+  response:
+    body:
+      string: !!binary |
+        UEsDBBQAAAAIAIozWEByqRnHjy0AABx0AAAnAAAAVGhlLkJpZy5CYW5nLlRoZW9yeS5TMDVFMTgu
+        SERUVi1MT0wuc3J0pX3rrtvYseZ/A34HtmeA/sPtw/tlJslBO52OnZPuDo47MPKTW+LeYrZEKiRl
+        tfIm8wrzWPMkU19VrVKx2zkYYADDsKVVxcW1vrrXWkpfv0qS/4E/WZzXSfTw8LtIPyjiPClev/rw
+        9Sn6+2VZo+dpHLtovozROkXroX/9almnuY+6cR8992vURU/9lb4Yxufl7etXr19lxhusKs+7jPO8
+        Be/jMToPu5foNl2iy/n1q+uhH/Gfr4nxfhp7ZpQbI6IrUs+oius2ef3qx5fuxkMLG4pvMj+0jauq
+        pGdGx+GljwZM+Dis67GPHvt17ef7w6Nl7W5x9HihMTTBeXg+rMy9NO5g5t8oTeKmooe/74nw46E/
+        0uSZpAokPGJDksV1koDkeJzeRljnQ0+v/TTN0ekWHbph3l1W8KiNB0j8S6VFnOT02OuwHqLv57fR
+        t1//OE5P8zDxwxsjxLjNw8u4rRPZ3WWaZ5r1X8cdrcVP03j7enn9ahixx9FhWs7D2h2ZXWvsQL2Z
+        Rx2ndYp3+XqJzjOt5y1aaF+ZLE2MDsNyR5elcZLQLH88xNG+7+Z4+xL/aiJpGjiCQephm+VxWRPH
+        T4cbAQikS6+gfP2qO16720JLez73DONT/+/Mz6CaEVTr1vMr47LKAZtdN0a0IUAOtohwInMxdPLQ
+        0tPWcVHQXP4meB6n9Qt7lBpksybOqtrR50mclymeDflSTEQMisfbl1gZPpnSL3SexlWZ8VQI7seh
+        /0zyS8uyRM+Xm6yBITWnJSz9e+RF3DT0Hn/4eXeh1bwsvABdtPS7adzLow2jGNz6HcmruEjoa5WK
+        mBaQQDKRxMavX9HOYl1ppwYRsdQwy3R+K/I6LrNSQdZFj9382M9CZMjkMX4NC1qJrFEi7EAg5IfT
+        ZwDX2J8P/VWUloEVlLl/kSIlCc7C88eo/7k7nY+0jtMTc3kZxj2zMHQyReFZlHFaVUxBz5zWYTkR
+        abdCrS7RTPy6cTXMy0QJuhFxJhU8i47LDK3MrvH8q7iBPnjXL8O+X1icXr8ylEQv43RdmIehlkm8
+        aihaWnf6ml5vtx4JdNM1UqV5utGiAYNQzYSjXQc8QDo74WpYZiYeQ2UWV0ABFOpdu0UzQWjeE/HT
+        PJ3whbwzvXD0E01ADYnhmrl4TJQFPYfFnRaxIyGD+iY18YJV6x6ny8rgzgzcINgojJKktsjBgVTC
+        h+hpmBfagdP0ud+zPo6Z3uDNwzcv1pBOgy2Lrh0hrJ8/TyQg/Gh6K9o4ngl9cb0DjxgazEHf3G1a
+        Sp/FSUvPWyasx2kiJMy0XnvYIprYF9aO2KkAKHXr2WVxVtDXSz+uYmDW6fWrXyuPPDEWeZyVmxmR
+        LQWofwI5i1G0XHYHUau0pcsvpyQMU2MI+twzbElKac3/BoiuPCnaO6HKjAqDSkdFFrRm+e8+yz6T
+        EptJCfUsLSfe6DwP5Dy69uT0Wi0B9IdJTPt9cbtlucw9ye4JpqK/RVfMyBaMNywvjDH4VJ4xSSEs
+        CBwh9mjIn8D8Xr/aT8djNy+wNCQxl5X3Ki+NEwgLz4kWCvaAVQJrZ5IzsOmX8WuaDF4cryorVRmf
+        Os6azPNpCKS0538ls9qL0j7p8tZGRGM2u0ymNIWJ+HbixeWHdbtdv9Cs1+kLQisL3gSGTO/fJiNv
+        panZ5szRlV5JCAyq/L2HKhnfKqHV+WmKzt3cnQ9zRzP/6e3Ht9EfjsO08kYUhlMe7nc4q+IUsOKV
+        G0S1k8HHB/SPaT7uo37cLw8PzMfgyWQeaFlLH9DqwlywZwWbAaQDNvqBMxmFQRZmN/NvRKY0b1Jn
+        +9S17aLnebqO0akbgx3qyG+anmi1h2nsjvKqBmbm4yWI7FyepIK5G9Y37A299ng5QYWuh7mHcRrF
+        wpynhZzciPVs2haVTN1QzQw3T6BFgF39E3z/hZyePU2YaQy/GJJ5CJHJTIEwzOpIQnAYTs60FwZY
+        HufXiQwlQeH1q++GsRfpHJ5IGe+mE96A/ssmdmD5KQzCoGo3z8/juqZXOk4TGwA2Wh1NYX6hBRW/
+        YzTPrTDoklkpGo8AshJpQ+/5kXH/MuyjpRv2AqSnyzgO/bKK+iPZ3ofYw5DN5B6ZZDWyqoXuOYsc
+        lobisiXM3MUmo8/IVWvVILE5owBBtAECrlt07Fa1IqViWIiq1HMp4wRmSaG/J51GjtuFbMgtgj7A
+        Wr75x2WYX25v3zCvzHgRabPh1ZAfS7z+z//639GPLMsTRQqXcSD9u9AGwfCRwe7IVVjhx4/En0Ko
+        tY+IgnnnxptYlZ43hTQJNBl4/4Q3HikMoDmSXnwcjiT1tAb0CZz354mUGTlIkBDwn9d+//bt2+hT
+        N6xf2aOK8Cjm3PhH5aQvCntU9AficCBl/dxxLLCbpqNxKY0LiCrPpSIDm9y5dJd1WufpfFjurPYz
+        8aId+qEnSejpKd1xoXX53B9p//c0YqL/h0dV9ihwzvyjmrgudd0/kb91GY4rK7VP8KKYHl/9Zvjd
+        5tvzjRzJYb/85t+G39lTansKMd0ghfR2UetTvu9WMhkfd0M/7kgQ3w+MOHqTyziTPTgy4A9wBKFM
+        bsa9CdzBbIOdTDWgLFcnEbVunsatpF2HZ9awxq81flvFl3GA1iT24u+I6iv/olVipBi5mUojU/nN
+        00SWfTcdp/m3/y1JvvsuSX6HnXxHswA/bCvkrPw5bX7zbxj8uy8QffcdE30iB+E6HZ+in2ZCJsVF
+        p24lfBrdj/PwPJBCj74ht/lbyASB97v+cb509Ah6vShL4DzQzE2YeaIeCBS9NQ0N+u1vo+U27mKa
+        x0xGmJYwokDwS+9D5qanqYR5RL/9LT/CZJyitNLZTvqgJNeDtvH3nSidc8d2n97wL9186hcEv4ee
+        gmk24pUJNNO1nlEdt1B1Hy/q0VUmkRRqJJkfW9Rxlea/8N73E6FMnmJSyANLT9nGFfQ38hcUF4ki
+        5jCZkwVkDM1ukALvb734pJUJGzGoW68dyoTUbnU31TzcpIa/9etV5nHa0o5hxpg5AiIyBKycye+X
+        BIGZZXm4SQkTe1STfWjqGh52N0oyDBx23RlYYieb3mJEHuoUHOXKZKSsydO9L2uOGCCH9/1nmME+
+        +LAfoueJvd6VRTkio0Dqm3nVKjQ57AgFkJ4XMke0D2/+0t2OE0UhH8/9buiOpBmi99O1m0mKPxH0
+        SJL/Cedj7v9xIePYcyRcp8YXbGrPl1xduApvaNtmCoXnVdOK0Q/ffPyG3I7pMC4kKh/P3a6Pfk++
+        uNq8OjOeYLF575omT8vy5j2FYCvcLY4hhSw3Mhrlkog5IgVOQnFSg6Js8r8IObRKgyz999OInW1o
+        XaPu7UnMZV0EfiB3EWUOk5EgQ/W3vjuoMwPPgz0vvFzMsR1/ljRJIjtQGjtQ555dQQqbXvqd5J6W
+        7gbTHWbzRmZTGXm1CSdz6PsCuR1kfuaeNhCZzyV6w48W4tqIMbZxxFkSl9AKH+D+uSCkI0/wzY9v
+        YPXptUaWM/Xy6iZwA3HmF4a0XYY4ElNBJoKDAmbMXOE3Rm+mwy/Zsi6oW2MLLn6ByH9PsB1vkEUk
+        fP9x2secTiV2tp+x+cqcWmaNQdz/3ndHAov6QI3JAangpN08hNw02JaPFD3ytJHtIQ4cbYzPCysB
+        BI/kkfCEG8M+k2aOF6nzFhH7J3JwNN88ndlLF0pDOAbmfjORE0OqjbOR2Iz+eKYVYul+6kmo1eNd
+        ERQfyG9aKQqYHiUZbBIAFb3ZGHLk27y+b4ylsJkxuYt7dpAkaH6cOWr+WqJ+YW3CwJy8TJKr3yJG
+        hDN/oQCMw4FNArUx6GNs4edF/nwLyfxLP4432lNBDVbsRJ4VubRHCZQagz8oNsJYoA5QIOP2JKk0
+        qJjlhVZ+scTdAfvwNB1fWFrj6HISriYXzKTyXCl4BiI5dYFsHcVGQmPox5CNIJIJKVr6+sqVDdq8
+        3eEyjxGsBEJBenJQcY1hnWjKxL8OEmCwSsbk1NGG72eKG/vFTN4zhSg30hS7F1F+reGa6f3+kOVJ
+        4X+TcNCLkwARZ2RDoCOWwzStw/g1MhB4FsxrMGqR1iZagzlz8sqjrCQaJBflcUKh5eHxSKq0Jwlh
+        SoM5D9xMiqQPWU4Lmx97sn47MXyt4ZiH3Y1VAcNXYkL3qoZGfZJNJW9pukXdug7rZd8zLwWukuae
+        F8ke1CoHzwhEFwn9ORAz5LelMSBHqK09gypukMyBUAn2KYCRRMrzRSLGtjJqDK48dRNXkFhJNq/R
+        ny7d+IC/ODv8DqkvipLeA8fCqjZWoCwdK2TCYMJ/QmrrkYWAvRbawjMH1n0Xs6t3Q/LqRI5f99yL
+        +7LsuuNZ+DeBP7PzL0oWq+FKIVaaE5/Rf89oPdn0LbRy63ACOPFQROaRprfH/mcIAftq9IDWHgB+
+        fi1QNmrvyQ6k/FB9uJzJf6FIguJ9aD1UrsjDHv/ZadUpMYakgNPMMaQoJYcC5kziFWmuVSJjms34
+        3Gugv5tGBLjszwvHNHAEA6eYC+SyuP7HRv4N8Pc8sfNAG/5rn+KNsMuMXbapDRYoJVWIuIn6jQqB
+        aPzXr6TUqn7lGyndJLlxIsJyMzECFub9A5vbiXboV7ZPeZgoMIkXhTyJMyg2GNg34rhY9SsxAcgz
+        ilYbT0ZzyTS0Z3NMK3qFBGqoliYGfx66oSVPBEEGpxyQWiCXkszbYeKEw4doHvb9nY9hn8k89os0
+        ThFGhDlcuxFRk1EaqslwpPmGklxyaK9/RWlwpdikLP3mUWhRlkr5aUuVGiZ5UOuoSDNnYbW+hZ8G
+        b/Q4fO7f3qkNfzzYrxdFFGWabqOXNDWA8dd+S5GQQj5O/aH5wriMnof5+DRT9L9/IL093eTf0ULf
+        PRBYaMRoxfA0NdQxt810aE1QjTRFrBSGMR5wVyIl9C8rKVCE9J1UGaVqEtLrJ5TKeK4hLThoajsN
+        5U9ltuGOsIZe93utoaLuOVPMgtKMhIwzx23gUhkXEDWeC70m4gt6avG2IhnYrdBuPbJTZ+RW+9M6
+        +aJoqIqW0O8ENs+roYivApThysTId+pe/OMy9PDooOlQG4UbZ9XRUB4tuQWhLRzHNItLFHEkmGY1
+        /BEqktSEpOrTUCbVsZknJoDkXGpeacsJfKNa2zQURHVM7okKiqRaNSx7VNNHrozuo+sk/w7KPQ01
+        USFyGqrk6gUSmWoVlu5EuzFNJ9rx9f7JfZtD+VMp/YQo4uAAgy0RG4WP03468ZT+OJ0IiN1Bk04n
+        0nxL4JgHjsxgw5E0M9TLJ7iakRYWWA+TNpuHZViURWEsQNF6FgV521XoSIAfhZ3llppjv/I+q0sF
+        SDKsQ2eKNicYrpmVRxFCHyleBt4fhCnIDMg8qvRkZFCRbgotBeHB+jxDLY/bLAeyJvT1X0+Igu7P
+        5IQevNKO3Yt3w/zSjxTVkAMqLA22zMEvD5mNJtWaARl2FvzPpPj2anclgzOdSUFN44J8V7e8sGkF
+        X0M0s9nwLSjqgtEKGa398IxgUmxvbqjGONf4VCI6ShCxyJZ/0HdE5KH9HgZljCw2pC36W1iKKCiU
+        RM4JCpNVGmqwP9/Ei2Rdal5kmhumKQYqNvCBYaqk+CoxJzukT8fpumhJZp3UWTvAy2RtBJYGaubg
+        d5HCmQqqGEv+yIweKVRA/9Nw7GFaWb1KQn8OQpIbwimyqTe6uyRvCOWDdxQDgxPLG6nt/mF34FyQ
+        cjAckzmqMq9+KALIa202kz4z8pUf58ty4IRV36+H/wlXXldz7TjK5fkqbwV7Ba1dOFNXoQBeomb0
+        ftChtQ3FN60fStEjsorvhzharvTUIbBvjIaGlImnobCn4Pr/aVicYxTqnDLCabyKE1cSxQeSGDUB
+        bQdKjK7apFYrqPwcrt7HSWpCKI4hnS7KnjHA7QtRqEilociptKVjlmrJDUmTK0L+KwezpMY/oLCu
+        FRbRCKHCKVStfxfUsJM2ZBdXLtH0M9cPXr/6Zz9PpFy6z8MaJpQbJxS/N5wIA4jHfj9Nx7fILWr/
+        lvZxdWEuhXEAQeU51PRBqepfu9DGvlPTGeqWOq72hBQyQZUgVIN/zaaIVP352I3iFRSGL4zN/bxJ
+        4Vco57FcPiOZ1R1PE4qmcPcBVzQ2ki8Ts0lCwl87pyQ4TwsDJLPKPO9aPO+O5Z43RXmynIn8az8j
+        vTPHHJyqmbuF9rWThqS0MPiCYevhmyGTkUv4J8kZoTD08gAPHIoGSqQrJ3RfYGLyj2cKbbi+LRkk
+        6UczLDORX3JECzXX2CniROaD+4xOHcVwLlxE9upK66ftbYZmpm48u4JUmva3ofANIsFLadjlMYUn
+        aqQbC4laFBJ1lbF6/+QK75mt2rDE1uu03ltgFNf6poZrZuqnVmTItklIye/zQGG3ZQ9JkXfrInw1
+        MZKWBnGm9YAoiph9KS63hvbVTtNgaWkQ53FeC1I4UyWS55GhBmj+ZjNhsmKQU3FJZ7hKZLHQjHLu
+        CW5hKdRdXXZz350IdzZ7g3NJbnjqZ096v0EigYZaXgDpQHaGZCVev5rv+B5GZWn4pbjBh2k11zqw
+        Xu+mWyypZKRGbijHHLvL84G9SECJm3tZRqX9Ux23UGpUTpVnDbPGeZMOeYwLCSw760IYCo06rvaE
+        GdnwCjG3Dk1tKL5p/FDNcEqt4ANpYiSKOMfO0+/3bBpke0P5TshcmrOGrUiQx0fKhVyWYQ+fBSEr
+        A/rzdIJcc5H71MvaTlqVSkMtr4aNSFO/uKTtE2Sjvxlv1+4WNjgU9PT7whMQXpG1glGRnJdU9Gjd
+        0B/efZ4kHAiVPaXYPJO0eughgWbhgJNNHSBDYJzRekBuDpxN7VytjBuIW8+tJo1aSjWSXValqI2i
+        3hT2aiSLEthgMWidZKw0Etn1I4VHT5dnMQqhoKdEmeNCgUQN48tZNZqxaeaFHFkx3DMQJcljRCZB
+        Z1YGSOaRe6bkyCGDwJGwFmKiw2XcHTDdM+0qRW6mFo73SL02rOZpnDYe5DmJJORn0xAoi1QbbHnQ
+        hgr5qUQtrW93T2vDKGoVtd9Z0ow5kr4SLgpEQ93nJs00Eus/oMdNKohpbehkcg82Uo5slzVwfB6e
+        VvjAZ6mvyf6JEQlRWm3IZVoviFCYDQfAd39fg3KOwlE6e/0KToEu708Py2GYwwIbnpmP37SCLG7C
+        MSmX7rS68OaP5GagfkGWpZsfbqRfaAUlNqkNzvC0Gw9O0qgtq6QZGvPUh7yBdCzCbUNgqjMkF2PZ
+        DehGFZVqZrk29DO/zQNSEsdW8kJ7pN1ZC0G7C6Uhvix+oYHKJs7SX+mK2tDM39+3r4EubKArrKuU
+        jPayXvZkeUVP015iwud+Oh+5ykLKq5NCW3elv6VdXKGt/Er/gJJWPuMIkm2CQEwkEZGlSqA1VKah
+        ZKekm8nS7GEyP0kJoGMfkazePg528p6rOUnHaBrqeErdOHZpEjMY0WaMl7lJdRgwZrEV+jzQ8/DK
+        05P+r4NfyFV4yZTghUJZC01YO4ovJi3yp6FK18D3Tir/emg8RVyLWPmDVBXplUQNhPqcjso9WU1o
+        ybiPVx9R2Vh85R+RoZZZbdtL2QmQJuJQH4RngU1G84PmP0IdTnn4dcwKHFVw50devyLFwjWs87BK
+        ipA8mDPKJLopjTEDbe2ZkecGd2A5DmfLLqJOMYy06eSeTLNWkSk4nZwD1u1J8FayMDrf1h4BXzB1
+        jyA3mL0BzHdUq94agvlbv76kdzNkKmhoZOewIC5sy39xKERPQhiGSf8myebhtCXwhj88fECmRccb
+        SPlrv2Mox8LX/NPDny7LA/eBXrtBm8jhYJ2Q5QvPNbAymX8LOLFwCj/2u8tMHvNXQmBo5O9bT1BS
+        sFC5mHK+qHVpDYs8xkMBuhL1NLRJWONuEAC0/LLUin/1CBdi6Z7CGhhqyb1sXcjdcvc8gn+U/bkl
+        FRIriTOkRm6R99tDDa5Fu0vqKpMtmk4y+NQ0lPOHokN2h373cuLMs9j06zAKhkK5rZUGxNSxIuHl
+        U0HvT6q2QuWs5eYPlxBt2S+BfEguC8lLUi3TLDnM0FqRhUpZC5cjceFhi4i0LVvfGRByW5oLhb15
+        nqY99zCcoVrPpGBXPUuTGuN8k7lsUahqsJtoUQ8VpRkHJpC/IGN7jJ47zfhmoVCmVLVnU5NKSiTj
+        hqgP/trKGnAYrRkvkhBAmeXGDLSZZ9ZIeCKrpfKZhcIYf98mfnVQGKvuSXzN5XIKE+3nMwKNvT62
+        DFyYyC8FSXkCr+99r10dpF5EyEOoJTlQtgwHsud6JiWUz4RD7TGCrrxaKqYKziwxcPKXHiVo2kja
+        cBjrPoEQ9YYkLO/s7eGA6lQoYWeJIZUEv2496NGODQftz0hQfOAWaoQFp/Nx2HUoi7ktNgwzkV8e
+        kvS2kl5s6HYWEhTHSMgFvqnBl4d6eMD5QhLi22F/tzpPl1EJDZ48zkOhgOAgpak7oDYex3CIXMrl
+        klbuEFiELsAOkxv1VFqWGm6ZnV8apExzafgj8MesDh5W/g/ysKIbFj7FYBk+ZWr4LbO43Agr+WQJ
+        tllOlMpoAy9/6VVbWUrb20P0vsdePkSwSode9zU1wGJgunlOJY78Rzk4al0afPgFCpI4/OFwD7ey
+        1JDKpLYQKU5AxRl8uO/JBT6jfVxS2fRP6GxpEBvQu4OMogT4g3S9KGuBNTgRcO6bn/IRYG66x+Fg
+        bdoSA8rxf79XBo0xoPF3KcIHFBvm9TYm0MVpjQhjWk/UoisRyFmvvWLkfOy46M57qgm7d9Pj4y36
+        bljow1mO9SXGtEX06JhSlFy1esQo9AM89uzIvuCACxs7PIlEgw8KnPW0TKaFt8DDLz28wFp7aJ8v
+        OHlC/OCSwbZfexxE1CwMp+Ri1OCh0MT3ebw86xMyewIODiT+CbQ4hcby2lohcTTtsaqVw+WEo5Rw
+        oPSwn1bjQN7Exb0POtXjwokYDc3PwyPTxmE7qy0bqyW5QLbhk8cl7MAP6lfxudDNSe9Mi25hcOmp
+        CSdJSDM/Yo+X4Wfk3BcUygmlH+RIxHI5nyftndt0bcgDKnsA+HngZkhHl7JsNDUOW8jdmIdHnDY9
+        dItBWOdqMsCUnhXO/WKPRQZ8X1QANedSlrUbAzOTB9ButjPnk2+kzwkhFHLgbBkhm+AxsJd2CHov
+        M+lgisazqOICFhOq5sLqhtYQ+VbVOrnJQA7B8stOVoqrTJr5WM44n0dWSU6jHIenXjgY4JnAA75I
+        yePH8TprGJduKO6EZpca4LyfawE3AzcTV54bt9Bze9uOIPh0QQMRKgbSNcwhp7rIUQhBrTKT5YZy
+        5uM1CBKySCi80/sH0MD+RM7MqifXstyQzUP9fpMXzG0iUKJ7NkURFMz+coSkwIZ3f+9OXTRPK7tG
+        IsK5gZ3pc8ewTOIcNhyNn9O1F/3O77SckRNZDiSGYV4Gaaby+062qkEVgl293RFhckhHZLnBF6NK
+        jzgyWhWfgP/6cy+iRoK1Ys9Ot3tLQJYbZplgM3/y2RDz/ZF8VLlkYe1epA+0WxEtLs8X4UgKasZO
+        SdD3NA/758De8Axud5Obpsj9lkW67Zx98E04mdbzwtjcE0M6cklshlw4EiEDamfQSeCIqV3ZMYDr
+        FDIxmVb2ApfSsy2gBO6tJSGDeZK7OlR6lU1mbEDVejZV3HCXshgDRMTcHfo4T2S+LkizcQ93j/ym
+        ihRXgZRzbpxxwjz1nAlkLTdVOMMqxp6LWKj/ioZTVoWxAqWfJDLQcPCgT84EK/KN7wUAPe1ufFXo
+        N6zLwJrv1vC7g757+P7vOKWOnkN2TVx4o0XBMLbyxJXecOKjJc5wwKuXiMk3QWdaBFTSwi8XmcEW
+        5uD77vaohT6gJdCz4loOKIlrK/rlzGeqwiwb4wxGteMMw9gWdkGFM39a/wtj/KvhSFbBQY80HET9
+        6XHGIQ227IduCof2DfhM0XgW5Cgg0PrjHKqzWWl4zlBR9jJG9rGsql+cErq3V+4nqXqL1S8N0Ey2
+        eSpZlCT5kjtXGlZ5TOaJyHOvtv3rIVuttAZODK39xMmAJki9fyNnwiV1SQpGCQ16PM4/FKez4L78
+        ZOeWCT3oguFjd0pu4OPRfodynCYqQ/4k4KA0hPH3HgdkKVkSrG8VYnKGo0KuHj33J/IOcQRGjAfO
+        s9/bALPS8IXQLfHILcizaUqXyOG2BfQ7yLMsg3aFd4PiBXcyHIaTsjYUMic/ZRgqbvVCUoaz39xG
+        8YGz1iTzypDTLB33Nco9EAZKZuDlnUIyvqdEumRHvlwAjnu/D7HYyA3/7GpIJPEycMmF9UK3KO61
+        2pdmfO+RCygy1oQoaGgrSqYFvfBN6Ye2Ep29JwvQa/QSvL5IOn70ZovceLQ+Tkv5BGxblKJnB19N
+        Wy7z5+Fzd4QrJB3JoSf7OqCDaOztZYrAnZnVnjsZDGhxHJt80gRdpoW98HXrx9doH+TxMZ/4vBNV
+        RoQxfhmyJObautyuIabhae4XRN+k5kwFgksduDDRhgsuoLLq6ONRKmW+007PyfN9AeEg2mOHcv2k
+        WNRiH7iVvi6HD2ApKy4y8rJan7fuUGuUGNh4ypoWFa+nJQ+ODHfd6WzEWroLYzdvBWeEU2gPh8tB
+        Zlkb+Phbv1+kZTjH/4efd/151cIstzJKVgQmiZbzaqfLs9rgybT+lXO0whbWmBI6AbWcRwAbF4p4
+        PnaPWEQynrQwO/Goa8Mr86g8U5RJCo2PlSvX739PKxK9J1A+/MfcnYIGrA2bTOg5FYm0bWqxYTn2
+        /ZkhjjBTF9aQyoM9UsnVb6HVtH6f1YZPfFN5ESPnvajYptAzzms4Bn/UdzVI8rjME1JsKw23+4tJ
+        3/MsBRzpUOXLcHCYddQbVbLaMMjkfkNKXDXUoPy2jzo5diGuCvm4Fzv4xOKvm2uoBGntX6rE9Wxc
+        XSKLder2w/HILUXXY79nLYj7awyXGF1syAFULVMv52mCxgqeupbYUj6kmjptxUdP+YTdXyZC4WP3
+        qIGSVtHCgMxTZHHRlsFDg4oLtk5LZ2FM7YlwAVDBO8biGoJorY6FEZUnIVHi3nQoIcCcD0gFlSTm
+        Um+Pk35l2rB1mk9kyMJ8SmMOXn4+SMvUHNaySTlTGIn1Ii10mUkxjT06M3FQB/YIdQcuRINnFXgy
+        i8LzhAup6SKUbHpxNvfkbame0JpaGOuJoT3h97/T0zvoy6IXRf52lT4lvcGoCSxA4Rz8nEtr8LSu
+        kgEXqdhNu8k19F5x1cPu5WG50qyUY2scwcBvNflW/MAP9CKX0AR7nocTaVvp0gpn+TiftJyHWTrZ
+        Mi2vKY/WIw63qmCZVksNomNGrrt5gcYgm3AcPtMGy/xaAy9T+kVDsQ3SeW9nux5C08i0KApagzKG
+        N5upoCWxMk98QWqi+6xC0xqaeVjj6eCequd2Ju2BprJ7UNEapnmch12B0zoMO9xJ0Onxw6ejSl1r
+        gC1wP4mXBgrSc3YWVxYAmupy4hz1vdbQGjR5sH8uBeg1Yp3Hvrusw9PlqEtreOQBraeoSXWa8dZH
+        Hi7jc7gOTWtlKR/ia+5le3yAngBC1TcaNew4TBUDoGUzHXVvak3lLF/SaH5QTZvEcRx9nadlQS5O
+        781KjA/uQkg8n1Z6IjjvBoeyP5JN6w+3PY6b7JU+NfrWt0jQB4hJMc3vyfXucWeLOAjrNK2Hc0ex
+        gHLIAocUhw/8m5B0V1AU6kbeT5lwypPziRJCIUCNpT3sMIXLorRWFvg0nnEb18j8AgV6mhX5XXIm
+        +Lo4PoxsfcnKrTBuIPYviqugikzvP6B5HMho6A2c4ajzPy6qTHMtpQWyDZ8SDpZGBftJSxIs2o98
+        69LlJiwqY4FjXn7PSEs0yPpRGCC3rvGbIbydmAcaR+xAHzcDwHsa1tClmmuhLbDy08szSKErx+rd
+        ZxpQbqJMTqgepYk1TwzizKL1PIuY+7t+CNe4Gaz5m8wPVbuOC3P0ijbDbr614gXHhPCRPuIA2Lbr
+        TmkNt5w09OAgj6JEcPYtI+PYr3p5E61fqF6EksjjND5P4cI4xTEfl6ruJ9TpgzSJ86bV0lYcclho
+        9xAPT68nVHayaFopA3XqL4PFB6V00r3r1RGWbjTJQ7E5+MCbv5ldYewqfzMkPmikiLW94hI+TjR9
+        vTtOMOHq4tFKjiF3kGuNLXDYzLCVu0OZyZZWSCsjpZGlnw0uSIDDgdqhZJosXbR5nzpwYILac8CF
+        n3WIuth7vs+5MTKMaj1ZI/ev6e4I4RLOlXzgPd9OoTVesM3+/SniKKtUVPChD7dP6BWBSSDjUbkn
+        K2Bv7lPAVYWYxX8xiVAhU2L/QlytgIOJ4WR2tKqaZwbUYnPSEB9kMR+l/bhO568i/E1g+EqoDI88
+        qPJURcyJ4jvVL2kNfAXk0k+yxNVfBeq3n4LLQTA8/vtXVtId5AbDzNDGJP75SLwDjHrRAlcD3ZV9
+        mYGNB/r35Sry/eApJ3o2q2so45F+r0ocQ2r18JoW6FEn8zKcGdow+n7ZHD5AdZC4/+eAzP0++q6/
+        jSeoZ03acAjvZ2JgY8rNErZos5ds7XRBhgR5pOeBr1vkBFK4ezXPDXtMdNfulVzc9qUJXbmh7anD
+        mcPofLgtw25QnzAP5Solbz0/cjIzbW6zktv/o2YJdSvlUnu2FHanrtMVxSs4Bv9i2ufLjPZLim7n
+        ngZcRuGfG3+wyz3/Wi5EhQHF+WV2/6GaycPUyRVG3GwiBz5fxCV9BiLXL/gqQCRmuCPmC/NRnmXg
+        ySz8OpJTxI8UnqQGn6dVaCqjwZDK0yCnmrBzpMc+KOh7/Ptl3K2DuuV5qFvxWabyfkwj5UNC3Lls
+        BkGufngMPl8oWOnI0pO2Uur/W2hXuU7zS/TFPW6NyeYsMH2QJZJX4pJBTCEJKgfk8glhKEnpOP90
+        MgUNkvtSawid6fcTnp2IFG5r28t5GeQ+7X5N5W+YJu/KmzU+TcTtZlDr6GqE0xhxqewiFWFhYOjl
+        8RsGrdxI9J/TdELnXPTN89z31oeYFwZMjHQ+BB8aqiDlP5BnRR50P3Z8kWOsx9sfcCYTXaKcfkAf
+        OprJye/EXXV6dWthyGVmfsnJgUrw4t0Toj/ubInOb/Wq1sLQycO8uJCN4Srcr19INGBhIOWRm0dS
+        NFi66OZl2O9DeJMXhk4Mq7yQ5Q0ui+S8MGRfQlwJ0nkXhd4gysP9lMnoVdCDFGre6z15YXDk7/2m
+        kb3j29r+1aaVBsgi37jMlVzDUPJtmHJL8L36I+9ZGtjkxgZP2+DSMaX93AtOTxdSvyTY3Uu/cAf9
+        y0CRr2qR0oBX8s30jlmZSRVu40EIkUGOx/gZoOkKOa2r3kiNA3uiTNZu0L7svDRQ8XC/cIh9Gy5v
+        fkWmXFyB0rBEFqi6nzVI+VhQDYv6gxUvbJ7/9QwUY3wEqGg9S3K8q0Su8zvPgx4GzkMtSb6/H+NM
+        +UBPwUWHX93pxz2FummN0WN47emLmI8k2e8haCAkeX654W+Gkb6f68hDnUipS88OvrqqUwkk5QYq
+        uQeWr17SuxbGnkyVtj/J/cqJcQWTwnOt4xI5RlQKOk7Zc2XvHuuGIpAO3cyoIbe5ELP+ITpOepk1
+        rvu+7A5Knhk5RleOHFcUIODfkitZHsh4lJ8xupg4gOLTAqFVlbPzuAyjX6UHYjruBWWh8FNzucOl
+        x2u5G60I0d1VmgAnPvC7oHOiOx7JcWC3W9R5KAopqX+bPBF7w3E6J4tln+UeM5d/1hc0oEKP3js2
+        8UEb8zHt9z0fHKG9vJzNbJJidBf1SxGMk+woy3snsTJgg58LiGuopqTNJAU5HYflcLyZuziEXJic
+        U5vl4klomu5I/KcVPULHoz7DwI/DQhvhKXAVdaM58NBim1cGb3yfbyalLcvvWbHp7XzcKNP/TM6R
+        Hb7PawNzseliTvnMTw3/KLjwmmPaBk4hoGKlYq61YKU2sJMCy+oNb4qg7AwllkgPvkbkSXWc6SZ/
+        TGdomGcirxNCRQFegy71r6gN+iXK8HeM4aJEuYfok+8DmaQHOA9FJB3WeLpU+mi+CZ2B/lo8kJZG
+        mm56ZxooYs6hS9sHjhOP3Pl5kCImXwLLV0D0IwCkr1AZv3zjFvN5JC5a/IVbXO5pOj3pFn6axK4S
+        UYa1MSw3JY0GTnoNq6sBn0sKcu3SUNMYBxBknkMr17a4Hzc5Djvc/RxoW6Nt/T0tKR9f4rbR73FM
+        fjjh9k9y9I8ykW0pkS+gj754/7w8JhSi+HhSUvpdIN2ZwGNzG6iJRbREySaGgpSO9mtEOpRz8tce
+        3WfIDZFUdbtDxPcf6n2hso2cYOH2r3sDah4qV8rJQwuJy7bRvjZYEL3pe4q+HRaa4bHjk2VgkhsT
+        5HYTz6SI25wrWdqHgCz+8XiziBC/OBBK5MrN0M7Em7et5HzWB3aHeTpvPk5Pa/Qf5B/d3gi5IZ5H
+        b96okXse/Q844ReA9LkGbYwr/FvgZgBkRkDzuderJ7orutXG7sVfRZQ3hmcmKj2XPK74yJDrcL3n
+        LxqDMY/z8+aTrIVVM3Q/+dprfajBmIf6JcOJKcBPjjz6RnjUYk6DXFV2v+kUk2NPSDi3hlxm5IWL
+        jE8Jr0XlHRlUWo8viHhr8GWSwvEocMcTbdg3p9D9rrlSrmTobzEYRHl07cnJ59n+6EfoYI6kKehx
+        2t84RYiMtc/z4vYn3IM+axtP3hqGUdxJ/SRJ1fMVUnLxP3FgBa1kCtaWj+a71JEcy5LJ+fuSj+rF
+        sF48agGPF2w3mWsVKlvKZMMVRySq+ytP4/HGfpm7laLTt4PKXTq5/SEP9S5l0XieOK1V853EVy2I
+        sPXs93ITUR4qXy1f3OiC8RaZDD7fqoZLcuh6s5fa6qXvg7SytOi2NoEns8g8z1J+MQzu49wfu5/f
+        Rgp9VEmkwQm3deqtWfzfmUCo3fl5qJrxWSz3MzEpn6fi2za+ketP7OfbilAh0yGFp2lw6JBoZFl6
+        cQ7CHd67S/jNj9Q4gKByHCgQ5+zo5gA7GsBQR9FrcvAbEMNMTtjfp5cwpyxwZAYbjiXOqtnxlg+b
+        JlVA4c5rUWa5MSNa56Dx2SpuepCDPuFnrz5of5k233OO/tBjyfnwtDA1+BecFHNMC9yKX25OtvxK
+        tovEgE6BcZF7UCIwhs59j2u8wiW6RWIo5u89EvmceKvt29a1934ia3NFY7XQG5JLFKk8NOAXhsOZ
+        2hIbflINDQ8ckGlfZJEYeJnKz7sscfeO1M8YX3HEDowSGjR5nJdsVjNwkztcpyHXUghRatjEmNJv
+        XdnID/Tdz06430FED/vIN/uwgkErg2smA2ODLPMxGczwqx/ywzh2q084PibFmkk04HeX8d7iXmht
+        LONfamzux/eyRG6eTQ2v925y7j44Ducz3wm2kjU+2g8BFVodC/QbhnXMKf/7rypq7SvjXxIs740E
+        +KDCsfuwSjeK+bQlvNM9ikKbbaHlrkC04VLHDcIcPlODZcZ9PHqnUcCXlrx09L2xMsOfuIBD+Wcx
+        lLxPq3REo8v/fsL+vu91YMa0hWeWyS98PES6AA/R3c7IqY5gTQqthgUqv8vkYWXh6Cw2lwRtN9nq
+        t4GOPJLi3ieZ8Q/otdCyeiWM3Ygmv/40hQN2+N2hxJjg7mW/hRwN5/9/vxjxfwFQSwECAAAUAAAA
+        CACKM1hAcqkZx48tAAAcdAAAJwAAAAAAAAAAAAAAAAAAAAAAVGhlLkJpZy5CYW5nLlRoZW9yeS5T
+        MDVFMTguSERUVi1MT0wuc3J0UEsFBgAAAAABAAEAVQAAANQtAAAAAA==
+    headers:
+      Accept-Ranges:
+      - bytes
+      Connection:
+      - keep-alive
+      Content-Disposition:
+      - attachment; filename="b2b8a2650b38289482e5d4ea71170cbd87781d04.zip"
+      Content-Length:
+      - '11839'
+      Content-Type:
+      - application/octet-stream
+      Date:
+      - Sat, 15 Feb 2025 01:07:34 GMT
+      ETag:
+      - '"4f472731-2e3f"'
+      Last-Modified:
+      - Fri, 24 Feb 2012 05:59:13 GMT
+      Server:
+      - nginx
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -26,6 +26,23 @@ if TYPE_CHECKING:
 TESTS_DIR = Path(__file__).parent
 
 
+def ensure(path: str | os.PathLike[str], *, directory: bool = False) -> Path:
+    """Create a file (or directory) at path."""
+    path = Path(path)
+    if directory:
+        # Create a directory at path
+        if not path.is_dir():
+            path.mkdir(parents=True)
+
+    else:
+        # Create a directory at parent
+        if not path.parent.is_dir():
+            path.parent.mkdir(parents=True)
+        # Create a file at path
+        path.touch()
+    return path
+
+
 @pytest.fixture(autouse=True, scope='session')
 def _configure_region() -> None:
     region.configure('dogpile.cache.null')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -669,6 +669,18 @@ def provider_manager(monkeypatch: pytest.MonkeyPatch) -> Generator[RegistrableEx
             'video_name': episode2_name,
             'matches': {'episode', 'season', 'series', 'year'},
         },
+        {
+            'language': Language.fromietf('ukr'),
+            'subtitle_id': 'WeOa',
+            'fake_content': (  # windows-1251
+                b'1\n00:00:02,090 --> 00:00:03,970\n'
+                b'\xcf\xf0\xe8\xe2\xb3\xf2!\n\n'  # Привіт!\n\n
+                b'2\n00:00:04,080 --> 00:00:05,550\n'
+                b'\xd2\xb3\xe2\xe8\xf0\xef!\n\n'  # Тівирп!\n\n
+            ),
+            'video_name': episode2_name,
+            'matches': {'episode', 'season', 'series', 'year'},
+        },
     ]
 
     ep_podnapisi = mock_subtitle_provider('Podnapisi', subtitle_pool_podnapisi)
@@ -786,6 +798,32 @@ def provider_manager(monkeypatch: pytest.MonkeyPatch) -> Generator[RegistrableEx
             ),
             'video_name': episode_name,
             'matches': {'episode', 'season', 'series'},
+        },
+        {
+            'language': Language.fromietf('en'),
+            'subtitle_id': 'f7fe1369-4154-fa0c-bd04-d3d332de614c',
+            'fake_content': (
+                b'1\n00:00:02,090 --> 00:00:03,970\n'
+                b'[hearing impaired] Greetings.\n\n'
+                b'2\n00:00:04,080 --> 00:00:05,550\n'
+                b'Sgniteerg.\n\n'
+            ),
+            'video_name': episode2_name,
+            'matches': {'episode', 'season', 'series', 'year'},
+            'hearing_impaired': True,
+        },
+        {
+            'language': Language.fromietf('en'),
+            'subtitle_id': 'b5fe1369-fa0c-bd04-4154-d3d332d1234e',
+            'fake_content': (
+                b'1\n00:00:02,090 --> 00:00:03,970\n'
+                b'[foreign only] Greetings.\n\n'
+                b'2\n00:00:04,080 --> 00:00:05,550\n'
+                b'Sgniteerg.\n\n'
+            ),
+            'video_name': episode2_name,
+            'matches': {'episode', 'season', 'series', 'year'},
+            'foreign_only': True,
         },
     ]
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -582,6 +582,7 @@ def provider_manager(monkeypatch: pytest.MonkeyPatch) -> Generator[RegistrableEx
     episode_name = os.path.join(
         'The Big Bang Theory', 'Season 07', 'The.Big.Bang.Theory.S07E05.720p.HDTV.X264-DIMENSION.mkv'
     )
+    episode2_name = 'Marvels.Agents.of.S.H.I.E.L.D.S02E06.720p.HDTV.x264-KILLERS.mkv'
 
     # Podnapisi, subtitle pool
     subtitle_pool_podnapisi = [
@@ -638,6 +639,18 @@ def provider_manager(monkeypatch: pytest.MonkeyPatch) -> Generator[RegistrableEx
             ),
             'video_name': movie_name,
             'matches': {'title', 'country', 'year'},
+        },
+        {
+            'language': Language.fromietf('en'),
+            'subtitle_id': 'Dadi',
+            'fake_content': (
+                b'1\n00:00:02,090 --> 00:00:03,970\n'
+                b'Greetings.\n\n'
+                b'2\n00:00:04,080 --> 00:00:05,550\n'
+                b'Sgniteerg.\n\n'
+            ),
+            'video_name': episode2_name,
+            'matches': {'episode', 'season', 'series', 'year'},
         },
     ]
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,76 @@
+# ruff: noqa: PT011, SIM115
+from __future__ import annotations
+
+import os
+from textwrap import dedent
+
+import pytest
+from click.testing import CliRunner
+from vcr import VCR
+
+from subliminal.cli import subliminal
+
+# Core test
+pytestmark = pytest.mark.core
+
+
+vcr = VCR(
+    path_transformer=lambda path: path + '.yaml',
+    record_mode=os.environ.get('VCR_RECORD_MODE', 'once'),
+    match_on=['method', 'scheme', 'host', 'port', 'path', 'query', 'body'],
+    cassette_library_dir=os.path.realpath(os.path.join('tests', 'cassettes', 'cli')),
+)
+
+
+def test_cli_help() -> None:
+    runner = CliRunner()
+    result = runner.invoke(subliminal, ['--help'])
+    assert result.exit_code == 0
+    assert result.output.startswith('Usage: subliminal [OPTIONS] COMMAND [ARGS]...')
+
+
+def test_cli_cache() -> None:
+    runner = CliRunner()
+
+    # Do nothing
+    result = runner.invoke(subliminal, ['cache'])
+    assert result.exit_code == 0
+    assert result.output == 'Nothing done.\n'
+
+    # Clean cache
+    result = runner.invoke(subliminal, ['cache', '--clear-subliminal'])
+    assert result.exit_code == 0
+    assert result.output == "Subliminal's cache cleared.\n"
+
+
+@vcr.use_cassette
+def test_cli_download(tmp_path: os.PathLike[str]) -> None:
+    runner = CliRunner()
+    movie_name = 'The.Big.Bang.Theory.S05E18.HDTV.x264-LOL.mp4'
+
+    with runner.isolated_filesystem(temp_dir=tmp_path) as td:
+        result = runner.invoke(subliminal, ['download', '-l', 'en', '-p', 'podnapisi', movie_name])
+
+        assert result.exit_code == 0
+        assert result.output.startswith('Collecting videos')
+        assert result.output.endswith('Downloaded 1 subtitle\n')
+
+        subtitle_filename = os.path.splitext(movie_name)[0] + '.en.srt'
+        assert subtitle_filename in os.listdir(td)
+
+        content = open(subtitle_filename, encoding='utf-8-sig').read()
+
+    expected = dedent(
+        """\
+        1
+        00:00:02,370 --> 00:00:04,304
+        I'm just gonna run to the
+        store and get a few things.
+
+        2
+        00:00:04,306 --> 00:00:05,339
+        I'll pick you up
+        when you're done.
+        """
+    )
+    assert content.startswith(expected)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,28 +3,44 @@ from __future__ import annotations
 
 import os
 from textwrap import dedent
+from typing import TYPE_CHECKING
+from unittest.mock import Mock
 
 import pytest
 from click.testing import CliRunner
-from vcr import VCR
 
-from subliminal.cli import subliminal
+from subliminal.cli import subliminal as subliminal_cli
+
+if TYPE_CHECKING:
+    from collections.abc import Generator
 
 # Core test
-pytestmark = pytest.mark.core
+# Core test
+pytestmark = [
+    pytest.mark.core,
+    pytest.mark.usefixtures('provider_manager'),
+    pytest.mark.usefixtures('disabled_providers'),
+]
 
 
-vcr = VCR(
-    path_transformer=lambda path: path + '.yaml',
-    record_mode=os.environ.get('VCR_RECORD_MODE', 'once'),
-    match_on=['method', 'scheme', 'host', 'port', 'path', 'query', 'body'],
-    cassette_library_dir=os.path.realpath(os.path.join('tests', 'cassettes', 'cli')),
-)
+@pytest.fixture
+def _mock_save_subtitles() -> Generator[None, None, None]:
+    import subliminal.cli
+
+    original_save_subtitles = subliminal.cli.save_subtitles
+
+    # Use mock
+    subliminal.cli.save_subtitles = Mock()
+
+    yield
+
+    # Restore value
+    subliminal.cli.save_subtitles = original_save_subtitles
 
 
 def test_cli_help() -> None:
     runner = CliRunner()
-    result = runner.invoke(subliminal, ['--help'])
+    result = runner.invoke(subliminal_cli, ['--help'])
     assert result.exit_code == 0
     assert result.output.startswith('Usage: subliminal [OPTIONS] COMMAND [ARGS]...')
 
@@ -33,29 +49,65 @@ def test_cli_cache() -> None:
     runner = CliRunner()
 
     # Do nothing
-    result = runner.invoke(subliminal, ['cache'])
+    result = runner.invoke(subliminal_cli, ['cache'])
     assert result.exit_code == 0
     assert result.output == 'Nothing done.\n'
 
     # Clean cache
-    result = runner.invoke(subliminal, ['cache', '--clear-subliminal'])
+    result = runner.invoke(subliminal_cli, ['cache', '--clear-subliminal'])
     assert result.exit_code == 0
     assert result.output == "Subliminal's cache cleared.\n"
 
 
-@vcr.use_cassette
+def test_cli_download_wrong_language(tmp_path: os.PathLike[str]) -> None:
+    runner = CliRunner()
+    video_name = 'Marvels.Agents.of.S.H.I.E.L.D.S02E06.720p.HDTV.x264-KILLERS.mkv'
+
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        result = runner.invoke(subliminal_cli, ['download', '-l', 'zzz', '-p', 'podnapisi', video_name])
+
+        assert result.exit_code > 0
+
+
+def test_cli_download_age(tmp_path: os.PathLike[str]) -> None:
+    runner = CliRunner()
+    video_name = 'Marvels.Agents.of.S.H.I.E.L.D.S02E06.720p.HDTV.x264-KILLERS.mkv'
+
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        # Wrong age
+        result = runner.invoke(subliminal_cli, ['download', '-l', 'en', '--age', '1h2y', '-p', 'podnapisi', video_name])
+
+        assert result.exit_code > 0
+
+        # Right age
+        result = runner.invoke(subliminal_cli, ['download', '-l', 'en', '--age', '3w6h', '-p', 'podnapisi', video_name])
+
+        assert result.exit_code == 0
+
+
+def test_cli_download_debug(tmp_path: os.PathLike[str]) -> None:
+    runner = CliRunner()
+    video_name = 'Marvels.Agents.of.S.H.I.E.L.D.S02E06.720p.HDTV.x264-KILLERS.mkv'
+
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        result = runner.invoke(subliminal_cli, ['--debug', 'download', '-l', 'en', '-p', 'podnapisi', video_name])
+
+        assert result.exit_code == 0
+        assert 'DEBUG' in result.output
+
+
 def test_cli_download(tmp_path: os.PathLike[str]) -> None:
     runner = CliRunner()
-    movie_name = 'The.Big.Bang.Theory.S05E18.HDTV.x264-LOL.mp4'
+    video_name = 'Marvels.Agents.of.S.H.I.E.L.D.S02E06.720p.HDTV.x264-KILLERS.mkv'
 
     with runner.isolated_filesystem(temp_dir=tmp_path) as td:
-        result = runner.invoke(subliminal, ['download', '-l', 'en', '-p', 'podnapisi', movie_name])
+        result = runner.invoke(subliminal_cli, ['download', '-l', 'en', '-p', 'podnapisi', video_name])
 
         assert result.exit_code == 0
         assert result.output.startswith('Collecting videos')
         assert result.output.endswith('Downloaded 1 subtitle\n')
 
-        subtitle_filename = os.path.splitext(movie_name)[0] + '.en.srt'
+        subtitle_filename = os.path.splitext(video_name)[0] + '.en.srt'
         assert subtitle_filename in os.listdir(td)
 
         content = open(subtitle_filename, encoding='utf-8-sig').read()
@@ -63,14 +115,13 @@ def test_cli_download(tmp_path: os.PathLike[str]) -> None:
     expected = dedent(
         """\
         1
-        00:00:02,370 --> 00:00:04,304
-        I'm just gonna run to the
-        store and get a few things.
+        00:00:02,090 --> 00:00:03,970
+        Greetings.
 
         2
-        00:00:04,306 --> 00:00:05,339
-        I'll pick you up
-        when you're done.
+        00:00:04,080 --> 00:00:05,550
+        Sgniteerg.
+
         """
     )
     assert content.startswith(expected)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import os
+from pathlib import Path
 from textwrap import dedent
 from typing import TYPE_CHECKING
 from unittest.mock import Mock
@@ -10,6 +11,7 @@ import pytest
 from click.testing import CliRunner
 
 from subliminal.cli import subliminal as subliminal_cli
+from tests.conftest import ensure
 
 if TYPE_CHECKING:
     from collections.abc import Generator
@@ -69,6 +71,18 @@ def test_cli_download_wrong_language(tmp_path: os.PathLike[str]) -> None:
         assert result.exit_code > 0
 
 
+def test_cli_download_guessing_error(tmp_path: os.PathLike[str]) -> None:
+    runner = CliRunner()
+    video_name = '1x1.mkv'
+
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        # Need --verbose for the message to appear
+        result = runner.invoke(subliminal_cli, ['download', '-l', 'en', '--verbose', '-p', 'podnapisi', video_name])
+
+        assert result.exit_code == 0
+        assert 'Insufficient data to process the guess' in result.output
+
+
 def test_cli_download_age(tmp_path: os.PathLike[str]) -> None:
     runner = CliRunner()
     video_name = 'Marvels.Agents.of.S.H.I.E.L.D.S02E06.720p.HDTV.x264-KILLERS.mkv'
@@ -96,6 +110,66 @@ def test_cli_download_debug(tmp_path: os.PathLike[str]) -> None:
         assert 'DEBUG' in result.output
 
 
+def test_cli_download_logfile(tmp_path: os.PathLike[str]) -> None:
+    runner = CliRunner()
+    video_name = 'Marvels.Agents.of.S.H.I.E.L.D.S02E06.720p.HDTV.x264-KILLERS.mkv'
+
+    logfile = 'subliminal.log'
+    with runner.isolated_filesystem(temp_dir=tmp_path) as td:
+        result = runner.invoke(
+            subliminal_cli,
+            ['--logfile', logfile, 'download', '-l', 'en', '-p', 'podnapisi', video_name],
+        )
+
+        assert result.exit_code == 0
+        # collect files recursively
+        files = [os.fspath(p.relative_to(td)) for p in Path(td).rglob('*')]
+        assert logfile in files
+
+        log_content = open(logfile).read()
+        assert 'DEBUG' in log_content
+
+
+@pytest.mark.parametrize('count', [0, 1, 2])
+@pytest.mark.parametrize('video_type', ['movie', 'episode'])
+def test_cli_download_verbose(count: int, video_type: str, tmp_path: os.PathLike[str]) -> None:
+    runner = CliRunner()
+    if video_type == 'episode':
+        video_name = 'Marvels.Agents.of.S.H.I.E.L.D.S02E06.720p.HDTV.x264-KILLERS.mkv'
+    else:  # elif video_type == 'movie':
+        video_name = os.path.join('Man of Steel (2013)', 'man.of.steel.2013.720p.bluray.x264-felony.mkv')
+
+    verbose = '' if not count else f'-{"v" * count}'
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        # Ensure that the file exists, otherwise the movie errors
+        ensure(video_name)
+        result = runner.invoke(subliminal_cli, ['download', verbose, '-l', 'en', '-p', 'podnapisi', video_name])
+
+        assert result.exit_code == 0
+        if count > 0:
+            assert '1 subtitle downloaded' in result.output
+        else:
+            assert '1 subtitle downloaded' not in result.output
+        if count > 1:
+            assert 'English subtitle from podnapisi' in result.output
+        else:
+            assert 'English subtitle from podnapisi' not in result.output
+
+
+def test_cli_download_no_provider(tmp_path: os.PathLike[str]) -> None:
+    runner = CliRunner()
+    video_name = 'Marvels.Agents.of.S.H.I.E.L.D.S02E06.720p.HDTV.x264-KILLERS.mkv'
+
+    with runner.isolated_filesystem(temp_dir=tmp_path):
+        result = runner.invoke(
+            subliminal_cli,
+            ['download', '-vv', '-l', 'en', '-p', 'podnapisi', '-P', 'podnapisi', video_name],
+        )
+
+        assert result.exit_code == 0
+        assert 'No provider was selected to download subtitles.' in result.output
+
+
 def test_cli_download(tmp_path: os.PathLike[str]) -> None:
     runner = CliRunner()
     video_name = 'Marvels.Agents.of.S.H.I.E.L.D.S02E06.720p.HDTV.x264-KILLERS.mkv'
@@ -108,7 +182,9 @@ def test_cli_download(tmp_path: os.PathLike[str]) -> None:
         assert result.output.endswith('Downloaded 1 subtitle\n')
 
         subtitle_filename = os.path.splitext(video_name)[0] + '.en.srt'
-        assert subtitle_filename in os.listdir(td)
+        # collect files recursively
+        files = [os.fspath(p.relative_to(td)) for p in Path(td).rglob('*')]
+        assert subtitle_filename in files
 
         content = open(subtitle_filename, encoding='utf-8-sig').read()
 
@@ -125,3 +201,140 @@ def test_cli_download(tmp_path: os.PathLike[str]) -> None:
         """
     )
     assert content.startswith(expected)
+
+
+def test_cli_download_directory(tmp_path: os.PathLike[str]) -> None:
+    runner = CliRunner()
+    movie_name = os.path.join('Man of Steel (2013)', 'man.of.steel.2013.720p.bluray.x264-felony.mkv')
+    episode_name = 'Marvels.Agents.of.S.H.I.E.L.D.S02E06.720p.HDTV.x264-KILLERS.mkv'
+
+    with runner.isolated_filesystem(temp_dir=tmp_path) as td:
+        ensure(movie_name)
+        ensure(episode_name)
+
+        result = runner.invoke(subliminal_cli, ['download', '-l', 'en', '-p', 'podnapisi', '.'])
+
+        assert result.exit_code == 0
+        assert result.output.startswith('Collecting videos')
+        assert result.output.endswith('Downloaded 2 subtitles\n')
+
+        subtitle_movie_filename = os.path.splitext(movie_name)[0] + '.en.srt'
+        subtitle_episode_filename = os.path.splitext(episode_name)[0] + '.en.srt'
+
+        # collect files recursively
+        files = [os.fspath(p.relative_to(td)) for p in Path(td).rglob('*')]
+        assert subtitle_movie_filename in files
+        assert subtitle_episode_filename in files
+
+
+@pytest.mark.parametrize(
+    ('encoding', 'real_encoding'),
+    [
+        ('', 'windows-1251'),
+        ('""', 'windows-1251'),
+        ("''", 'windows-1251'),
+        (None, 'utf-8'),
+        ('utf-8', 'utf-8'),
+    ],
+)
+def test_cli_download_encoding(encoding: str | None, real_encoding: str, tmp_path: os.PathLike[str]) -> None:
+    runner = CliRunner()
+    video_name = 'Marvels.Agents.of.S.H.I.E.L.D.S02E06.720p.HDTV.x264-KILLERS.mkv'
+
+    cli_args = ['download', '-l', 'ukr', '-p', 'podnapisi', video_name]
+    if encoding is not None:
+        cli_args.extend([f'--encoding={encoding}'])
+
+    with runner.isolated_filesystem(temp_dir=tmp_path) as td:
+        result = runner.invoke(subliminal_cli, cli_args)
+
+        assert result.exit_code == 0
+        subtitle_filename = os.path.splitext(video_name)[0] + '.uk.srt'
+        # collect files recursively
+        files = [os.fspath(p.relative_to(td)) for p in Path(td).rglob('*')]
+        assert subtitle_filename in files
+
+        content = open(subtitle_filename, encoding=real_encoding).read()
+
+    expected = dedent(
+        """\
+        1
+        00:00:02,090 --> 00:00:03,970
+        Привіт!
+
+        2
+        00:00:04,080 --> 00:00:05,550
+        Тівирп!
+
+        """
+    )
+    assert content.startswith(expected)
+
+
+def test_cli_download_subtitle_format(tmp_path: os.PathLike[str]) -> None:
+    runner = CliRunner()
+    video_name = 'Marvels.Agents.of.S.H.I.E.L.D.S02E06.720p.HDTV.x264-KILLERS.mkv'
+
+    with runner.isolated_filesystem(temp_dir=tmp_path) as td:
+        result = runner.invoke(
+            subliminal_cli,
+            ['download', '-l', 'en', '-p', 'podnapisi', video_name, '--subtitle-format', 'ass'],
+        )
+
+        assert result.exit_code == 0
+        subtitle_filename = os.path.splitext(video_name)[0] + '.en.ass'
+        # collect files recursively
+        files = [os.fspath(p.relative_to(td)) for p in Path(td).rglob('*')]
+        assert subtitle_filename in files
+
+        content = open(subtitle_filename).read()
+
+    expected = dedent(
+        """\
+        [Events]
+        Format: Layer, Start, End, Style, Name, MarginL, MarginR, MarginV, Effect, Text
+        Dialogue: 0,0:00:02.09,0:00:03.97,Default,,0,0,0,,Greetings.
+        Dialogue: 0,0:00:04.08,0:00:05.55,Default,,0,0,0,,Sgniteerg.
+        """
+    )
+    assert content.endswith(expected)
+
+
+def test_cli_download_hearing_impaired(tmp_path: os.PathLike[str]) -> None:
+    runner = CliRunner()
+    video_name = 'Marvels.Agents.of.S.H.I.E.L.D.S02E06.720p.HDTV.x264-KILLERS.mkv'
+
+    cli_args = ['download', '-l', 'en', '--hearing-impaired', '--language-type-suffix', '-p', 'gestdown', video_name]
+    with runner.isolated_filesystem(temp_dir=tmp_path) as td:
+        result = runner.invoke(subliminal_cli, cli_args)
+
+        assert result.exit_code == 0
+        assert result.output.endswith('Downloaded 1 subtitle\n')
+
+        subtitle_filename = os.path.splitext(video_name)[0] + '.hi.en.srt'
+        # collect files recursively
+        files = [os.fspath(p.relative_to(td)) for p in Path(td).rglob('*')]
+        assert subtitle_filename in files
+
+        content = open(subtitle_filename, encoding='utf-8-sig').read()
+
+    assert '[hearing impaired]' in content
+
+
+def test_cli_download_foreign_only(tmp_path: os.PathLike[str]) -> None:
+    runner = CliRunner()
+    video_name = 'Marvels.Agents.of.S.H.I.E.L.D.S02E06.720p.HDTV.x264-KILLERS.mkv'
+
+    cli_args = ['download', '-l', 'en', '--foreign-only', '--language-type-suffix', '-p', 'gestdown', video_name]
+    with runner.isolated_filesystem(temp_dir=tmp_path) as td:
+        result = runner.invoke(subliminal_cli, cli_args)
+
+        assert result.exit_code == 0
+        assert result.output.endswith('Downloaded 1 subtitle\n')
+
+        subtitle_filename = os.path.splitext(video_name)[0] + '.fo.en.srt'
+        assert subtitle_filename in os.listdir(td)
+
+        content = open(subtitle_filename, encoding='utf-8-sig').read()
+
+    assert '[foreign only]' in content

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -3,9 +3,8 @@ from __future__ import annotations
 
 import os
 from datetime import datetime, timedelta, timezone
-from pathlib import Path
 from textwrap import dedent
-from typing import Any
+from typing import TYPE_CHECKING, Any
 from unittest.mock import Mock
 
 import pytest
@@ -25,6 +24,9 @@ from subliminal.subtitle import Subtitle
 from subliminal.utils import timestamp
 from subliminal.video import Episode, Movie
 from tests.conftest import ensure
+
+if TYPE_CHECKING:
+    from pathlib import Path
 
 # Core test
 pytestmark = pytest.mark.core

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -24,26 +24,10 @@ from subliminal.core import (
 from subliminal.subtitle import Subtitle
 from subliminal.utils import timestamp
 from subliminal.video import Episode, Movie
+from tests.conftest import ensure
 
 # Core test
 pytestmark = pytest.mark.core
-
-
-def ensure(path: str | os.PathLike[str], *, directory: bool = False) -> Path:
-    """Create a file (or directory) at path."""
-    path = Path(path)
-    if directory:
-        # Create a directory at path
-        if not path.is_dir():
-            path.mkdir(parents=True)
-
-    else:
-        # Create a directory at parent
-        if not path.parent.is_dir():
-            path.parent.mkdir(parents=True)
-        # Create a file at path
-        path.touch()
-    return path
 
 
 def test_check_video_languages(movies: dict[str, Movie]) -> None:

--- a/tox.ini
+++ b/tox.ini
@@ -77,7 +77,7 @@ commands =
         -m core --cov=subliminal --cov-report= --cov-fail-under=0 \
         {posargs:-n auto}
     coverage report \
-        --omit='src/subliminal/cli.py,src/subliminal/__main__.py,'\
+        --omit='src/subliminal/__main__.py,'\
             'src/subliminal/converters/*,src/subliminal/providers/*,src/subliminal/refiners/*' \
         --skip-covered --show-missing --fail-under=100
 


### PR DESCRIPTION
While adding the tests, I fixed some issues with the CLI:
- make `--encoding ""` actually work
- pass all `[default]` values from the config file to the CLI. Only `cache_dir` was passed before.
- add the `--no-language-type-suffix` flag variant to override it from config file.