### PR TITLE
Make win32-setctime an optional tests dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,7 +73,7 @@ tests = [
     "sympy",
     "colorama",  # used in scripts/
     "vcrpy>=5",  # keep synchronized with docs dependencies
-    "win32-setctime",
+    "win32-setctime; sys_platform=='win32'",
     "importlib_metadata>=4.6; python_version<'3.10'",
 ]
 types = [

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -7,7 +7,6 @@ from typing import TYPE_CHECKING
 from unittest.mock import Mock
 
 import pytest
-from win32_setctime import SUPPORTED, setctime
 
 from subliminal.utils import sanitize, timestamp
 from subliminal.video import Episode, Movie, Video
@@ -40,6 +39,12 @@ def test_video_exists_age_no_use_ctime(
 
 
 def test_video_exists_age(movies: dict[str, Movie], tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    try:
+        from win32_setctime import SUPPORTED, setctime
+    except (ImportError, ModuleNotFoundError):
+        SUPPORTED = False
+        setctime = None
+
     monkeypatch.chdir(tmp_path)
     video = movies['man_of_steel']
     video_path = tmp_path / video.name


### PR DESCRIPTION
fixes #1275 

Needed only for win32 platform