### PR TITLE
CLI make option --use-ctime default to True

### DIFF
--- a/src/subliminal/cli.py
+++ b/src/subliminal/cli.py
@@ -546,11 +546,9 @@ def cache(ctx: click.Context, clear_subliminal: bool) -> None:
     help='Filter videos newer than AGE, e.g. 12h, 1w2d.',
 )
 @click.option(
-    '--use_creation_time',
-    'use_ctime',
+    '--use-ctime/--no-use-ctime',
     is_flag=True,
-    default=False,
-    show_envvar=True,
+    default=True,
     help=(
         'Use the latest of modification date and creation date to calculate the age. '
         'Otherwise, just use the modification date.'

--- a/src/subliminal/cli.py
+++ b/src/subliminal/cli.py
@@ -800,7 +800,7 @@ def download(
             if os.path.isdir(p):
                 # collect video files
                 try:
-                    collected_filepaths = collect_video_filepaths(p, age=age, archives=archives)
+                    collected_filepaths = collect_video_filepaths(p, age=age, archives=archives, use_ctime=use_ctime)
                 except ValueError:  # pragma: no cover
                     logger.exception('Unexpected error while collecting directory path %s', p)
                     errored_paths.append(p)
@@ -838,13 +838,15 @@ def download(
                     errored_paths.append(filepath)
                     continue
 
+                # Set the use_time attribute before refining
+                video.use_ctime = use_ctime
                 video_candidates.append(video)
 
             # check and refine videos
             for video in video_candidates:
                 if not force and not force_external_subtitles:
                     video.subtitles |= set(search_external_subtitles(video.name, directory=directory).values())
-                if check_video(video, languages=language_set, age=age, use_ctime=use_ctime, undefined=single):
+                if check_video(video, languages=language_set, age=age, undefined=single):
                     refine(
                         video,
                         refiners=use_refiners,
@@ -869,8 +871,7 @@ def download(
             msg = f'{video_name!r} ignored'
             if video.exists:
                 langs = ', '.join(str(s) for s in video.subtitle_languages) or 'none'
-                video_age = video.get_age(use_ctime=use_ctime)
-                days = f"{video_age.days:d} day{'s' if video_age.days > 1 else ''}"
+                days = f"{video.age.days:d} day{'s' if video.age.days > 1 else ''}"
                 msg += f' - subtitles: {langs} / age: {days}'
             else:
                 msg += ' - not a video file'

--- a/src/subliminal/core.py
+++ b/src/subliminal/core.py
@@ -372,7 +372,6 @@ def check_video(
     *,
     languages: Set[Language] | None = None,
     age: timedelta | None = None,
-    use_ctime: bool = False,
     undefined: bool = False,
 ) -> bool:
     """Perform some checks on the `video`.
@@ -388,8 +387,6 @@ def check_video(
     :param languages: desired languages.
     :type languages: set of :class:`~babelfish.language.Language`
     :param datetime.timedelta age: maximum age of the video.
-    :param bool use_ctime: use the latest of creation time and modification time to compute the age of the video,
-        instead of just modification time.
     :param bool undefined: fail on existing undefined language.
     :return: `True` if the video passes the checks, `False` otherwise.
     :rtype: bool
@@ -401,8 +398,7 @@ def check_video(
         return False
 
     # age test
-    file_age = video.get_age(use_ctime=use_ctime)
-    if age and file_age > age:
+    if age and video.age > age:
         logger.debug('Video is older than %r', age)
         return False
 
@@ -571,7 +567,7 @@ def collect_video_filepaths(
     path: str | os.PathLike,
     *,
     age: timedelta | None = None,
-    use_ctime: bool = False,
+    use_ctime: bool = True,
     archives: bool = True,
     name: str | None = None,
 ) -> list[str]:

--- a/src/subliminal/video.py
+++ b/src/subliminal/video.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import logging
 import os
-import warnings
 from typing import TYPE_CHECKING, Any
 
 from guessit import guessit  # type: ignore[import-untyped]
@@ -181,6 +180,9 @@ class Video:
     #: TMDB id of the video
     tmdb_id: int | None
 
+    #: Use the latest of creation time and modification time for the video age
+    use_ctime: bool
+
     #: Existing subtitle languages
     subtitles: set[Subtitle]
 
@@ -198,6 +200,7 @@ class Video:
         duration: float | None = None,
         hashes: Mapping[str, str] | None = None,
         size: int | None = None,
+        use_ctime: bool = True,
         subtitles: Set[Subtitle] | None = None,
         title: str | None = None,
         year: int | None = None,
@@ -216,6 +219,7 @@ class Video:
         self.duration = duration
         self.hashes = dict(hashes) if hashes is not None else {}
         self.size = size
+        self.use_ctime = use_ctime
         self.subtitles = set(subtitles) if subtitles is not None else set()
         self.title = title
         self.year = year
@@ -231,12 +235,7 @@ class Video:
     @property
     def age(self) -> timedelta:
         """Age of the video."""
-        warnings.warn(
-            'Use `get_age(use_ctime)` instead, to specify if modification time is used or also creation time.',
-            DeprecationWarning,
-            stacklevel=1,
-        )
-        return self.get_age(use_ctime=False)
+        return get_age(self.name, use_ctime=self.use_ctime)
 
     @property
     def subtitle_languages(self) -> set[Language]:
@@ -269,10 +268,6 @@ class Video:
 
         """
         return cls.fromguess(name, guessit(name))
-
-    def get_age(self, *, use_ctime: bool = False) -> timedelta:
-        """Age of the video, with an option to take into account creation time."""
-        return get_age(self.name, use_ctime=use_ctime)
 
     def __repr__(self) -> str:  # pragma: no cover
         return f'<{self.__class__.__name__} [{self.name!r}]>'

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -42,11 +42,7 @@ def test_check_video_languages(movies: dict[str, Movie]) -> None:
 
 def test_check_video_age(movies: dict[str, Movie], monkeypatch: pytest.MonkeyPatch) -> None:
     video = movies['man_of_steel']
-
-    def fake_age(*args: Any, **kwargs: Any) -> timedelta:
-        return timedelta(weeks=2)
-
-    monkeypatch.setattr('subliminal.video.Video.get_age', fake_age)
+    monkeypatch.setattr('subliminal.video.Video.age', timedelta(weeks=2))
     assert check_video(video, age=timedelta(weeks=3))
     assert not check_video(video, age=timedelta(weeks=1))
 

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -27,13 +27,11 @@ def test_video_exists_age(movies: dict[str, Movie], tmp_path: Path, monkeypatch:
     ts = timestamp(datetime.now(timezone.utc) - timedelta(days=3))
     os.utime(video_path, (ts, ts))
     assert video.exists
-    with pytest.deprecated_call():
-        assert timedelta(days=3) <= video.age < timedelta(days=3, seconds=1)
+    assert timedelta(days=3) <= video.age < timedelta(days=3, seconds=1)
 
 
 def test_video_age(movies: dict[str, Movie]) -> None:
-    with pytest.deprecated_call():
-        assert movies['man_of_steel'].age == timedelta()
+    assert movies['man_of_steel'].age == timedelta()
 
 
 def test_video_fromguess_episode(episodes: dict[str, Episode], monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
This is breaking, but as it was a change asked by several people (#959 #860), it can be seen as an improvement with possibility to use the previous behavior is needed.

To simplify the code, `use_ctime` is now an attribute of `Video`, so the `get_age` method is not needed anymore (and is removed by this PR) and instead use the `age` property (not deprecated anymore).