### PR TITLE
Use fps match for scoring subtitles

### DIFF
--- a/changelog.d/1250.change.rst
+++ b/changelog.d/1250.change.rst
@@ -1,0 +1,1 @@
+score: add fps match, remove hearing_impaired match

--- a/docs/user/usage.rst
+++ b/docs/user/usage.rst
@@ -146,8 +146,8 @@ And then compute a score with those matches with :func:`~subliminal.score.comput
 
     >>> for s in subtitles[video]:
     ...     {s: compute_score(s, video)}
-    {<PodnapisiSubtitle 'ZtAW' [hu]>: 789}
-    {<PodnapisiSubtitle 'ONAW' [hu]>: 772}
+    {<PodnapisiSubtitle 'ZtAW' [hu]>: 941}
+    {<PodnapisiSubtitle 'ONAW' [hu]>: 922}
 
 Now you should have a better idea about which one you should choose.
 

--- a/src/subliminal/score.py
+++ b/src/subliminal/score.py
@@ -23,7 +23,7 @@ Available matches:
   * source
   * audio_codec
   * resolution
-  * hearing_impaired
+  * fps
   * video_codec
   * series_imdb_id
   * imdb_id
@@ -60,34 +60,34 @@ logger = logging.getLogger(__name__)
 
 #: Scores for episodes
 episode_scores: dict[str, int] = {
-    'hash': 809,
-    'series': 405,
-    'year': 135,
-    'country': 135,
-    'season': 45,
-    'episode': 45,
-    'release_group': 15,
-    'streaming_service': 15,
-    'source': 7,
-    'audio_codec': 3,
-    'resolution': 2,
-    'video_codec': 2,
-    'hearing_impaired': 1,
+    'hash': 971,
+    'series': 486,
+    'country': 162,
+    'year': 162,
+    'episode': 54,
+    'season': 54,
+    'release_group': 18,
+    'streaming_service': 18,
+    'fps': 9,
+    'source': 4,
+    'audio_codec': 2,
+    'resolution': 1,
+    'video_codec': 1,
 }
 
 #: Scores for movies
 movie_scores: dict[str, int] = {
-    'hash': 269,
-    'title': 135,
-    'year': 45,
-    'country': 45,
-    'release_group': 15,
-    'streaming_service': 15,
-    'source': 7,
-    'audio_codec': 3,
-    'resolution': 2,
-    'video_codec': 2,
-    'hearing_impaired': 1,
+    'hash': 323,
+    'title': 162,
+    'country': 54,
+    'year': 54,
+    'release_group': 18,
+    'streaming_service': 18,
+    'fps': 9,
+    'source': 4,
+    'audio_codec': 2,
+    'resolution': 1,
+    'video_codec': 1,
 }
 
 #: All scores names
@@ -130,15 +130,6 @@ def get_scores(video: Video) -> dict[str, Any]:
 
     msg = 'video must be an instance of Episode or Movie'  # pragma: no-cover
     raise ValueError(msg)  # pragma: no-cover
-
-
-def match_hearing_impaired(subtitle: Subtitle, *, hearing_impaired: bool | None = None) -> bool:
-    """Match hearing impaired, if it is defined for the subtitle."""
-    return (  # pragma: no cover
-        hearing_impaired is not None
-        and subtitle.hearing_impaired is not None
-        and subtitle.hearing_impaired == hearing_impaired
-    )
 
 
 def compute_score(subtitle: Subtitle, video: Video, **kwargs: Any) -> int:
@@ -223,9 +214,8 @@ if WITH_SYMPY:  # pragma: no cover
         For testing purposes.
         """
         hash, series, year, country, season, episode = symbols('hash series year country season episode')  # noqa: A001
-        release_group, streaming_service, source = symbols('release_group streaming_service source')
+        release_group, streaming_service, fps, source = symbols('release_group streaming_service fps source')
         audio_codec, resolution, video_codec = symbols('audio_codec resolution video_codec')
-        hearing_impaired = symbols('hearing_impaired')
 
         equations = [
             # hash is best
@@ -238,6 +228,7 @@ if WITH_SYMPY:  # pragma: no cover
                 + episode
                 + release_group
                 + streaming_service
+                + fps
                 + source
                 + audio_codec
                 + resolution
@@ -252,6 +243,7 @@ if WITH_SYMPY:  # pragma: no cover
                 + episode
                 + release_group
                 + streaming_service
+                + fps
                 + source
                 + audio_codec
                 + resolution
@@ -265,6 +257,7 @@ if WITH_SYMPY:  # pragma: no cover
                 + episode
                 + release_group
                 + streaming_service
+                + fps
                 + source
                 + audio_codec
                 + resolution
@@ -274,23 +267,23 @@ if WITH_SYMPY:  # pragma: no cover
             # year counts as much as country
             Eq(year, country),
             # season is important too
-            Eq(season, release_group + streaming_service + source + audio_codec + resolution + video_codec + 1),
+            Eq(season, release_group + streaming_service + fps + source + audio_codec + resolution + video_codec + 1),
             # episode is equally important to season
             Eq(episode, season),
             # release group is the next most wanted match
-            Eq(release_group, source + audio_codec + resolution + video_codec + 1),
+            Eq(release_group, fps + source + audio_codec + resolution + video_codec + 1),
             # streaming service counts as much as release group
             Eq(release_group, streaming_service),
+            # fps is the next most wanted match
+            Eq(fps, source + audio_codec + resolution + video_codec + 1),
             # source counts as much as audio_codec, resolution and video_codec
             Eq(source, audio_codec + resolution + video_codec),
             # audio_codec is more valuable than video_codec
             Eq(audio_codec, video_codec + 1),
             # resolution counts as much as video_codec
             Eq(resolution, video_codec),
-            # video_codec is the least valuable match but counts more than the sum of all scoring increasing matches
-            Eq(video_codec, hearing_impaired + 1),
-            # hearing impaired is only used for score increasing, so put it to 1
-            Eq(hearing_impaired, 1),
+            # video_codec is the least valuable match, so put it to 1
+            Eq(video_codec, 1),
         ]
 
         return solve(  # type: ignore[no-any-return]
@@ -304,11 +297,11 @@ if WITH_SYMPY:  # pragma: no cover
                 episode,
                 release_group,
                 streaming_service,
+                fps,
                 source,
                 audio_codec,
                 resolution,
                 video_codec,
-                hearing_impaired,
             ],
         )
 
@@ -318,8 +311,8 @@ if WITH_SYMPY:  # pragma: no cover
         For testing purposes.
         """
         hash, title, year, country, release_group = symbols('hash title year country release_group')  # noqa: A001
-        streaming_service, source, audio_codec, resolution = symbols('streaming_service source audio_codec resolution')
-        video_codec, hearing_impaired = symbols('video_codec hearing_impaired')
+        streaming_service, fps, source, audio_codec = symbols('streaming_service fps source audio_codec')
+        resolution, video_codec, hearing_impaired = symbols('resolution video_codec hearing_impaired')
 
         equations = [
             # hash is best
@@ -330,6 +323,7 @@ if WITH_SYMPY:  # pragma: no cover
                 + country
                 + release_group
                 + streaming_service
+                + fps
                 + source
                 + audio_codec
                 + resolution
@@ -342,6 +336,7 @@ if WITH_SYMPY:  # pragma: no cover
                 + country
                 + release_group
                 + streaming_service
+                + fps
                 + source
                 + audio_codec
                 + resolution
@@ -349,23 +344,23 @@ if WITH_SYMPY:  # pragma: no cover
                 + 1,
             ),
             # year is the second most important part
-            Eq(year, release_group + streaming_service + source + audio_codec + resolution + video_codec + 1),
+            Eq(year, release_group + streaming_service + fps + source + audio_codec + resolution + video_codec + 1),
             # year counts as much as country
             Eq(year, country),
             # release group is the next most wanted match
-            Eq(release_group, source + audio_codec + resolution + video_codec + 1),
+            Eq(release_group, fps + source + audio_codec + resolution + video_codec + 1),
             # streaming service counts as much as release group
             Eq(release_group, streaming_service),
+            # fps is the next most wanted match
+            Eq(fps, source + audio_codec + resolution + video_codec + 1),
             # source counts as much as audio_codec, resolution and video_codec
             Eq(source, audio_codec + resolution + video_codec),
             # audio_codec is more valuable than video_codec
             Eq(audio_codec, video_codec + 1),
             # resolution counts as much as video_codec
             Eq(resolution, video_codec),
-            # video_codec is the least valuable match but counts more than the sum of all scoring increasing matches
-            Eq(video_codec, hearing_impaired + 1),
-            # hearing impaired is only used for score increasing, so put it to 1
-            Eq(hearing_impaired, 1),
+            # video_codec is the least valuable match, so put it to 1
+            Eq(video_codec, 1),
         ]
 
         return solve(  # type: ignore[no-any-return]
@@ -377,10 +372,10 @@ if WITH_SYMPY:  # pragma: no cover
                 country,
                 release_group,
                 streaming_service,
+                fps,
                 source,
                 audio_codec,
                 resolution,
                 video_codec,
-                hearing_impaired,
             ],
         )


### PR DESCRIPTION
closes #1250 

Also remove `hearing_impaired` matching.
An FPS match counts less than a release group match, but more than a source match.