### PR TITLE
Add Subtitle.set_content method

### DIFF
--- a/changelog.d/1243.misc.rst
+++ b/changelog.d/1243.misc.rst
@@ -1,0 +1,1 @@
+Add Subtitle.set_content method and use it instead of Subtitle.content property setter

--- a/src/subliminal/providers/addic7ed.py
+++ b/src/subliminal/providers/addic7ed.py
@@ -21,7 +21,7 @@ from requests.cookies import RequestsCookieJar
 from subliminal.cache import SHOW_EXPIRATION_TIME, region
 from subliminal.exceptions import ConfigurationError, DownloadLimitExceeded, NotInitializedProviderError
 from subliminal.matches import guess_matches
-from subliminal.subtitle import Subtitle, fix_line_ending
+from subliminal.subtitle import Subtitle
 from subliminal.utils import sanitize
 from subliminal.video import Episode, Video
 
@@ -638,4 +638,4 @@ class Addic7edProvider(Provider):
         if r.headers['Content-Type'] == 'text/html':  # pragma: no cover
             raise DownloadLimitExceeded
 
-        subtitle.content = fix_line_ending(r.content)
+        subtitle.set_content(r.content)

--- a/src/subliminal/providers/bsplayer.py
+++ b/src/subliminal/providers/bsplayer.py
@@ -16,7 +16,7 @@ from defusedxml import ElementTree  # type: ignore[import-untyped]
 from requests import Session
 
 from subliminal.exceptions import AuthenticationError, NotInitializedProviderError
-from subliminal.subtitle import Subtitle, fix_line_ending
+from subliminal.subtitle import Subtitle
 
 from . import Provider
 
@@ -361,4 +361,4 @@ class BSPlayerProvider(Provider):
             'Content-Length': '0',
         }
         r = self.session.get(subtitle.page_link or '', headers=headers, timeout=self.timeout)
-        subtitle.content = fix_line_ending(zlib.decompress(r.content, 47))
+        subtitle.set_content(zlib.decompress(r.content, 47))

--- a/src/subliminal/providers/gestdown.py
+++ b/src/subliminal/providers/gestdown.py
@@ -12,7 +12,7 @@ from requests import HTTPError, Session
 
 from subliminal.exceptions import DownloadLimitExceeded, NotInitializedProviderError
 from subliminal.matches import guess_matches
-from subliminal.subtitle import Subtitle, fix_line_ending
+from subliminal.subtitle import Subtitle
 from subliminal.utils import sanitize
 from subliminal.video import Episode, Video
 
@@ -420,4 +420,4 @@ class GestdownProvider(Provider):
         if r.headers['Content-Type'] == 'text/html':
             raise DownloadLimitExceeded
 
-        subtitle.content = fix_line_ending(r.content)
+        subtitle.set_content(r.content)

--- a/src/subliminal/providers/mock.py
+++ b/src/subliminal/providers/mock.py
@@ -176,7 +176,7 @@ class MockProvider(Provider):
             self.__class__.__name__,
             subtitle,
         )
-        subtitle.content = subtitle.fake_content
+        subtitle.set_content(subtitle.fake_content)
 
 
 def mock_subtitle_provider(

--- a/src/subliminal/providers/napiprojekt.py
+++ b/src/subliminal/providers/napiprojekt.py
@@ -64,7 +64,6 @@ class NapiProjektSubtitle(Subtitle):
         fps: float = 24,
     ) -> None:
         super().__init__(language, subtitle_id, fps=fps)
-        self.content = None
 
     @property
     def info(self) -> str:

--- a/src/subliminal/providers/napiprojekt.py
+++ b/src/subliminal/providers/napiprojekt.py
@@ -177,7 +177,7 @@ class NapiProjektProvider(Provider):
 
         # Create subtitle object
         subtitle = self.subtitle_class(language=language, subtitle_id=video_hash)
-        subtitle.content = content
+        subtitle.set_content(content)
         logger.debug('Found subtitle %r', subtitle)
 
         return [subtitle]

--- a/src/subliminal/providers/opensubtitles.py
+++ b/src/subliminal/providers/opensubtitles.py
@@ -22,7 +22,7 @@ from subliminal.exceptions import (
     ServiceUnavailable,
 )
 from subliminal.matches import guess_matches
-from subliminal.subtitle import Subtitle, fix_line_ending
+from subliminal.subtitle import Subtitle
 from subliminal.utils import decorate_imdb_id, sanitize_id
 from subliminal.video import Episode, Movie, Video
 
@@ -341,7 +341,7 @@ class OpenSubtitlesProvider(Provider):
         """Download the content of the subtitle."""
         logger.info('Downloading subtitle %r', subtitle)
         response = checked(self.server.DownloadSubtitles(self.token, [str(subtitle.subtitle_id)]))  # type: ignore[arg-type]
-        subtitle.content = fix_line_ending(zlib.decompress(base64.b64decode(response['data'][0]['data']), 47))
+        subtitle.set_content(zlib.decompress(base64.b64decode(response['data'][0]['data']), 47))
 
 
 class OpenSubtitlesVipSubtitle(OpenSubtitlesSubtitle):

--- a/src/subliminal/providers/opensubtitlescom.py
+++ b/src/subliminal/providers/opensubtitlescom.py
@@ -25,7 +25,7 @@ from subliminal.exceptions import (
     ServiceUnavailable,
 )
 from subliminal.matches import guess_matches
-from subliminal.subtitle import Subtitle, fix_line_ending
+from subliminal.subtitle import Subtitle
 from subliminal.video import Episode, Movie, Video
 
 from . import Provider
@@ -782,7 +782,7 @@ class OpenSubtitlesComProvider(Provider):
             logger.debug('Unable to download subtitle. No data returned from provider')
             return
 
-        subtitle.content = fix_line_ending(download_response.content)
+        subtitle.set_content(download_response.content)
 
 
 class OpenSubtitlesComVipSubtitle(OpenSubtitlesComSubtitle):

--- a/src/subliminal/providers/podnapisi.py
+++ b/src/subliminal/providers/podnapisi.py
@@ -14,7 +14,7 @@ from requests import Session
 
 from subliminal.exceptions import NotInitializedProviderError, ProviderError
 from subliminal.matches import guess_matches
-from subliminal.subtitle import Subtitle, fix_line_ending
+from subliminal.subtitle import Subtitle
 from subliminal.video import Episode, Movie, Video
 
 from . import Provider, SecLevelOneTLSAdapter
@@ -249,4 +249,4 @@ class PodnapisiProvider(Provider):
                 msg = 'More than one file to unzip'
                 raise ProviderError(msg)
 
-            subtitle.content = fix_line_ending(zf.read(zf.namelist()[0]))
+            subtitle.set_content(zf.read(zf.namelist()[0]))

--- a/src/subliminal/providers/subtitulamos.py
+++ b/src/subliminal/providers/subtitulamos.py
@@ -16,7 +16,7 @@ from subliminal import __short_version__
 from subliminal.cache import SHOW_EXPIRATION_TIME, region
 from subliminal.exceptions import NotInitializedProviderError, ProviderError
 from subliminal.matches import guess_matches
-from subliminal.subtitle import Subtitle, fix_line_ending
+from subliminal.subtitle import Subtitle
 from subliminal.video import Episode
 
 from . import ParserBeautifulSoup, Provider
@@ -330,7 +330,7 @@ class SubtitulamosProvider(Provider):
         r = self.session.get(subtitle.download_link, headers={'Referer': subtitle.page_link}, timeout=10)
         r.raise_for_status()
 
-        subtitle.content = fix_line_ending(r.content)
+        subtitle.set_content(r.content)
 
 
 class SubtitulamosError(ProviderError):

--- a/src/subliminal/providers/tvsubtitles.py
+++ b/src/subliminal/providers/tvsubtitles.py
@@ -16,7 +16,7 @@ from requests import Session
 from subliminal.cache import EPISODE_EXPIRATION_TIME, SHOW_EXPIRATION_TIME, region
 from subliminal.exceptions import NotInitializedProviderError, ProviderError
 from subliminal.matches import guess_matches
-from subliminal.subtitle import Subtitle, fix_line_ending
+from subliminal.subtitle import Subtitle
 from subliminal.utils import sanitize
 from subliminal.video import Episode, Video
 
@@ -329,4 +329,4 @@ class TVsubtitlesProvider(Provider):
                 msg = 'More than one file to unzip'
                 raise ProviderError(msg)
 
-            subtitle.content = fix_line_ending(zf.read(zf.namelist()[0]))
+            subtitle.set_content(zf.read(zf.namelist()[0]))

--- a/src/subliminal/subtitle.py
+++ b/src/subliminal/subtitle.py
@@ -263,11 +263,7 @@ class Subtitle:
 
     @content.setter
     def content(self, value: bytes | None) -> None:
-        self.clear_content()
-        self._content = value
-
-        if self.force_guess_encoding and self.encoding is None:
-            self.encoding = self.guess_encoding()
+        self.set_content(value)
 
     @property
     def text(self) -> str:
@@ -275,6 +271,18 @@ class Subtitle:
         if not self._is_decoded:
             self._text = self._decode_content()
         return self._text
+
+    def set_content(self, value: bytes | None, *, fix: bool = True) -> None:
+        """Set subtitle bytes content."""
+        if fix and value:
+            value = fix_line_ending(value)
+
+        # Clear the previous content before adding new content
+        self.clear_content()
+        self._content = value
+
+        if self.force_guess_encoding and self.encoding is None:
+            self.encoding = self.guess_encoding()
 
     def clear_content(self) -> None:
         """Clear the content of the subtitle."""

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -394,11 +394,11 @@ def test_save_subtitles(movies: dict[str, Movie], tmp_path: Path, monkeypatch: p
     ensure(tmp_path / movies['man_of_steel'].name)
     subtitle_no_content = Subtitle(Language('eng'), '')
     subtitle = Subtitle(Language('fra'), '')
-    subtitle.content = b'Some content'
+    subtitle.set_content(b'Some content')
     subtitle_other = Subtitle(Language('fra'), '')
-    subtitle_other.content = b'Some other content'
+    subtitle_other.set_content(b'Some other content')
     subtitle_pt_br = Subtitle(Language('por', 'BR'), '')
-    subtitle_pt_br.content = b'Some brazilian content'
+    subtitle_pt_br.set_content(b'Some brazilian content')
     subtitles = [subtitle_no_content, subtitle, subtitle_other, subtitle_pt_br]
 
     save_subtitles(movies['man_of_steel'], subtitles)
@@ -420,9 +420,9 @@ def test_save_subtitles(movies: dict[str, Movie], tmp_path: Path, monkeypatch: p
 
 def test_save_subtitles_single_directory_encoding(movies: dict[str, Movie], tmp_path: Path) -> None:
     subtitle = Subtitle(Language('jpn'), '')
-    subtitle.content = 'ハローワールド'.encode('shift-jis')
+    subtitle.set_content('ハローワールド'.encode('shift-jis'))
     subtitle_pt_br = Subtitle(Language('por', 'BR'), '')
-    subtitle_pt_br.content = b'Some brazilian content'
+    subtitle_pt_br.set_content(b'Some brazilian content')
     subtitles = [subtitle, subtitle_pt_br]
 
     save_subtitles(movies['man_of_steel'], subtitles, single=True, directory=os.fspath(tmp_path), encoding='utf-8')
@@ -458,7 +458,7 @@ def test_save_subtitles_convert(movies: dict[str, Movie], tmp_path: Path, monkey
         """
     )
     subtitle = Subtitle(Language('pol'), '')
-    subtitle.content = text.encode('utf-8')
+    subtitle.set_content(text.encode('utf-8'))
     subtitles = [subtitle]
 
     save_subtitles(video, subtitles, single=True, subtitle_format='srt')

--- a/tests/test_subtitle.py
+++ b/tests/test_subtitle.py
@@ -259,6 +259,14 @@ def test_subtitle_invalid_encoding() -> None:
     assert subtitle.hearing_impaired is False
 
 
+def test_subtitle_set_content() -> None:
+    subtitle = Subtitle(language=Language('kur'), encoding=None)
+    content = b'Ti\xc5\x9ftek li vir'
+    subtitle.content = content
+    assert subtitle.content == content
+    assert subtitle.text == content.decode()
+
+
 def test_subtitle_guess_encoding_utf8() -> None:
     subtitle = Subtitle(
         language=Language('zho'),

--- a/tests/test_subtitle.py
+++ b/tests/test_subtitle.py
@@ -50,7 +50,7 @@ def test_languague_type(hearing_impaired: bool | None, foreign_only: bool | None
 
 def test_subtitle_text() -> None:
     subtitle = Subtitle(Language('eng'))
-    subtitle.content = b'Some ascii text'
+    subtitle.set_content(b'Some ascii text')
     assert subtitle.text == 'Some ascii text'
 
 
@@ -61,7 +61,7 @@ def test_subtitle_text_no_content() -> None:
 
 def test_subtitle_none_content() -> None:
     subtitle = Subtitle(Language('jpn'))
-    subtitle.content = None
+    subtitle.set_content(None)
     assert subtitle.is_valid() is False
 
 
@@ -266,7 +266,7 @@ def test_subtitle_guess_encoding_utf8() -> None:
         page_link=None,
         encoding=None,
     )
-    subtitle.content = b'Something here'
+    subtitle.set_content(b'Something here')
     assert subtitle.foreign_only is False
     assert subtitle.guess_encoding() == 'utf-8'
     assert subtitle.text == 'Something here'
@@ -281,7 +281,7 @@ def test_subtitle_text_guess_encoding_none() -> None:
         page_link=None,
         encoding=None,
     )
-    subtitle.content = content
+    subtitle.set_content(content)
 
     assert subtitle.guess_encoding() is None
     assert not subtitle.is_valid()
@@ -294,7 +294,7 @@ def test_subtitle_reencode() -> None:
         language=Language('por'),
         encoding='latin1',
     )
-    subtitle.content = content
+    subtitle.set_content(content)
     success = subtitle.reencode()
     assert success
     assert subtitle.content == b'Uma palavra longa \xc3\xa9 melhor do que um p\xc3\xa3o curto'
@@ -329,7 +329,7 @@ def test_subtitle_convert_same_format_same_encoding() -> None:
         encoding='utf-8',
     )
     text = "1\n00:00:05,000 --> 00:00:10,000\n«Attention, ce flim n'est pas un flim sur le cyclimse»\n\n"
-    subtitle.content = text.encode('utf-8')
+    subtitle.set_content(text.encode('utf-8'))
     assert subtitle.encoding == 'utf-8'
     assert subtitle.text == text
 
@@ -342,7 +342,7 @@ def test_subtitle_convert_same_format_different_encoding() -> None:
         encoding='latin1',
     )
     text = "1\n00:00:05,000 --> 00:00:10,000\n«Attention, ce flim n'est pas un flim sur le cyclimse»\n\n"
-    subtitle.content = text.encode('latin1')
+    subtitle.set_content(text.encode('latin1'))
     assert subtitle.encoding == 'iso8859-1'
     assert subtitle.text == text
 
@@ -362,7 +362,7 @@ def test_subtitle_convert_from_microdvd_no_fps() -> None:
     {3244}{3299}To kwestia tygodni.
     {3299}{3390}Ostrzegałem, że eksploatacja jądra|to samobójstwo.
     """
-    subtitle.content = text.encode('utf-8')
+    subtitle.set_content(text.encode('utf-8'))
 
     assert not subtitle.convert(output_format='srt', output_encoding='utf-8')
 
@@ -379,7 +379,7 @@ def test_subtitle_convert_from_microdvd_subtitle_fps() -> None:
     {3244}{3299}To kwestia tygodni.
     {3299}{3390}Ostrzegałem, że eksploatacja jądra|to samobójstwo.
     """
-    subtitle.content = text.encode('utf-8')
+    subtitle.set_content(text.encode('utf-8'))
 
     assert subtitle.convert(output_format='srt', output_encoding='utf-8')
     assert subtitle.subtitle_format == 'srt'
@@ -426,7 +426,7 @@ def test_subtitle_convert_from_microdvd_argument_fps() -> None:
     {3244}{3299}To kwestia tygodni.
     {3299}{3390}Ostrzegałem, że eksploatacja jądra|to samobójstwo.
     """
-    subtitle.content = text.encode('utf-8')
+    subtitle.set_content(text.encode('utf-8'))
 
     assert subtitle.convert(output_format='srt', output_encoding='utf-8', fps=24)
     assert subtitle.subtitle_format == 'srt'
@@ -492,7 +492,7 @@ def test_subtitle_convert_to_ssa() -> None:
 
         """
     )
-    subtitle.content = text.encode('utf-8')
+    subtitle.set_content(text.encode('utf-8'))
 
     assert subtitle.convert(output_format='ass')
     assert subtitle.subtitle_format == 'ass'


### PR DESCRIPTION
Using a method instead of a property setter `Subtitle.content = ...`, we can add arguments.
`fix` is added to apply `fix_line_ending` to the content.