### PR TITLE
Generate a default config file

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -40,6 +40,19 @@ Download English subtitles::
     Downloading subtitles  [####################################]  100%
     Downloaded 1 subtitle
 
+Configuration
+^^^^^^^^^^^^^
+Arguments can be passed to the CLI with a configuration file. By default, it looks for
+a `subliminal.toml` file in the default configuration folder (see the CLI help for
+the exact platform-dependent default path). Or specify the path to the configuration
+file with the `-c` option.
+
+`Look for this example configuration file <https://github.com/Diaoul/subliminal/blob/main/docs/config.toml>`__
+or use the `generate_default_config` function from the `subliminal.cli` module to generate a
+configuration file with all the options and their default values.
+
+    $ python -c "from subliminal.cli import generate_default_config; print(generate_default_config())"
+
 Library
 ^^^^^^^
 Download best subtitles in French and English for videos less than two weeks old in a video folder:

--- a/README.rst
+++ b/README.rst
@@ -42,10 +42,10 @@ Download English subtitles::
 
 Configuration
 ^^^^^^^^^^^^^
-Arguments can be passed to the CLI with a configuration file. By default, it looks for
-a `subliminal.toml` file in the default configuration folder (see the CLI help for
-the exact platform-dependent default path). Or specify the path to the configuration
-file with the `-c` option.
+Arguments can be passed to the CLI using a configuration file.
+By default it looks for a `subliminal.toml` file in the default configuration folder
+(see the CLI help for the exact platform-specific default path).
+Or use the `-c` option to specify the path to the configuration file.
 
 `Look for this example configuration file <https://github.com/Diaoul/subliminal/blob/main/docs/config.toml>`__
 or use the `generate_default_config` function from the `subliminal.cli` module to generate a

--- a/changelog.d/1266.doc.rst
+++ b/changelog.d/1266.doc.rst
@@ -1,0 +1,1 @@
+docs: add a generate_default_config function

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -16,6 +16,7 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 import subliminal
+from subliminal.cli import generate_default_config  # noqa: F401
 
 # -- General configuration ------------------------------------------------
 

--- a/docs/user/cli.rst
+++ b/docs/user/cli.rst
@@ -11,8 +11,6 @@ subliminal
 
 .. _cli-subliminal-download:
 
-.. _cli-subliminal-download:
-
 subliminal download
 -------------------
 .. program-output:: subliminal download --help

--- a/docs/user/cli.rst
+++ b/docs/user/cli.rst
@@ -3,10 +3,13 @@
 CLI
 ===
 
+.. _cli-subliminal:
+
 subliminal
 ----------
 .. program-output:: subliminal --help
 
+.. _cli-subliminal-download:
 
 .. _cli-subliminal-download:
 
@@ -14,6 +17,7 @@ subliminal download
 -------------------
 .. program-output:: subliminal download --help
 
+.. _cli-subliminal-cache:
 
 subliminal cache
 ----------------

--- a/docs/user/configuration_file.rst
+++ b/docs/user/configuration_file.rst
@@ -40,5 +40,5 @@ Default configuration
 Here is a list of all the options of the configuration file.
 Commented options need a value to be valid.
 
-.. program-output:: python -c "from subliminal.cli import generate_default_config; print(generate_default_config())"
+.. program-output:: python -c "from subliminal.cli import generate_default_config; print(generate_default_config(commented=False))"
     :language: toml

--- a/docs/user/configuration_file.rst
+++ b/docs/user/configuration_file.rst
@@ -32,13 +32,3 @@ An example of configuration file:
 
 .. literalinclude:: ../config.toml
     :language: toml
-
-
-Default configuration
----------------------
-
-Here is a list of all the options of the configuration file.
-Commented options need a value to be valid.
-
-.. program-output:: python -c "from subliminal.cli import generate_default_config; print(generate_default_config())"
-    :language: toml

--- a/docs/user/configuration_file.rst
+++ b/docs/user/configuration_file.rst
@@ -32,3 +32,13 @@ An example of configuration file:
 
 .. literalinclude:: ../config.toml
     :language: toml
+
+
+Default configuration
+---------------------
+
+Here is a list of all the options of the configuration file.
+Commented options need a value to be valid.
+
+.. program-output:: python -c "from subliminal.cli import generate_default_config; print(generate_default_config())"
+    :language: toml

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ dependencies = [
     "requests>=2.0",
     "srt>=3.5",
     "stevedore>=3.0",
-    "tomli>=2",
+    "tomlkit>=0.13.2",
 ]
 
 # extras

--- a/src/subliminal/cli.py
+++ b/src/subliminal/cli.py
@@ -50,7 +50,7 @@ from subliminal.extensions import get_default_providers, get_default_refiners
 from subliminal.utils import get_parameters_from_signature, merge_extend_and_ignore_unions
 
 if TYPE_CHECKING:
-    from collections.abc import Callable, MutableMapping, Sequence, Set
+    from collections.abc import Callable, MutableMapping, Sequence
 
     from subliminal.utils import Parameter
 
@@ -262,7 +262,7 @@ def generate_default_config(*, compact: bool = True, commented: bool = True) -> 
         # Get the options for each subcommand
         com_table = tomlkit.table()
         # We need to keep track of duplicated options
-        existing_options: Set[str] = set()
+        existing_options: set[str] = set()
         for opt in command.params:
             if opt.name is None:  # pragma: no cover
                 continue
@@ -315,7 +315,7 @@ def generate_default_config(*, compact: bool = True, commented: bool = True) -> 
         if not compact:  # pragma: no cover
             doc.add(tomlkit.nl())
 
-    return tomlkit.dumps(doc)
+    return str(tomlkit.dumps(doc))
 
 
 def plural(quantity: int, name: str, *, bold: bool = True, **kwargs: Any) -> str:

--- a/src/subliminal/cli.py
+++ b/src/subliminal/cli.py
@@ -207,7 +207,7 @@ def generate_default_config(*, compact: bool = True) -> str:
 
     def add_value_to_table(opt: click.Option, table: tomlkit.items.Table, *, name: str | None = None) -> None:
         """Add a value to a TOML table."""
-        if opt.name is None:
+        if opt.name is None:  # pragma: no cover
             return
         # Override option name
         opt_name = name if name is not None else opt.name
@@ -229,7 +229,7 @@ def generate_default_config(*, compact: bool = True) -> str:
     for opt in subliminal.params:
         if not isinstance(opt, click.Option) or isinstance(opt, GroupedOption):
             continue
-        if opt.name is None:
+        if opt.name is None:  # pragma: no cover
             continue
         if opt.name.startswith(('__', 'fake')):
             continue
@@ -237,11 +237,11 @@ def generate_default_config(*, compact: bool = True) -> str:
             continue
         # Add key=value to table
         add_value_to_table(opt, default)
-        if not compact:
+        if not compact:  # pragma: no cover
             default.add(tomlkit.nl())
     # Adding the table to the document
     doc.add('default', default)
-    if not compact:
+    if not compact:  # pragma: no cover
         doc.add(tomlkit.nl())
 
     # Get subcommands
@@ -249,7 +249,7 @@ def generate_default_config(*, compact: bool = True) -> str:
         # Get the options for each subcommand
         com_table = tomlkit.table()
         for opt in command.params:
-            if opt.name is None:
+            if opt.name is None:  # pragma: no cover
                 continue
             if not isinstance(opt, click.Option):
                 continue
@@ -258,12 +258,12 @@ def generate_default_config(*, compact: bool = True) -> str:
                 continue
             # Add key=value to table
             add_value_to_table(opt, com_table)
-            if not compact:
+            if not compact:  # pragma: no cover
                 com_table.add(tomlkit.nl())
 
         # Adding the table to the document
         doc.add(command_name, com_table)
-        if not compact:
+        if not compact:  # pragma: no cover
             doc.add(tomlkit.nl())
 
     # Add providers and refiners options
@@ -275,27 +275,27 @@ def generate_default_config(*, compact: bool = True) -> str:
         ]
         provider_tables: dict[str, tomlkit.items.Table] = {}
         for opt in provider_options:
-            if opt.name is None:
+            if opt.name is None:  # pragma: no cover
                 continue
             _, provider, opt_name = opt.name.split('__')
             provider_table = provider_tables.setdefault(provider, tomlkit.table())
-            if opt.name in provider_table:
+            if opt.name in provider_table:  # pragma: no cover
                 # Duplicated option
                 continue
 
             # Add key=value to table
             add_value_to_table(opt, provider_table, name=opt_name)
-            if not compact:
+            if not compact:  # pragma: no cover
                 provider_table.add(tomlkit.nl())
 
         # Adding the table to the document
         parent_provider_table = tomlkit.table()
         for provider, table in provider_tables.items():
             parent_provider_table.add(provider, table)
-            if not compact:
+            if not compact:  # pragma: no cover
                 doc.add(tomlkit.nl())
         doc.add(class_type, parent_provider_table)
-        if not compact:
+        if not compact:  # pragma: no cover
             doc.add(tomlkit.nl())
 
     return tomlkit.dumps(doc)

--- a/src/subliminal/cli.py
+++ b/src/subliminal/cli.py
@@ -207,6 +207,7 @@ def generate_default_config(*, compact: bool = True, commented: bool = True) -> 
 
     :param compact: if True, generate a compact configuration without newlines between options.
     :param commented: if True, all the options are commented out.
+    :return: the default configuration as a string.
     """
 
     def add_value_to_table(opt: click.Option, table: tomlkit.items.Table, *, name: str | None = None) -> str | None:
@@ -230,6 +231,7 @@ def generate_default_config(*, compact: bool = True, commented: bool = True) -> 
         else:
             table.add(tomlkit.comment(f'{opt_name} = '))
 
+        # Return the key to keep track of duplicates
         return opt_name
 
     # Create TOML document

--- a/src/subliminal/cli.py
+++ b/src/subliminal/cli.py
@@ -202,7 +202,7 @@ def configure(ctx: click.Context, param: click.Parameter | None, filename: str |
     ctx.default_map = config['default_map']
 
 
-def generate_default_config(*, compact: bool = True) -> tomlkit.toml_document.TOMLDocument:
+def generate_default_config(*, compact: bool = True) -> str:
     """Generate a default configuration file."""
 
     def add_value_to_table(opt: click.Option, table: tomlkit.items.Table, *, name: str | None = None) -> None:
@@ -212,13 +212,12 @@ def generate_default_config(*, compact: bool = True) -> tomlkit.toml_document.TO
         # Override option name
         opt_name = name if name is not None else opt.name
 
-        table.add(tomlkit.comment(opt.help or opt_name))
+        table.add(tomlkit.comment((opt.help or opt_name).capitalize()))
         # default.add(tomlkit.comment(f'{opt.name} = {opt.default}'))
         if opt.default is not None:
             table.add(opt_name, opt.default)
         else:
-            table.add(opt_name, tomlkit.items.Null())
-            table.add(tomlkit.nl())
+            table.add(tomlkit.comment(f'{opt_name} = '))
 
     # Create TOML document
     doc = tomlkit.document()
@@ -299,7 +298,7 @@ def generate_default_config(*, compact: bool = True) -> tomlkit.toml_document.TO
         if not compact:
             doc.add(tomlkit.nl())
 
-    return doc
+    return tomlkit.dumps(doc)
 
 
 def plural(quantity: int, name: str, *, bold: bool = True, **kwargs: Any) -> str:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,7 +8,6 @@ from typing import TYPE_CHECKING
 from unittest.mock import Mock
 
 import pytest
-import tomlkit
 from click.testing import CliRunner
 
 from subliminal.cli import generate_default_config
@@ -513,7 +512,7 @@ def test_cli_download_with_generated_config(tmp_path: os.PathLike[str]) -> None:
     with runner.isolated_filesystem(temp_dir=tmp_path) as td:
         doc = generate_default_config()
         with open('subliminal.toml', 'w') as f:
-            tomlkit.dump(doc, f)
+            f.write(doc)
 
         result = runner.invoke(subliminal_cli, ['--config', 'subliminal.toml', 'download', '-l', 'en', video_name])
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -8,8 +8,10 @@ from typing import TYPE_CHECKING
 from unittest.mock import Mock
 
 import pytest
+import tomlkit
 from click.testing import CliRunner
 
+from subliminal.cli import generate_default_config
 from subliminal.cli import subliminal as subliminal_cli
 from tests.conftest import ensure
 
@@ -502,3 +504,24 @@ def test_cli_download_with_config_with_option_error(tmp_path: os.PathLike[str]) 
         assert result.exit_code > 0
         # Error in the config file is treated as an error in the CLI arguments
         assert 'Value must be an iterable' in result.output
+
+
+def test_cli_download_with_generated_config(tmp_path: os.PathLike[str]) -> None:
+    runner = CliRunner()
+    video_name = 'Marvels.Agents.of.S.H.I.E.L.D.S02E06.720p.HDTV.x264-KILLERS.mkv'
+
+    with runner.isolated_filesystem(temp_dir=tmp_path) as td:
+        doc = generate_default_config()
+        with open('subliminal.toml', 'w') as f:
+            tomlkit.dump(doc, f)
+
+        result = runner.invoke(subliminal_cli, ['--config', 'subliminal.toml', 'download', '-l', 'en', video_name])
+
+        assert result.exit_code == 0
+        assert result.output.startswith('Collecting videos')
+        assert '1 subtitle' in result.output
+
+        subtitle_filename = os.path.splitext(video_name)[0] + '.en.srt'
+        # collect files recursively
+        files = [os.fspath(p.relative_to(td)) for p in Path(td).rglob('*')]
+        assert subtitle_filename in files


### PR DESCRIPTION
* Add a `generate_default_config` function in `subliminal.cli` to generate an example configuration file (as a string) with the default values.
* Add information about the configuration file in the README
* switch from using the `tomli` package to using `tomlkit` because it can structure toml files with comments and new lines, used for `generate_default_config`.