### PR TITLE
Fix guessit title str

### DIFF
--- a/changelog.d/1304.misc.rst
+++ b/changelog.d/1304.misc.rst
@@ -1,0 +1,1 @@
+ensure Episode.series is always a string, not a list from guessit bug

--- a/src/subliminal/utils.py
+++ b/src/subliminal/utils.py
@@ -204,6 +204,17 @@ def ensure_list(value: T | Sequence[T] | None) -> list[T]:
     return list(value)
 
 
+def ensure_str(value: Any, *, sep: str = ' ') -> str:
+    """Ensure to return a str."""
+    if value is None:
+        return ''
+    # If a list of str, join them
+    if is_iterable(value):
+        return sep.join([str(v) for v in value])
+    # Make sure the output is a string
+    return str(value)
+
+
 def modification_date(filepath: os.PathLike | str) -> float:
     """Get the modification date of the file."""
     # Use the more cross-platform modification time.

--- a/src/subliminal/video.py
+++ b/src/subliminal/video.py
@@ -9,7 +9,7 @@ from typing import TYPE_CHECKING, Any
 from guessit import guessit  # type: ignore[import-untyped]
 
 from subliminal.exceptions import GuessingError
-from subliminal.utils import ensure_list, get_age, matches_extended_title
+from subliminal.utils import ensure_list, ensure_str, get_age, matches_extended_title
 
 if TYPE_CHECKING:
     from collections.abc import Mapping, Sequence
@@ -388,7 +388,7 @@ class Episode(Video):
 
         return cls(
             name,
-            series=guess['title'],
+            series=ensure_str(guess['title']),
             season=guess.get('season', 1),
             episodes=guess.get('episode', []),
             title=guess.get('episode_title'),

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -507,6 +507,15 @@ def episodes() -> dict[str, Episode]:
             2,
             year=1914,
         ),
+        'adam-12_s01e02': Episode(
+            'Adam-12 1968 Season 1 Complete x264 [i_c]/Adam-12 S01E02 Log 141 The Color TV Bandit.mkv',
+            'Adam 12',
+            1,
+            2,
+            year=1968,
+            release_group='[i_c]',
+            video_codec='H.264',
+        ),
     }
 
 

--- a/tests/test_archives.py
+++ b/tests/test_archives.py
@@ -93,6 +93,6 @@ def test_scan_videos_error(
     scan_videos(folder)
 
     # But error was logged
-    for record in caplog.records:
-        assert record.levelname == 'ERROR'
+    error_records = [record for record in caplog.records if record.levelname == 'ERROR']
+    assert len(error_records) > 0
     assert 'Error scanning archive' in caplog.text

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,6 +13,7 @@ from subliminal.utils import (
     creation_date,
     decorate_imdb_id,
     ensure_list,
+    ensure_str,
     get_age,
     get_extend_and_ignore_union,
     handle_exception,
@@ -166,6 +167,24 @@ def test_ensure_list() -> None:
     ret = ensure_list({'a', 'b'})  # type: ignore[arg-type]
     assert isinstance(ret, list)
     assert set(ret) == {'a', 'b'}
+
+
+def test_ensure_str() -> None:
+    ret: str = ensure_str(None)
+    assert isinstance(ret, str)
+    assert ret == ''
+
+    ret = ensure_str('a')
+    assert isinstance(ret, str)
+    assert ret == 'a'
+
+    ret = ensure_str(('a', 'b'))
+    assert isinstance(ret, str)
+    assert ret == 'a b'
+
+    ret = ensure_str(['a', 'b'], sep=' - ')
+    assert isinstance(ret, str)
+    assert ret == 'a - b'
 
 
 @pytest.mark.parametrize(

--- a/tests/test_video.py
+++ b/tests/test_video.py
@@ -236,3 +236,18 @@ def test_episode_fromname(episodes: dict[str, Episode]) -> None:
     assert video.title is None
     assert video.year is None
     assert video.tvdb_id is None
+
+
+def test_episode_fromname_guessit_bug(episodes: dict[str, Episode]) -> None:
+    # Only works with Video.fromname, not Episode.fromname
+    video = Video.fromname(episodes['adam-12_s01e02'].name)
+    assert isinstance(video, Episode)
+    assert video.name == episodes['adam-12_s01e02'].name
+    assert video.release_group == episodes['adam-12_s01e02'].release_group
+    assert video.resolution == episodes['adam-12_s01e02'].resolution
+    assert video.video_codec == episodes['adam-12_s01e02'].video_codec
+    assert video.series == episodes['adam-12_s01e02'].series
+    assert video.season == episodes['adam-12_s01e02'].season
+    assert video.episode == episodes['adam-12_s01e02'].episode
+    assert video.title is None
+    assert video.year == episodes['adam-12_s01e02'].year


### PR DESCRIPTION
fixes #1304

Due to guessit bug (https://github.com/guessit-io/guessit/issues/796), `Episode` series are sometimes parsed as a list of `str` instead of a `str`, resulting in a downstream bug.
This ensures that `Episode.series` is always a str.