### PR TITLE
Convert Video and Subtitle to dataclasses

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -296,6 +296,7 @@ texinfo_documents = [
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3.12', None),
+    'attrs': ('https://www.attrs.org/en/stable/', None),
     'guessit': ('https://guessit.readthedocs.org/en/latest', None),
     'babelfish': ('https://babelfish.readthedocs.org/en/latest', None),
     'dogpilecache': ('https://dogpilecache.sqlalchemy.org/en/latest', None),

--- a/hatch.toml
+++ b/hatch.toml
@@ -11,6 +11,10 @@ features = [
 ]
 
 # ---------------------------------------------------------
+[envs.hatch-test]
+features = ["tests"]
+
+# ---------------------------------------------------------
 [envs.pkg]
 description = "package information"
 features = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,6 +34,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
+    "attrs>=22.2",
     "babelfish>=0.6.1",
     "beautifulsoup4>=4.4.0",
     "defusedxml>=0.7.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -70,6 +70,8 @@ tests = [
     "pytest>=6.0",
     "pytest-cov",
     "pytest-xdist",
+    "cattrs",
+    "packaging",
     "sympy",
     "vcrpy>=5",  # keep synchronized with docs dependencies
     "importlib_metadata>=4.6; python_version<'3.10'",

--- a/src/subliminal/subtitle.py
+++ b/src/subliminal/subtitle.py
@@ -160,7 +160,7 @@ class Subtitle:
     force_guessing_encoding: bool = field(kw_only=True, default=True, eq=False)
 
     #: Content as bytes
-    _content: bytes | None = field(init=False, default=None, eq=True)
+    _content: bytes | None = field(init=False, default=None, eq=False)
 
     #: Content as string
     _text: str = field(init=False, default='', eq=False)
@@ -195,7 +195,7 @@ class Subtitle:
         return self.language_type.is_hearing_impaired()
 
     @hearing_impaired.setter
-    def hearing_impaired(self, value: bool | None) -> None:
+    def hearing_impaired(self, value: bool | None) -> None:  # pragma: no cover
         """Whether the subtitle is for hearing impaired."""
         self._hearing_impaired = value
 
@@ -205,7 +205,7 @@ class Subtitle:
         return self.language_type.is_foreign_only()
 
     @foreign_only.setter
-    def foreign_only(self, value: bool | None) -> None:
+    def foreign_only(self, value: bool | None) -> None:  # pragma: no cover
         """Whether the subtitle is a foreign only / forced subtitle."""
         self._foreign_only = value
 

--- a/src/subliminal/video.py
+++ b/src/subliminal/video.py
@@ -246,9 +246,6 @@ class Video:
     def __repr__(self) -> str:  # pragma: no cover
         return f'<{self.__class__.__name__} [{self.name!r}]>'
 
-    def __hash__(self) -> int:
-        return hash(self.name)
-
 
 @define
 class Episode(Video):

--- a/tests/providers/test_napiprojekt.py
+++ b/tests/providers/test_napiprojekt.py
@@ -74,7 +74,7 @@ def test_query_srt_reencode(episodes: dict[str, Episode]) -> None:
     assert subtitle.content
     assert subtitle.is_valid()
     assert subtitle.subtitle_format == 'srt'
-    assert subtitle.encoding == 'windows-1250'
+    assert subtitle.encoding == 'cp1250'
     subtitle.reencode()
     assert subtitle.encoding == 'utf-8'
     assert 'O czym myślisz?' in subtitle.text

--- a/tests/test_subtitle.py
+++ b/tests/test_subtitle.py
@@ -1,11 +1,14 @@
 from __future__ import annotations
 
 import os
+from importlib.metadata import version as get_version
 from textwrap import dedent
 from typing import TYPE_CHECKING
 
 import pytest
 from babelfish import Language  # type: ignore[import-untyped]
+from cattrs import structure, unstructure
+from packaging.version import Version
 
 from subliminal.subtitle import (
     EmbeddedSubtitle,
@@ -566,3 +569,24 @@ def test_embedded_subtitle_info_foreign_only(monkeypatch: pytest.MonkeyPatch) ->
     assert subtitle.foreign_only is True
     assert isinstance(subtitle.id, str)
     assert isinstance(subtitle.info, str)
+
+
+@pytest.mark.skipif(
+    Version(get_version('babelfish')) <= Version('0.6.1'),
+    reason='babelfish.Language needs to be a hashable dataclass',
+)
+def test_serialize_subtitle() -> None:
+    content = b'1\n00:01:00 --> 00:02:00\nA long text\n\n'
+
+    subtitle = Subtitle(
+        language=Language('eng'),
+        hearing_impaired=False,
+        page_link=None,
+        encoding=None,
+    )
+    subtitle.content = content
+
+    ser = unstructure(subtitle)
+    new_subtitle = structure(ser, Subtitle)
+
+    assert subtitle == new_subtitle

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -3,10 +3,13 @@ from __future__ import annotations
 
 import os
 from datetime import datetime, timedelta, timezone
+from importlib.metadata import version as get_version
 from typing import TYPE_CHECKING
 from unittest.mock import Mock
 
 import pytest
+from cattrs import structure, unstructure
+from packaging.version import Version
 
 from subliminal.utils import sanitize, timestamp
 from subliminal.video import Episode, Movie, Video
@@ -209,3 +212,29 @@ def test_episode_fromname(episodes: dict[str, Episode]) -> None:
     assert video.title is None
     assert video.year is None
     assert video.tvdb_id is None
+
+
+@pytest.mark.skipif(
+    Version(get_version('babelfish')) <= Version('0.6.1'),
+    reason='babelfish.Language needs to be a hashable dataclass',
+)
+def test_serialize_movie(movies: dict[str, Movie]) -> None:
+    video = movies['man_of_steel']
+
+    ser = unstructure(video)
+    new_video = structure(ser, Movie)
+
+    assert video == new_video
+
+
+@pytest.mark.skipif(
+    Version(get_version('babelfish')) <= Version('0.6.1'),
+    reason='babelfish.Language needs to be a hashable dataclass',
+)
+def test_serialize_episode(episodes: dict[str, Episode]) -> None:
+    video = episodes['bbt_s07e05']
+
+    ser = unstructure(video)
+    new_video = structure(ser, Episode)
+
+    assert video == new_video


### PR DESCRIPTION
closes #1094

It adds a dependency to the `attrs` package. And `cattrs` for tests.

By transforming the classes in dataclasses, it's easier to serialize them so they can be saved and passed around more easily. This can only work after a new release of [babelfish](https://github.com/Diaoul/babelfish) is out, that includes [this PR](https://github.com/Diaoul/babelfish/pull/50). 

