### PR TITLE
Make EmbeddedSubtitle id unique

### DIFF
--- a/changelog.d/1347.change.rst
+++ b/changelog.d/1347.change.rst
@@ -1,0 +1,1 @@
+make EmbeddedSubtitle subtitle_id unique

--- a/src/subliminal/refiners/metadata.py
+++ b/src/subliminal/refiners/metadata.py
@@ -157,12 +157,14 @@ def refine(
                 # language
                 lang = st.get('language', Language('und'))
 
-                sub = EmbeddedSubtitle(
+                sub = EmbeddedSubtitle.from_video_path(
                     lang,
-                    subtitle_id=video.name,
+                    movie_path=video.name,
                     hearing_impaired=st.get('hearing_impaired', st.get('closed_caption')),
                     foreign_only=st.get('forced'),
-                    subtitle_format=get_subtitle_format(st.get('format', 'srt')),
+                    subtitle_format=get_subtitle_format_from_knowit(st.get('format', 'srt')),
+                    subtitle_track=st.get('id'),
+                    subtitle_title=st.get('name', ''),
                 )
 
                 # add to set
@@ -196,7 +198,7 @@ def get_float(value: Any) -> float | None:
     return float(value)
 
 
-def get_subtitle_format(value: str | None) -> str | None:
+def get_subtitle_format_from_knowit(value: str | None) -> str | None:
     """Normalize the subtitle format name."""
     if value is None:
         return None

--- a/src/subliminal/refiners/metadata.py
+++ b/src/subliminal/refiners/metadata.py
@@ -159,7 +159,7 @@ def refine(
 
                 sub = EmbeddedSubtitle.from_video_path(
                     lang,
-                    movie_path=video.name,
+                    video_path=video.name,
                     hearing_impaired=st.get('hearing_impaired', st.get('closed_caption')),
                     foreign_only=st.get('forced'),
                     subtitle_format=get_subtitle_format_from_knowit(st.get('format', 'srt')),

--- a/src/subliminal/subtitle.py
+++ b/src/subliminal/subtitle.py
@@ -624,13 +624,13 @@ class EmbeddedSubtitle(Subtitle):
         """
         video_path = Path(video_path)
         category = SubtitleCategory.from_flags(hearing_impaired=hearing_impaired, foreign_only=foreign_only)
-        language_suffix = get_subtitle_suffix(language, category=category, category_suffix=True)
+        language_suffix = get_subtitle_suffix(language, category=category, category_suffix=True).removeprefix('.')
         fake_path = os.fspath(video_path)
         if subtitle_track is not None:
             fake_path += f':{subtitle_track}'
         if subtitle_title:
             fake_path += f':{subtitle_title}'
-        if language_suffix:
+        if language_suffix:  # pragma: no branch
             fake_path += f':{language_suffix}'
 
         return cls(

--- a/src/subliminal/subtitle.py
+++ b/src/subliminal/subtitle.py
@@ -623,8 +623,8 @@ class EmbeddedSubtitle(Subtitle):
         subtitle category, subtitle track and subtitle name.
         """
         video_path = Path(video_path)
-        language_type = LanguageType.from_flags(hearing_impaired=hearing_impaired, foreign_only=foreign_only)
-        suffix = get_subtitle_suffix(language, language_type=language_type, language_type_suffix=True)
+        category = SubtitleCategory.from_flags(hearing_impaired=hearing_impaired, foreign_only=foreign_only)
+        suffix = get_subtitle_suffix(language, category=category, language_type_suffix=True)
         fake_path = video_path.parent / f'{video_path.stem}{suffix}{video_path.suffix}'
         if subtitle_track is not None:
             fake_path += f':{subtitle_track}'

--- a/src/subliminal/subtitle.py
+++ b/src/subliminal/subtitle.py
@@ -624,12 +624,14 @@ class EmbeddedSubtitle(Subtitle):
         """
         video_path = Path(video_path)
         category = SubtitleCategory.from_flags(hearing_impaired=hearing_impaired, foreign_only=foreign_only)
-        suffix = get_subtitle_suffix(language, category=category, language_type_suffix=True)
-        fake_path = video_path.parent / f'{video_path.stem}{suffix}{video_path.suffix}'
+        language_suffix = get_subtitle_suffix(language, category=category, category_suffix=True)
+        fake_path = os.fspath(video_path)
         if subtitle_track is not None:
             fake_path += f':{subtitle_track}'
         if subtitle_title:
             fake_path += f':{subtitle_title}'
+        if language_suffix:
+            fake_path += f':{language_suffix}'
 
         return cls(
             language,

--- a/tests/refiners/test_metadata.py
+++ b/tests/refiners/test_metadata.py
@@ -11,7 +11,7 @@ from knowit.units import units  # type: ignore[import-untyped]
 from subliminal.core import scan_video
 from subliminal.refiners.metadata import (
     get_float,
-    get_subtitle_format,
+    get_subtitle_format_from_knowit,
     loaded_providers,
     refine,
 )
@@ -51,9 +51,9 @@ def test_get_float_error() -> None:
         ('pgs', 'pgs'),
     ],
 )
-def test_get_subtitle_format(value: str | None, expected: str | None) -> None:
+def test_get_subtitle_format_from_knowit(value: str | None, expected: str | None) -> None:
     """Convert str subrip -> srt."""
-    subtitle_format = get_subtitle_format(value)
+    subtitle_format = get_subtitle_format_from_knowit(value)
     assert subtitle_format == expected
 
 

--- a/tests/test_subtitle.py
+++ b/tests/test_subtitle.py
@@ -532,6 +532,63 @@ def test_subtitle_info(monkeypatch: pytest.MonkeyPatch) -> None:
     assert isinstance(subtitle.info, str)
 
 
+def test_embedded_subtitle_from_video_path(monkeypatch: pytest.MonkeyPatch) -> None:
+    video_path = 'My video.mp4'
+    name = 'forced'
+
+    # No track, no title
+    subtitle_0 = EmbeddedSubtitle.from_video_path(
+        Language('ita'),
+        video_path=video_path,
+        subtitle_format=None,
+        subtitle_track=None,
+        subtitle_title=None,
+    )
+
+    assert 'it' in subtitle_0.id
+    assert name not in subtitle_0.id
+    assert '0' not in subtitle_0.id
+
+    # No title
+    subtitle_1 = EmbeddedSubtitle.from_video_path(
+        Language('ita'),
+        video_path=video_path,
+        subtitle_format=None,
+        subtitle_track=1,
+        subtitle_title=None,
+    )
+
+    assert 'it' in subtitle_1.id
+    assert name not in subtitle_1.id
+    assert '1' in subtitle_1.id
+
+    # No track
+    subtitle_2 = EmbeddedSubtitle.from_video_path(
+        Language('ita'),
+        video_path=video_path,
+        subtitle_format=None,
+        subtitle_track=None,
+        subtitle_title='forced',
+    )
+
+    assert 'it' in subtitle_2.id
+    assert name in subtitle_2.id
+    assert '2' not in subtitle_2.id
+
+    # Everything
+    subtitle_3 = EmbeddedSubtitle.from_video_path(
+        Language('ita'),
+        video_path=video_path,
+        subtitle_format=None,
+        subtitle_track=3,
+        subtitle_title='forced',
+    )
+
+    assert 'it' in subtitle_3.id
+    assert name in subtitle_3.id
+    assert '3' in subtitle_3.id
+
+
 def test_embedded_subtitle_info(monkeypatch: pytest.MonkeyPatch) -> None:
     subtitle = EmbeddedSubtitle(
         Language('ita'),


### PR DESCRIPTION
To make sure that the `id` of `EmbeddedSubtitle` is unique, it should contain the video path, subtitle language and subtitle track number.