### PR TITLE
Fix tag-release and publish workflows

### DIFF
--- a/.github/workflows/publish-pypi.yaml
+++ b/.github/workflows/publish-pypi.yaml
@@ -1,13 +1,6 @@
-name: Publish
+name: Publish on PyPI
 
 on:
-  push:
-    tags:
-      - '*'
-  workflow_run:
-    workflows: ["Tag release"]
-    types:
-      - completed
   release:
     types:
       - published
@@ -33,48 +26,6 @@ jobs:
 
       - uses: hynek/build-and-inspect-python-package@v2
         id: baipp
-
-    outputs:
-      # Used to define the matrix for tests below. The value is based on
-      # packaging metadata (trove classifiers).
-      supported-python-versions: ${{ steps.baipp.outputs.supported_python_classifiers_json_array }}
-
-  github-release:
-    name: Make a GitHub Release
-    needs: [build-package]
-    # only publish a Github release on push tag
-    if: |
-      github.repository == 'Diaoul/subliminal'
-      && (
-        (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
-        || github.event_name == 'workflow_run'
-      )
-    runs-on: ubuntu-latest
-
-    permissions:
-      # IMPORTANT: mandatory for making GitHub Releases
-      contents: write
-      id-token: write
-
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          fetch-depth: 0
-          persist-credentials: false
-
-      - name: Download packages built by build-and-inspect-python-package
-        uses: actions/download-artifact@v4
-        with:
-          name: Packages
-          path: dist
-
-      - name: Publish GitHub Release
-        uses: softprops/action-gh-release@v2
-        with:
-          files: dist/*
-          generate_release_notes: true
-          draft: true
 
   publish-to-pypi:
     name: Publish package to pypi.

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -1,0 +1,85 @@
+name: Publish Github release
+
+on:
+  push:
+    tags:
+      - '*'
+  workflow_call:
+    inputs:
+      tag-name:
+        description: 'Tag name'
+        required: true
+        type: 'string'
+  workflow_dispatch:
+    inputs:
+      tag-name:
+        description: 'Tag name'
+        required: true
+        type: 'string'
+
+permissions: {}
+
+env:
+  FORCE_COLOR: "1"
+  PIP_DISABLE_PIP_VERSION_CHECK: "1"
+  PIP_NO_PYTHON_VERSION_WARNING: "1"
+
+jobs:
+  # Always build & lint package.
+  build-package:
+    name: Build & verify package
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - uses: hynek/build-and-inspect-python-package@v2
+        id: baipp
+
+  github-release:
+    name: Make a GitHub Release
+    needs: [build-package]
+    # Publish a Github release when a tag was pushed, or it's called with a tag.
+    if: |
+      (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/'))
+      || github.event_name == 'workflow_call'
+      || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+
+    permissions:
+      # IMPORTANT: mandatory for making GitHub Releases
+      contents: write
+      id-token: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        if: github.event_name == 'push'
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        if: |
+          github.event_name == 'workflow_dispatch'
+          || github.event_name == 'workflow_call'
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.tag-name }}
+          persist-credentials: false
+
+      - name: Download packages built by build-and-inspect-python-package
+        uses: actions/download-artifact@v4
+        with:
+          name: Packages
+          path: dist
+
+      - name: Publish GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: dist/*
+          generate_release_notes: true
+          draft: true

--- a/.github/workflows/tag-release.yaml
+++ b/.github/workflows/tag-release.yaml
@@ -31,17 +31,44 @@ jobs:
 
       - uses: hynek/build-and-inspect-python-package@v2
 
-  tag-manually:
-    name: Tag a new release manually
+  define-tag:
+    name: Define tag
     # tag a release after a release PR was accepted
-    if: github.event_name == 'workflow_dispatch'
-    needs: [build-package]
+    runs-on: ubuntu-latest
     env:
-      RELEASE_VERSION: ${{ inputs.version }}
+      RELEASE_VERSION: ''
+    steps:
+      - if: github.event_name == 'workflow_dispatch'
+        name: from workflow_dispatch
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+        run: TRUE
+      - if: |
+          github.repository == 'Diaoul/subliminal'
+          && github.event_name == 'pull_request'
+          && github.event.action == 'closed'
+          && github.event.pull_request.merged == true
+          && github.event.pull_request.head.repo.full_name == github.repository
+          && contains(github.event.pull_request.labels.*.name, 'type/release')
+          && startsWith(github.head_ref, 'releases/')
+        name: from merged PR
+        run: |
+          echo "RELEASE_VERSION=${GITHUB_HEAD_REF#release-}" >> $GITHUB_ENV
+      - run: echo "$RELEASE_VERSION"
+
+    outputs:
+      tag: $RELEASE_VERSION
+
+  tag-and-release:
+    name: Tag and publish a release draft
+    needs: [define-tag, build-package]
     runs-on: ubuntu-latest
     permissions:
       id-token: write
       contents: write
+    if: ${{ define-tag.outputs.tag != ''}}
+    env:
+      RELEASE_VERSION: ${{ define-tag.outputs.tag }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -50,45 +77,13 @@ jobs:
 
       - name: Tag the commit
         run: |
-          RELEASE_VERSION=${GITHUB_HEAD_REF#release-}
           echo Release version: $RELEASE_VERSION
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git tag --annotate --message="Release version $RELEASE_VERSION" $RELEASE_VERSION ${{ github.sha }}
           git push origin $RELEASE_VERSION
 
-
-  tag-release:
-    name: Tag a new release, from a release PR
-    # for security, the PR must be from a 'releases/*' branch of the same repo
-    # AND have the 'type/release' label.
-    # keep the label in sync with scripts/prepare-release-pr.py
-    if: |
-      github.repository == 'Diaoul/subliminal'
-      && github.event_name == 'pull_request'
-      && github.event.action == 'closed'
-      && github.event.pull_request.merged == true
-      && github.event.pull_request.head.repo.full_name == github.repository
-      && contains(github.event.pull_request.labels.*.name, 'type/release')
-      && startsWith(github.head_ref, 'releases/')
-    needs: [build-package]
-    env:
-      GITHUB_HEAD_REF: ${{ github.head_ref }}
-    runs-on: ubuntu-latest
-    permissions:
-      id-token: write
-      contents: write
-    steps:
-      - uses: actions/checkout@v4
+      - uses: ./.github/workflows/publish-release.yml
+        # publish a release draft after pushing the release tag
         with:
-          fetch-depth: 0
-          persist-credentials: false
-
-      - name: Tag the commit
-        run: |
-          RELEASE_VERSION=${GITHUB_HEAD_REF#release-}
-          echo Release version: $RELEASE_VERSION
-          git config user.name 'github-actions[bot]'
-          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
-          git tag --annotate --message="Release version $RELEASE_VERSION" $RELEASE_VERSION ${{ github.sha }}
-          git push origin $RELEASE_VERSION
+          tag-name: $RELEASE_VERSION

--- a/.github/zizmor.yml
+++ b/.github/zizmor.yml
@@ -2,4 +2,3 @@ rules:
   dangerous-triggers:
     ignore:
       - coverage.yaml:3:1
-      - publish.yaml:3:1


### PR DESCRIPTION
`publish.yaml` was being triggered by `workflow_run` of `tag-release.yaml`, because `tag-release` was completed, although nothing was done.

This PR removes the `workflow_run` trigger and `tag-release` directly calls `publish-release` before completing.