### PR TITLE
Fix publish release 7

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -6,6 +6,12 @@ on:
       - main
     tags:
       - "*.*.*"
+  workflow_call:
+    inputs:
+      tag-name:
+        description: 'Tag name'
+        required: true
+        type: 'string'
   pull_request:
 
 env:
@@ -22,12 +28,21 @@ jobs:
 
     steps:
       - name: Checkout repository
+        if: github.event_name == 'push' || github.event_name == 'pull_request'
         uses: actions/checkout@v4
         with:
+          fetch-tags: true
+          persist-credentials: false
+      - name: Checkout repository
+        if: github.event_name == 'workflow_call'
+        uses: actions/checkout@v4
+        with:
+          fetch-tags: true
+          ref: ${{ inputs.tag-name }}
           persist-credentials: false
 
       - name: Set up QEMU
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' || github.event_name == 'workflow_call'
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
@@ -65,7 +80,7 @@ jobs:
 
       - name: Build and push Docker image
         uses: docker/build-push-action@v6
-        if: github.event_name == 'push'
+        if: github.event_name == 'push' || github.event_name == 'workflow_call'
         with:
           context: .
           platforms: linux/amd64,linux/arm64,linux/arm/v7

--- a/.github/workflows/publish-release.yaml
+++ b/.github/workflows/publish-release.yaml
@@ -45,7 +45,7 @@ jobs:
         with:
           fetch-tags: true
           ref: ${{ inputs.tag-name }}
-          persist-credentials: true
+          persist-credentials: false
 
       - name: Build dist
         uses: hynek/build-and-inspect-python-package@v2
@@ -71,6 +71,8 @@ jobs:
           path: scripts/latest-release-notes.md
           include-hidden-files: false
           if-no-files-found: error
+    outputs:
+      tag: ${{ steps.baipp.outputs.package_version }}
 
   github-release:
     name: Make a GitHub Release
@@ -84,6 +86,13 @@ jobs:
 
     # Publish a Github release when a tag was pushed, or it's called with a tag.
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-tags: true
+          ref: ${{ needs.build-package.outputs.tag }}
+          persist-credentials: false
+
       - name: Download packages built by build-and-inspect-python-package
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/tag-release.yaml
+++ b/.github/workflows/tag-release.yaml
@@ -79,14 +79,30 @@ jobs:
           persist-credentials: true
 
       - name: Tag the commit
+        id: create-tag
         run: |
           echo "Release version: $RELEASE_VERSION"
           git config user.name 'github-actions[bot]'
           git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
           git tag --annotate --message="Release version $RELEASE_VERSION" $RELEASE_VERSION ${{ github.sha }}
           git push origin $RELEASE_VERSION
+          echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_OUTPUT
+    outputs:
+      tag-name: ${{ steps.create-tag.outputs.RELEASE_VERSION }}
 
-      - uses: ./.github/workflows/publish-release.yml
-        # publish a release draft after pushing the release tag
-        with:
-          tag-name: $RELEASE_VERSION
+
+  trigger-release:
+    # Tagging from an action does not trigger a push>tag event, therefore we use workflow_call
+    # Publish a release draft after pushing the release tag
+    needs: [tag-and-release]
+    uses: ./.github/workflows/publish-release.yml
+    with:
+      tag-name: ${{ needs.tag-and-release.outputs.tag-name }}
+
+  trigger-docker-build:
+    # Tagging from an action does not trigger a push>tag event, therefore we use workflow_call
+    # Publish a docker image for the release tag
+    needs: [tag-and-release]
+    uses: ./.github/workflows/docker-build.yml
+    with:
+      tag-name: ${{ needs.tag-and-release.outputs.tag-name }}

--- a/changelog.d/1276.misc.rst
+++ b/changelog.d/1276.misc.rst
@@ -1,0 +1,1 @@
+fix publishing on PyPI and github release notes


### PR DESCRIPTION
Github actions:
* fix `tag-release.yaml`: reusable workflow with `workflow_call` should be [called as jobs, not steps](https://docs.github.com/en/actions/sharing-automations/reusing-workflows#calling-a-reusable-workflow).
* fix `publish-release.yaml`: checkout before publishing the GH release, otherwise it fails.
* make sure `docker-build.yaml` is called after `tag-release.yaml` completes by using `workflow_call`. Before, `docker-buid.yaml` was trigger on pull>tag, but this event was silenced when the tag was done inside the `tag-release` workflow.