### PR TITLE
Cli: add --subtitle-categories option

### DIFF
--- a/changelog.d/1357.cli.rst
+++ b/changelog.d/1357.cli.rst
@@ -1,0 +1,1 @@
+add a ``--subtitle-categories`` option to replace ``-hi/-HI`` and ``-fo/-FO``

--- a/src/subliminal/cli/commands/download_best.py
+++ b/src/subliminal/cli/commands/download_best.py
@@ -210,7 +210,10 @@ REFINER = click.Choice(['ALL', *sorted(refiner_manager.names())])
     is_flag=True,
     flag_value=True,
     multiple=True,
-    deprecated='use `--subtitle-categories fo,n,hi` to favor fo or `--subtitle-categories fo` to download fo only.',
+    deprecated=(
+        'use `--subtitle-categories fo,n,hi` to favor fo (the current fallback) or `--subtitle-categories fo` '
+        'to download fo only.'
+    ),
     help='Prefer foreign-only subtitles.',
 )
 @click.option(
@@ -220,7 +223,10 @@ REFINER = click.Choice(['ALL', *sorted(refiner_manager.names())])
     is_flag=True,
     flag_value=False,
     multiple=True,
-    deprecated='use `--subtitle-categories n,hi,fo` to disfavor fo or `--subtitle-categories n,hi` to avoid fo.',
+    deprecated=(
+        'use `--subtitle-categories n,hi,fo` to disfavor fo (the current fallback) or `--subtitle-categories n,hi` '
+        'to skip fo.'
+    ),
     help='Disfavor foreign-only subtitles.',
 )
 @click.option(
@@ -230,7 +236,10 @@ REFINER = click.Choice(['ALL', *sorted(refiner_manager.names())])
     is_flag=True,
     flag_value=True,
     multiple=True,
-    deprecated='use `--subtitle-categories hi,n,fo` to favor hi or `--subtitle-categories hi` to download hi only.',
+    deprecated=(
+        'use `--subtitle-categories hi,n,fo` to favor hi (the current fallback) or `--subtitle-categories hi` '
+        'to download hi only.'
+    ),
     help='Prefer hearing-impaired subtitles.',
 )
 @click.option(
@@ -240,17 +249,22 @@ REFINER = click.Choice(['ALL', *sorted(refiner_manager.names())])
     is_flag=True,
     flag_value=False,
     multiple=True,
-    deprecated='use `--subtitle-categories n,fo,hi` to disfavor hi or `--subtitle-categories n,fo` to avoid hi.',
+    deprecated=(
+        'use `--subtitle-categories n,fo,hi` to disfavor hi (the current fallback) or `--subtitle-categories n,fo` '
+        'to skip hi.'
+    ),
     help='Disfavor hearing-impaired subtitles.',
 )
 @click.option(
     '-C',
     '--subtitle-categories',
-    default='n,hi,fo',
+    default='',
     help=(
-        'Comma-separated ordered list of subtitle categories to download. Skipping one category means to avoid '
-        'downloading subtitles of such category. The (exclusive) categories are: hi (hearing impaired), '
-        'fo (foreign only) and n (narrative, standard subtitles).'
+        'Comma-separated ordered list of subtitle categories to download. Skip one or two categories to filter out '
+        'subtitles of these categories. The (exclusive) categories are: hi (hearing impaired), '
+        'fo (foreign only) and n (narrative, standard subtitles). For instance, "hi,n,fo" would sort hearing impaired '
+        'subtitles first and foreign only subtitles last; "hi" would only download hearing impaired subtitles. '
+        'If set to an empty string (the default), no filtering or sorting is carried out.'
     ),
 )
 @click.option(
@@ -376,6 +390,7 @@ def download(
     if not subtitle_format or subtitle_format in ['""', "''"]:
         subtitle_format = None
 
+    # TODO: deprecate
     # subtitle category
     hearing_impaired_flag: bool | None = None
     if len(hearing_impaired) > 0:
@@ -383,6 +398,10 @@ def download(
     foreign_only_flag: bool | None = None
     if len(foreign_only) > 0:
         foreign_only_flag = foreign_only[-1]
+    if hearing_impaired_flag is not None:
+        subtitle_categories = 'hi,n,fo' if hearing_impaired_flag else 'n,fo,hi'
+    elif foreign_only_flag is not None:
+        subtitle_categories = 'fo,n,hi' if foreign_only_flag else 'n,hi,fo'
 
     if language_type_suffix in [False, True]:  # pragma: no cover
         msg = '`--[no-]language_type_suffix` has been renamed `--[no-]category-suffix`'
@@ -549,8 +568,6 @@ def download(
                     v,
                     language_set,
                     min_score=scores['hash'] * min_score // 100,
-                    hearing_impaired=hearing_impaired_flag,
-                    foreign_only=foreign_only_flag,
                     subtitle_categories=subtitle_categories,
                     skip_wrong_fps=skip_wrong_fps,
                     only_one=single,

--- a/src/subliminal/cli/commands/download_best.py
+++ b/src/subliminal/cli/commands/download_best.py
@@ -210,6 +210,7 @@ REFINER = click.Choice(['ALL', *sorted(refiner_manager.names())])
     is_flag=True,
     flag_value=True,
     multiple=True,
+    deprecated='use `--subtitle-categories fo,n,hi` to favor fo or `--subtitle-categories fo` to download fo only.',
     help='Prefer foreign-only subtitles.',
 )
 @click.option(
@@ -219,6 +220,7 @@ REFINER = click.Choice(['ALL', *sorted(refiner_manager.names())])
     is_flag=True,
     flag_value=False,
     multiple=True,
+    deprecated='use `--subtitle-categories n,hi,fo` to disfavor fo or `--subtitle-categories n,hi` to avoid fo.',
     help='Disfavor foreign-only subtitles.',
 )
 @click.option(
@@ -228,6 +230,7 @@ REFINER = click.Choice(['ALL', *sorted(refiner_manager.names())])
     is_flag=True,
     flag_value=True,
     multiple=True,
+    deprecated='use `--subtitle-categories hi,n,fo` to favor hi or `--subtitle-categories hi` to download hi only.',
     help='Prefer hearing-impaired subtitles.',
 )
 @click.option(
@@ -237,7 +240,18 @@ REFINER = click.Choice(['ALL', *sorted(refiner_manager.names())])
     is_flag=True,
     flag_value=False,
     multiple=True,
+    deprecated='use `--subtitle-categories n,fo,hi` to disfavor hi or `--subtitle-categories n,fo` to avoid hi.',
     help='Disfavor hearing-impaired subtitles.',
+)
+@click.option(
+    '-C',
+    '--subtitle-categories',
+    default='n,hi,fo',
+    help=(
+        'Comma-separated ordered list of subtitle categories to download. Skipping one category means to avoid '
+        'downloading subtitles of such category. The (exclusive) categories are: hi (hearing impaired), '
+        'fo (foreign only) and n (narrative, standard subtitles).'
+    ),
 )
 @click.option(
     '-m',
@@ -332,6 +346,7 @@ def download(
     skip_wrong_fps: bool,
     hearing_impaired: tuple[bool | None, ...],
     foreign_only: tuple[bool | None, ...],
+    subtitle_categories: str,
     min_score: int,
     language_type_suffix: bool | None,
     category_suffix: bool,
@@ -536,6 +551,7 @@ def download(
                     min_score=scores['hash'] * min_score // 100,
                     hearing_impaired=hearing_impaired_flag,
                     foreign_only=foreign_only_flag,
+                    subtitle_categories=subtitle_categories,
                     skip_wrong_fps=skip_wrong_fps,
                     only_one=single,
                     ignore_subtitles=ignore_subtitles,

--- a/src/subliminal/cli/helpers.py
+++ b/src/subliminal/cli/helpers.py
@@ -131,7 +131,8 @@ def read_configuration(filename: str | os.PathLike) -> dict[str, dict[str, Any]]
 
     # make download options
     download_dict = toml_dict.setdefault('download', {})
-    # handle language types
+    # TODO: deprecated
+    # handle language categories
     for lt in ('hearing_impaired', 'foreign_only'):
         # if an option was defined in the config file, make it a tuple, the expected type
         if lt in download_dict and (isinstance(download_dict[lt], bool) or download_dict[lt] is None):

--- a/src/subliminal/core.py
+++ b/src/subliminal/core.py
@@ -788,8 +788,7 @@ def download_best_subtitles(
     languages: Set[Language],
     *,
     min_score: int = 0,
-    hearing_impaired: bool | None = None,
-    foreign_only: bool | None = None,
+    subtitle_categories: str = '',
     skip_wrong_fps: bool = False,
     only_one: bool = False,
     compute_score: ComputeScore | None = None,
@@ -805,8 +804,8 @@ def download_best_subtitles(
     :param languages: languages to download.
     :type languages: set of :class:`~babelfish.language.Language`
     :param int min_score: minimum score for a subtitle to be downloaded.
-    :param (bool | None) hearing_impaired: hearing impaired preference (yes/no/indifferent).
-    :param (bool | None) foreign_only: foreign only preference (yes/no/indifferent).
+    :param str subtitle_categories: ordered list of categories to download, omitted categories are filtered out.
+        Empty string corresponds to no filtering or sorting.
     :param bool skip_wrong_fps: skip subtitles with an FPS that do not match the video (False).
     :param bool only_one: download only one subtitle, not one per language.
     :param compute_score: function that takes `subtitle` and `video` as positional arguments,
@@ -841,8 +840,7 @@ def download_best_subtitles(
                 video,
                 languages,
                 min_score=min_score,
-                hearing_impaired=hearing_impaired,
-                foreign_only=foreign_only,
+                subtitle_categories=subtitle_categories,
                 skip_wrong_fps=skip_wrong_fps,
                 only_one=only_one,
                 compute_score=compute_score,

--- a/src/subliminal/core.py
+++ b/src/subliminal/core.py
@@ -26,7 +26,7 @@ from .extensions import (
 )
 from .matches import fps_matches
 from .score import compute_score as default_compute_score
-from .subtitle import SUBTITLE_EXTENSIONS, ExternalSubtitle, SubtitleCategory
+from .subtitle import SUBTITLE_EXTENSIONS, ExternalSubtitle, filter_and_sort_categories
 from .utils import get_age, handle_exception
 from .video import VIDEO_EXTENSIONS, Episode, Movie, Video
 
@@ -267,16 +267,6 @@ class ProviderPool:
         # filter and sort by subtitle categories
         subtitles = filter_and_sort_categories(subtitles, subtitle_categories=subtitle_categories)
 
-        # # sort by hearing impaired and foreign only
-        # category = SubtitleCategory.from_flags(hearing_impaired=hearing_impaired, foreign_only=foreign_only)
-        # if category != SubtitleCategory.UNKNOWN:
-        #     logger.info('Sort subtitles by %s types first', category.value)
-        #     subtitles = sorted(
-        #         subtitles,
-        #         key=lambda s: s.category == category,
-        #         reverse=True,
-        #     )
-
         # sort subtitles by score
         scored_subtitles = sorted(
             [(s, compute_score(s, video)) for s in subtitles],
@@ -372,49 +362,6 @@ class AsyncProviderPool(ProviderPool):
                 subtitles.extend(provider_subtitles)
 
         return subtitles
-
-
-def filter_and_sort_categories(subtitles: Sequence[Subtitle], subtitle_categories: str = 'n,hi,fo') -> list[Subtitle]:
-    """Filter and sort subtitles by categories.
-
-    :param subtitles: list of subtitles
-    :type subtitles: Sequence of :class:`~subliminal.subtitle.Subtitle`
-    :param str subtitle_categories: ordered list of categories to download, omitted categories are filtered out.
-    :return: the filtered and sorted list of subtitles.
-    :rtype: list of :class:`~subliminal.subtitle.Subtitle`
-    """
-    correspond = {
-        'n': SubtitleCategory.NARRATIVE,
-        'hi': SubtitleCategory.HEARING_IMPAIRED,
-        'fo': SubtitleCategory.FOREIGN_ONLY,
-    }
-
-    # default categories, if empty, reset to default
-    # this is on purpose, no need to write a log message
-    if not subtitle_categories:
-        subtitle_categories = 'n,hi,fo'
-
-    # parse categories
-    categories = [vv for v in subtitle_categories.split(',') if (vv := correspond.get(v))]
-
-    if not categories:
-        msg = (
-            'fallback to "n,hi,fo", cannot parse the comma-separated list of subtitle categories: '
-            f'{subtitle_categories}'
-        )
-        logger.warning(msg)
-        categories = list(correspond.values())
-
-    else:
-        categories_str = ','.join([k for k, v in correspond.items() for c in categories if v == c])
-        msg = f'Filter and sort subtitles by categories: {categories_str}'
-        logger.info(msg)
-
-    # filter
-    subtitles = filter(lambda s: s.category in categories, subtitles)
-
-    # sort
-    return sorted(subtitles, key=lambda s: categories.index(s.category))
 
 
 def check_video(

--- a/src/subliminal/core.py
+++ b/src/subliminal/core.py
@@ -225,9 +225,7 @@ class ProviderPool:
         languages: Set[Language],
         *,
         min_score: int = 0,
-        hearing_impaired: bool | None = None,
-        foreign_only: bool | None = None,
-        subtitle_categories: str = 'n,hi,fo',
+        subtitle_categories: str = '',
         skip_wrong_fps: bool = False,
         only_one: bool = False,
         compute_score: ComputeScore | None = None,
@@ -242,9 +240,8 @@ class ProviderPool:
         :param languages: languages to download.
         :type languages: set of :class:`~babelfish.language.Language`
         :param int min_score: minimum score for a subtitle to be downloaded.
-        :param (bool | None) hearing_impaired: hearing impaired preference (yes/no/indifferent).
-        :param (bool | None) foreign_only: foreign only preference (yes/no/indifferent).
         :param str subtitle_categories: ordered list of categories to download, omitted categories are filtered out.
+            Empty string corresponds to no filtering or sorting.
         :param bool skip_wrong_fps: skip subtitles with an FPS that do not match the video (False).
         :param bool only_one: download only one subtitle, not one per language.
         :param compute_score: function that takes `subtitle` and `video` as positional arguments,

--- a/src/subliminal/core.py
+++ b/src/subliminal/core.py
@@ -227,6 +227,7 @@ class ProviderPool:
         min_score: int = 0,
         hearing_impaired: bool | None = None,
         foreign_only: bool | None = None,
+        subtitle_categories: str = 'n,hi,fo',
         skip_wrong_fps: bool = False,
         only_one: bool = False,
         compute_score: ComputeScore | None = None,
@@ -243,6 +244,7 @@ class ProviderPool:
         :param int min_score: minimum score for a subtitle to be downloaded.
         :param (bool | None) hearing_impaired: hearing impaired preference (yes/no/indifferent).
         :param (bool | None) foreign_only: foreign only preference (yes/no/indifferent).
+        :param str subtitle_categories: ordered list of categories to download, omitted categories are filtered out.
         :param bool skip_wrong_fps: skip subtitles with an FPS that do not match the video (False).
         :param bool only_one: download only one subtitle, not one per language.
         :param compute_score: function that takes `subtitle` and `video` as positional arguments,
@@ -262,15 +264,18 @@ class ProviderPool:
         if skip_wrong_fps and video.frame_rate is not None and video.frame_rate > 0:
             subtitles = [s for s in subtitles if fps_matches(video, fps=s.fps, strict=False)]
 
-        # sort by hearing impaired and foreign only
-        category = SubtitleCategory.from_flags(hearing_impaired=hearing_impaired, foreign_only=foreign_only)
-        if category != SubtitleCategory.UNKNOWN:
-            logger.info('Sort subtitles by %s types first', category.value)
-            subtitles = sorted(
-                subtitles,
-                key=lambda s: s.category == category,
-                reverse=True,
-            )
+        # filter and sort by subtitle categories
+        subtitles = filter_and_sort_categories(subtitles, subtitle_categories=subtitle_categories)
+
+        # # sort by hearing impaired and foreign only
+        # category = SubtitleCategory.from_flags(hearing_impaired=hearing_impaired, foreign_only=foreign_only)
+        # if category != SubtitleCategory.UNKNOWN:
+        #     logger.info('Sort subtitles by %s types first', category.value)
+        #     subtitles = sorted(
+        #         subtitles,
+        #         key=lambda s: s.category == category,
+        #         reverse=True,
+        #     )
 
         # sort subtitles by score
         scored_subtitles = sorted(
@@ -367,6 +372,49 @@ class AsyncProviderPool(ProviderPool):
                 subtitles.extend(provider_subtitles)
 
         return subtitles
+
+
+def filter_and_sort_categories(subtitles: Sequence[Subtitle], subtitle_categories: str = 'n,hi,fo') -> list[Subtitle]:
+    """Filter and sort subtitles by categories.
+
+    :param subtitles: list of subtitles
+    :type subtitles: Sequence of :class:`~subliminal.subtitle.Subtitle`
+    :param str subtitle_categories: ordered list of categories to download, omitted categories are filtered out.
+    :return: the filtered and sorted list of subtitles.
+    :rtype: list of :class:`~subliminal.subtitle.Subtitle`
+    """
+    correspond = {
+        'n': SubtitleCategory.NARRATIVE,
+        'hi': SubtitleCategory.HEARING_IMPAIRED,
+        'fo': SubtitleCategory.FOREIGN_ONLY,
+    }
+
+    # default categories, if empty, reset to default
+    # this is on purpose, no need to write a log message
+    if not subtitle_categories:
+        subtitle_categories = 'n,hi,fo'
+
+    # parse categories
+    categories = [vv for v in subtitle_categories.split(',') if (vv := correspond.get(v))]
+
+    if not categories:
+        msg = (
+            'fallback to "n,hi,fo", cannot parse the comma-separated list of subtitle categories: '
+            f'{subtitle_categories}'
+        )
+        logger.warning(msg)
+        categories = list(correspond.values())
+
+    else:
+        categories_str = ','.join([k for k, v in correspond.items() for c in categories if v == c])
+        msg = f'Filter and sort subtitles by categories: {categories_str}'
+        logger.info(msg)
+
+    # filter
+    subtitles = filter(lambda s: s.category in categories, subtitles)
+
+    # sort
+    return sorted(subtitles, key=lambda s: categories.index(s.category))
 
 
 def check_video(

--- a/src/subliminal/subtitle.py
+++ b/src/subliminal/subtitle.py
@@ -6,7 +6,7 @@ import codecs
 import logging
 import os
 from codecs import BOM_UTF8, BOM_UTF16_BE, BOM_UTF16_LE, BOM_UTF32_BE, BOM_UTF32_LE
-from enum import Enum
+from enum import Flag, auto
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, ClassVar
 
@@ -18,6 +18,8 @@ from pysubs2 import SSAFile, UnknownFPSError  # type: ignore[import-untyped]
 from subliminal.utils import trim_pattern
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from subliminal.video import Video
 
 logger = logging.getLogger(__name__)
@@ -68,13 +70,13 @@ def ensure_positive(value: float | None) -> float | None:
 
 
 #: Subtitle category
-class SubtitleCategory(Enum):
+class SubtitleCategory(Flag):
     """Subtitle category."""
 
-    UNKNOWN = 'unknown'
-    FOREIGN_ONLY = 'foreign_only'
-    NARRATIVE = 'narrative'
-    HEARING_IMPAIRED = 'hearing_impaired'
+    UNKNOWN = auto()
+    FOREIGN_ONLY = auto()
+    NARRATIVE = auto()
+    HEARING_IMPAIRED = auto()
 
     @classmethod
     def from_flags(cls, *, hearing_impaired: bool | None = None, foreign_only: bool | None = None) -> SubtitleCategory:
@@ -107,6 +109,50 @@ class SubtitleCategory(Enum):
         if self == SubtitleCategory.UNKNOWN:
             return None
         return False
+
+
+def filter_and_sort_categories(subtitles: Sequence[Subtitle], subtitle_categories: str = 'n,hi,fo') -> list[Subtitle]:
+    """Filter and sort subtitles by categories.
+
+    :param subtitles: list of subtitles
+    :type subtitles: Sequence of :class:`~subliminal.subtitle.Subtitle`
+    :param str subtitle_categories: ordered list of categories to download, omitted categories are filtered out.
+    :return: the filtered and sorted list of subtitles.
+    :rtype: list of :class:`~subliminal.subtitle.Subtitle`
+    """
+    correspond = {
+        'n': SubtitleCategory.NARRATIVE | SubtitleCategory.UNKNOWN,
+        'hi': SubtitleCategory.HEARING_IMPAIRED,
+        'fo': SubtitleCategory.FOREIGN_ONLY,
+    }
+
+    # default categories, if empty, reset to default
+    # this is on purpose, no need to write a log message
+    if not subtitle_categories:
+        subtitle_categories = 'n,hi,fo'
+
+    # parse categories
+    categories = [vv for v in subtitle_categories.split(',') if (vv := correspond.get(v))]
+
+    if not categories:
+        msg = (
+            'fallback to "n,hi,fo", cannot parse the comma-separated list of subtitle categories: '
+            f'{subtitle_categories}'
+        )
+        logger.warning(msg)
+        categories = list(correspond.values())
+
+    else:
+        categories_str = ','.join([k for k, v in correspond.items() for c in categories if v == c])
+        msg = f'Filter and sort subtitles by categories: {categories_str}'
+        logger.info(msg)
+
+    # filter and sort
+    return sorted(
+        # TODO: with python 3.11+ replace `bool(s.category & cc)` with `s.category in cc`
+        filter(lambda s: any(bool(s.category & cc) for cc in categories), subtitles),
+        key=lambda s: [bool(s.category & cc) for cc in categories].index(True),
+    )
 
 
 class Subtitle:

--- a/src/subliminal/subtitle.py
+++ b/src/subliminal/subtitle.py
@@ -98,41 +98,40 @@ class SubtitleCategory(Flag):
         return bool(self == SubtitleCategory.FOREIGN_ONLY)
 
 
-def filter_and_sort_categories(subtitles: Sequence[Subtitle], subtitle_categories: str = 'n,hi,fo') -> list[Subtitle]:
+def filter_and_sort_categories(subtitles: Sequence[Subtitle], subtitle_categories: str = '') -> list[Subtitle]:
     """Filter and sort subtitles by categories.
 
     :param subtitles: list of subtitles
     :type subtitles: Sequence of :class:`~subliminal.subtitle.Subtitle`
     :param str subtitle_categories: ordered list of categories to download, omitted categories are filtered out.
+        Empty string corresponds to no filtering or sorting.
     :return: the filtered and sorted list of subtitles.
     :rtype: list of :class:`~subliminal.subtitle.Subtitle`
     """
-    correspond = {
+    correspondence = {
         'n': SubtitleCategory.NARRATIVE,
         'hi': SubtitleCategory.HEARING_IMPAIRED,
         'fo': SubtitleCategory.FOREIGN_ONLY,
     }
 
-    # default categories, if empty, reset to default
-    # this is on purpose, no need to write a log message
+    # if empty, no filtering or sorting
     if not subtitle_categories:
-        subtitle_categories = 'n,hi,fo'
+        return list(subtitles)
 
     # parse categories
-    categories = [vv for v in subtitle_categories.split(',') if (vv := correspond.get(v))]
+    categories = [vv for v in subtitle_categories.split(',') if (vv := correspondence.get(v))]
 
     if not categories:
         msg = (
-            'fallback to "n,hi,fo", cannot parse the comma-separated list of subtitle categories: '
+            'No filtering or sorting by category, cannot parse the comma-separated list of subtitle categories: '
             f'{subtitle_categories}'
         )
         logger.warning(msg)
-        categories = list(correspond.values())
+        return list(subtitles)
 
-    else:
-        categories_str = ','.join([k for k, v in correspond.items() for c in categories if v == c])
-        msg = f'Filter and sort subtitles by categories: {categories_str}'
-        logger.info(msg)
+    categories_str = ','.join([k for k, v in correspondence.items() for c in categories if v == c])
+    msg = f'Filter and sort subtitles by categories: {categories_str}'
+    logger.info(msg)
 
     # filter and sort
     return sorted(

--- a/src/subliminal/subtitle.py
+++ b/src/subliminal/subtitle.py
@@ -73,42 +73,29 @@ def ensure_positive(value: float | None) -> float | None:
 class SubtitleCategory(Flag):
     """Subtitle category."""
 
-    UNKNOWN = auto()
-    FOREIGN_ONLY = auto()
     NARRATIVE = auto()
     HEARING_IMPAIRED = auto()
+    FOREIGN_ONLY = auto()
 
     @classmethod
     def from_flags(cls, *, hearing_impaired: bool | None = None, foreign_only: bool | None = None) -> SubtitleCategory:
         """Convert to SubtitleCategory from flags."""
-        category = cls.UNKNOWN
+        category = cls.NARRATIVE
         # hearing_impaired takes precedence over foreign_only if both are True
         if hearing_impaired:
             category = cls.HEARING_IMPAIRED
         elif foreign_only:
             category = cls.FOREIGN_ONLY
-        # if hearing_impaired or foreign_only is specified to be False
-        # then for sure the subtitle is normal.
-        elif hearing_impaired is False or foreign_only is False:
-            category = cls.NARRATIVE
 
         return category
 
-    def is_hearing_impaired(self) -> bool | None:
+    def is_hearing_impaired(self) -> bool:
         """Flag for hearing impaired."""
-        if self == SubtitleCategory.HEARING_IMPAIRED:
-            return True
-        if self == SubtitleCategory.UNKNOWN:
-            return None
-        return False
+        return bool(self == SubtitleCategory.HEARING_IMPAIRED)
 
-    def is_foreign_only(self) -> bool | None:
+    def is_foreign_only(self) -> bool:
         """Flag for foreign only."""
-        if self == SubtitleCategory.FOREIGN_ONLY:
-            return True
-        if self == SubtitleCategory.UNKNOWN:
-            return None
-        return False
+        return bool(self == SubtitleCategory.FOREIGN_ONLY)
 
 
 def filter_and_sort_categories(subtitles: Sequence[Subtitle], subtitle_categories: str = 'n,hi,fo') -> list[Subtitle]:
@@ -121,7 +108,7 @@ def filter_and_sort_categories(subtitles: Sequence[Subtitle], subtitle_categorie
     :rtype: list of :class:`~subliminal.subtitle.Subtitle`
     """
     correspond = {
-        'n': SubtitleCategory.NARRATIVE | SubtitleCategory.UNKNOWN,
+        'n': SubtitleCategory.NARRATIVE,
         'hi': SubtitleCategory.HEARING_IMPAIRED,
         'fo': SubtitleCategory.FOREIGN_ONLY,
     }
@@ -150,8 +137,8 @@ def filter_and_sort_categories(subtitles: Sequence[Subtitle], subtitle_categorie
     # filter and sort
     return sorted(
         # TODO: with python 3.11+ replace `bool(s.category & cc)` with `s.category in cc`
-        filter(lambda s: any(bool(s.category & cc) for cc in categories), subtitles),
-        key=lambda s: [bool(s.category & cc) for cc in categories].index(True),
+        filter(lambda s: s.category in categories, subtitles),
+        key=lambda s: categories.index(s.category),
     )
 
 
@@ -811,7 +798,7 @@ def get_subtitle_suffix(
     language: Language,
     *,
     language_format: str = 'alpha2',
-    category: SubtitleCategory = SubtitleCategory.UNKNOWN,
+    category: SubtitleCategory = SubtitleCategory.NARRATIVE,
     category_suffix: bool = False,
     language_first: bool = False,
 ) -> str:

--- a/tests/test_provider_pool.py
+++ b/tests/test_provider_pool.py
@@ -480,7 +480,7 @@ def test_download_best_subtitles_category(episodes: dict[str, Episode]) -> None:
         # ('gestdown', 'a295515c-a460-44ea-9ba8-8d37bcb9b5a6'),
     }
 
-    subtitles = download_best_subtitles({video}, languages, hearing_impaired=True, providers=providers)
+    subtitles = download_best_subtitles({video}, languages, subtitle_categories='hi,n,fo', providers=providers)
 
     assert len(subtitles) == 1
     assert len(subtitles[video]) == 1

--- a/tests/test_subtitle.py
+++ b/tests/test_subtitle.py
@@ -13,12 +13,15 @@ from subliminal.subtitle import (
     ExternalSubtitle,
     Subtitle,
     SubtitleCategory,
+    filter_and_sort_categories,
     fix_line_ending,
     get_subtitle_path,
     get_subtitle_suffix,
 )
 
 if TYPE_CHECKING:
+    from collections.abc import Sequence
+
     from subliminal.video import Movie
 
 # Core test
@@ -43,9 +46,38 @@ def test_languague_type(hearing_impaired: bool | None, foreign_only: bool | None
         assert category.is_hearing_impaired() is False
         assert category.is_foreign_only() is False
     else:
-        assert category == SubtitleCategory.UNKNOWN
-        assert category.is_hearing_impaired() is None
-        assert category.is_foreign_only() is None
+        assert category == SubtitleCategory.NARRATIVE
+        assert category.is_hearing_impaired() is False
+        assert category.is_foreign_only() is False
+
+
+@pytest.mark.parametrize(
+    ('categories', 'sorting_indices'),
+    [
+        ('', (0, 1, 2, 3, 4, 5, 6)),
+        ('hi,n,fo', (2, 6, 0, 3, 4, 1, 5)),
+        ('fo,n,hi', (1, 5, 0, 3, 4, 2, 6)),
+        ('hi,fo,n', (2, 6, 1, 5, 0, 3, 4)),
+        ('hi,n', (2, 6, 0, 3, 4)),
+        ('hi', (2, 6)),
+        ('unknown', (0, 1, 2, 3, 4, 5, 6)),
+    ],
+)
+def test_filter_and_sort_categories(categories: str, sorting_indices: Sequence[int]) -> None:
+    subtitles = [
+        Subtitle(Language('eng'), hearing_impaired=None, foreign_only=None),
+        Subtitle(Language('ita'), hearing_impaired=None, foreign_only=True),
+        Subtitle(Language('fra'), hearing_impaired=True, foreign_only=None),
+        Subtitle(Language('deu'), hearing_impaired=None, foreign_only=False),
+        Subtitle(Language('spa'), hearing_impaired=False, foreign_only=None),
+        Subtitle(Language('zho'), hearing_impaired=False, foreign_only=True),
+        Subtitle(Language('jpn'), hearing_impaired=True, foreign_only=False),
+    ]
+
+    sorted_subtitles = filter_and_sort_categories(subtitles, subtitle_categories=categories)
+
+    expected = [subtitles[i] for i in sorting_indices]
+    assert sorted_subtitles == expected
 
 
 def test_subtitle_text() -> None:


### PR DESCRIPTION
Deprecate the `--[no-]hearing-impaired` and `--[no-]foreign-only` options in favor of the `--subtitle-categories/-C` option.

The `--subtitle-categories` option accepts strings as a comma-separated list of subtitle categories, from the three existing categories:
 - "hi", hearing impaired subtitle
 - "fo", foreign only subtitle
 - "n", narrative, standard subtitle

For instance `--subtitle-categories=hi,n,fo` sorts the subtitles by hearing impaired first, then narrative and foreign only last.
If a category is omitted, the corresponding subtitles will be skipped. For instance `--subtitle-categories=hi` will select the best subtitle among hearing impaired only subtitles.
An empty string (the default) with not sort or filter out the subtitles.

The `--[no-]hearing-impaired` and `--[no-]foreign-only`  option are now deprecated.