### PR TITLE
Cli: parameterize --name with sed-like substitution

### DIFF
--- a/changelog.d/1362.cli.rst
+++ b/changelog.d/1362.cli.rst
@@ -1,0 +1,1 @@
+Allow ``--name`` to parameterize the guessed name per file, using a sed-like ``s/pattern/replacement/flags`` substitution or a ``--name`` template combined with a new ``--name-pattern`` regular expression

--- a/changelog.d/1362.cli.rst
+++ b/changelog.d/1362.cli.rst
@@ -1,2 +1,2 @@
-Allow ``--name`` to be a sed-like ``s/pattern/replacement/flags`` substitution, applied to each file name
-individually, to parameterize the guessed name per file
+Allow ``--name`` to be a sed-like ``s/pattern/replacement/flags`` substitution, applied to the path of each
+file individually, to parameterize the guessed name per file

--- a/changelog.d/1362.cli.rst
+++ b/changelog.d/1362.cli.rst
@@ -1,1 +1,2 @@
-Allow ``--name`` to parameterize the guessed name per file, using a sed-like ``s/pattern/replacement/flags`` substitution or a ``--name`` template combined with a new ``--name-pattern`` regular expression
+Allow ``--name`` to be a sed-like ``s/pattern/replacement/flags`` substitution, applied to each file name
+individually, to parameterize the guessed name per file

--- a/docs/user/usage.rst
+++ b/docs/user/usage.rst
@@ -33,31 +33,6 @@ Download English subtitles::
     only. Otherwise you will get banned from the providers for abuse due to too many requests. If subliminal didn't
     find subtitles for an old video, it's unlikely it will find subtitles for that video ever anyway.
 
-Parameterized name
-^^^^^^^^^^^^^^^^^^^
-
-The ``--name/-n`` option lets you override the name used to guess information about a file. In addition to a
-plain static name, it can rewrite each file name individually so you no longer need a shell loop to rename
-poorly-named releases before downloading.
-
-Pass a `sed <https://www.gnu.org/software/sed/manual/sed.html>`_-like substitution
-``s/pattern/replacement/flags`` and it is applied to every file name on its own. Back-references
-(``\1``, ``\2``, …) are available in the replacement, and the ``g`` (replace all occurrences) and ``i``
-(case-insensitive) flags are supported::
-
-    $ subliminal download -l pl \
-        --name 's/.*YP-1R-([0-9]+)x([0-9]+).*/My Little Pony Friendship Is Magic S\1E\2.mkv/' \
-        */YP-1R-*.mkv
-
-Unlike sed, ``&`` is a literal character (not the whole match), so titles containing an ampersand need
-no escaping::
-
-    $ subliminal download -l pl \
-        --name 's/.*_-_([0-9]+)_.*/Panty & Stocking with Garterbelt S01E\1.mkv/' \
-        *Garterbelt_-_*.mkv
-
-Any file whose name does not match is left untouched and scanned as-is.
-
 You can use a configuration file in the `TOML <https://toml.io/en/>`_ format with the ``--config/-c`` option. If no configuration file is
 provided, it looks for a ``subliminal.toml`` file in the default configuration folder for the application. This folder is
 `OS dependent <https://github.com/tox-dev/platformdirs>`_:
@@ -76,6 +51,31 @@ See :ref:`cli` for more details on the available commands and options.
 
         $ python -m subliminal download -h
 
+
+Parameterized name
+^^^^^^^^^^^^^^^^^^^
+
+The ``--name/-n`` option lets you override the file name that is used to guess information about a video.
+In addition to a static alternative name, you can use a
+`sed <https://www.gnu.org/software/sed/manual/sed.html>`_-like substitution pattern
+``s/pattern/replacement/flags`` to override the names of all the files in a folder.
+The pattern needs to be a valid Python regex. Back-references (``\1``, ``\2``, …) are available in the
+replacement, and the ``g`` (replace all occurrences) and ``i`` (case-insensitive) flags are supported::
+
+    $ subliminal download -l pl \
+        --name 's/.*YP-1R-([0-9]+)x([0-9]+).*/My Little Pony Friendship Is Magic S\1E\2.mkv/' \
+        */YP-1R-*.mkv
+
+Unlike sed, ``&`` is a literal character (not the whole match), so titles containing an ampersand need
+no escaping::
+
+    $ subliminal download -l pl \
+        --name 's/.*_-_([0-9]+)_.*/Panty & Stocking with Garterbelt S01E\1.mkv/' \
+        *Garterbelt_-_*.mkv
+
+The substitution is applied to the path of each file (after the optional conversion to an absolute path
+with ``--use-absolute-path``), so the pattern can also match parent directories. Any file whose path does
+not match is left untouched and scanned as-is.
 
 Nautilus/Nemo integration
 -------------------------

--- a/docs/user/usage.rst
+++ b/docs/user/usage.rst
@@ -33,6 +33,32 @@ Download English subtitles::
     only. Otherwise you will get banned from the providers for abuse due to too many requests. If subliminal didn't
     find subtitles for an old video, it's unlikely it will find subtitles for that video ever anyway.
 
+Parameterized name
+^^^^^^^^^^^^^^^^^^^
+
+The ``--name/-n`` option lets you override the name used to guess information about a file. In addition to a
+plain static name, it can rewrite each file name individually so you no longer need a shell loop to rename
+poorly-named releases before downloading.
+
+Use a `sed <https://www.gnu.org/software/sed/manual/sed.html>`_-like substitution
+``s/pattern/replacement/flags`` and it is applied to every file name on its own. Back-references
+(``\1``, ``\2``, …) and the whole-match reference (``&``) are available in the replacement, and the
+``g`` (replace all occurrences) and ``i`` (case-insensitive) flags are supported::
+
+    $ subliminal download -l pl \
+        --name 's/.*YP-1R-([0-9]+)x([0-9]+).*/My Little Pony Friendship Is Magic S\1E\2.mkv/' \
+        */YP-1R-*.mkv
+
+Alternatively, supply a regular expression with ``--name-pattern`` and use ``--name`` as a template whose
+back-references are filled from the match on each file name::
+
+    $ subliminal download -l pl \
+        --name-pattern '.*_-_([0-9]+)_.*' \
+        --name 'Panty & Stocking with Garterbelt S01E\1.mkv' \
+        *Garterbelt_-_*.mkv
+
+Any file whose name does not match is left untouched and scanned as-is.
+
 You can use a configuration file in the `TOML <https://toml.io/en/>`_ format with the ``--config/-c`` option. If no configuration file is
 provided, it looks for a ``subliminal.toml`` file in the default configuration folder for the application. This folder is
 `OS dependent <https://github.com/tox-dev/platformdirs>`_:

--- a/docs/user/usage.rst
+++ b/docs/user/usage.rst
@@ -40,21 +40,20 @@ The ``--name/-n`` option lets you override the name used to guess information ab
 plain static name, it can rewrite each file name individually so you no longer need a shell loop to rename
 poorly-named releases before downloading.
 
-Use a `sed <https://www.gnu.org/software/sed/manual/sed.html>`_-like substitution
+Pass a `sed <https://www.gnu.org/software/sed/manual/sed.html>`_-like substitution
 ``s/pattern/replacement/flags`` and it is applied to every file name on its own. Back-references
-(``\1``, ``\2``, …) and the whole-match reference (``&``) are available in the replacement, and the
-``g`` (replace all occurrences) and ``i`` (case-insensitive) flags are supported::
+(``\1``, ``\2``, …) are available in the replacement, and the ``g`` (replace all occurrences) and ``i``
+(case-insensitive) flags are supported::
 
     $ subliminal download -l pl \
         --name 's/.*YP-1R-([0-9]+)x([0-9]+).*/My Little Pony Friendship Is Magic S\1E\2.mkv/' \
         */YP-1R-*.mkv
 
-Alternatively, supply a regular expression with ``--name-pattern`` and use ``--name`` as a template whose
-back-references are filled from the match on each file name::
+Unlike sed, ``&`` is a literal character (not the whole match), so titles containing an ampersand need
+no escaping::
 
     $ subliminal download -l pl \
-        --name-pattern '.*_-_([0-9]+)_.*' \
-        --name 'Panty & Stocking with Garterbelt S01E\1.mkv' \
+        --name 's/.*_-_([0-9]+)_.*/Panty & Stocking with Garterbelt S01E\1.mkv/' \
         *Garterbelt_-_*.mkv
 
 Any file whose name does not match is left untouched and scanned as-is.

--- a/docs/user/usage.rst
+++ b/docs/user/usage.rst
@@ -57,7 +57,7 @@ Parameterized name
 
 The ``--name/-n`` option lets you override the file name that is used to guess information about a video.
 In addition to a static alternative name, you can use a
-`sed <https://www.gnu.org/software/sed/manual/sed.html>`_-like substitution pattern
+`sed <https://www.gnu.org/software/sed/>`_-like substitution pattern
 ``s/pattern/replacement/flags`` to override the names of all the files in a folder.
 The pattern needs to be a valid Python regex. Back-references (``\1``, ``\2``, …) are available in the
 replacement, and the ``g`` (replace all occurrences) and ``i`` (case-insensitive) flags are supported::

--- a/docs/user/usage.rst
+++ b/docs/user/usage.rst
@@ -57,7 +57,7 @@ Parameterized name
 
 The ``--name/-n`` option lets you override the file name that is used to guess information about a video.
 In addition to a static alternative name, you can use a
-`sed <https://www.gnu.org/software/sed/>`_-like substitution pattern
+`sed <https://www.man7.org/linux/man-pages/man1/sed.1.html>`_-like substitution pattern
 ``s/pattern/replacement/flags`` to override the names of all the files in a folder.
 The pattern needs to be a valid Python regex. Back-references (``\1``, ``\2``, …) are available in the
 replacement, and the ``g`` (replace all occurrences) and ``i`` (case-insensitive) flags are supported::

--- a/src/subliminal/cli/commands/download_best.py
+++ b/src/subliminal/cli/commands/download_best.py
@@ -33,7 +33,7 @@ from subliminal.core import (
 )
 from subliminal.exceptions import GuessingError
 from subliminal.extensions import get_default_providers, get_default_refiners
-from subliminal.utils import merge_extend_and_ignore_unions
+from subliminal.utils import NameResolver, merge_extend_and_ignore_unions
 
 from ._format import AgeParamType, LanguageParamType, plural
 
@@ -332,7 +332,22 @@ REFINER = click.Choice(['ALL', *sorted(refiner_manager.names())])
     metavar='NAME',
     help=(
         'Name used instead of the path name for guessing information about the file. '
-        'If used with multiple paths or a directory, `name` is passed to ALL the files.'
+        'If used with multiple paths or a directory, `name` is passed to ALL the files. '
+        'NAME may also be a sed-like substitution `s/pattern/replacement/flags` '
+        '(flags `g` and `i` are supported), applied to each file name individually. '
+        'Or, when --name-pattern is given, NAME is used as a template whose '
+        r'back-references (\1, \2, ...) are filled from the match on each file name.'
+    ),
+)
+@click.option(
+    '--name-pattern',
+    type=click.STRING,
+    metavar='PATTERN',
+    default=None,
+    help=(
+        'Regular expression matched against each file name to capture groups that are '
+        r'substituted into the --name template (\1, \2, ...). Ignored when --name is '
+        'a sed-like substitution expression.'
     ),
 )
 @click.option('-v', '--verbose', count=True, help='Increase verbosity.')
@@ -369,6 +384,7 @@ def download(
     archives: bool,
     use_absolute_path: str,
     name: str | None,
+    name_pattern: str | None,
     verbose: int,
     path: list[str],
 ) -> None:
@@ -389,6 +405,12 @@ def download(
     # no subtitle_format specified, default to None Also convert to None --subtitle_format=''
     if not subtitle_format or subtitle_format in ['""', "''"]:
         subtitle_format = None
+
+    # build the per-file name resolver (static name, sed substitution or template + pattern)
+    try:
+        name_resolver = NameResolver(name, name_pattern)
+    except ValueError as e:
+        raise click.BadParameter(str(e), param_hint='--name') from e
 
     # TODO: deprecate
     # subtitle category
@@ -466,15 +488,19 @@ def download(
             # scan videos
             video_candidates: list[Video] = []
             for filepath in collected_filepaths:
+                # Resolve the name to use for this specific file
+                file_name = name_resolver(filepath)
                 # Try scanning the video at path
-                video = scan_video_path(filepath, absolute_path=absolute_path, name=name, verbose=verbose, debug=debug)
+                video = scan_video_path(
+                    filepath, absolute_path=absolute_path, name=file_name, verbose=verbose, debug=debug
+                )
                 if video is None:
                     # Fallback to scanning with absolute path
                     if use_absolute_path == 'fallback':
                         video = scan_video_path(
                             filepath,
                             absolute_path=True,
-                            name=name,
+                            name=file_name,
                             verbose=verbose,
                             debug=debug,
                         )

--- a/src/subliminal/cli/commands/download_best.py
+++ b/src/subliminal/cli/commands/download_best.py
@@ -334,8 +334,8 @@ REFINER = click.Choice(['ALL', *sorted(refiner_manager.names())])
         'Name used instead of the path name for guessing information about the file. '
         'If used with multiple paths or a directory, `name` is passed to ALL the files. '
         'NAME may also be a sed-like substitution `s/pattern/replacement/flags`, applied '
-        r'to each file name individually: back-references (\1, \2, ...) are available in '
-        'the replacement, `&` is a literal character and the `g` (replace all) and `i` '
+        r'to each file path individually: back-references (\1, \2, ...) are available in '
+        'the replacement, `&` is a literal character (unlike in sed) and the `g` (replace all) and `i` '
         '(case-insensitive) flags are supported.'
     ),
 )
@@ -476,11 +476,9 @@ def download(
             # scan videos
             video_candidates: list[Video] = []
             for filepath in collected_filepaths:
-                # Resolve the name to use for this specific file
-                file_name = name_resolver(filepath)
                 # Try scanning the video at path
                 video = scan_video_path(
-                    filepath, absolute_path=absolute_path, name=file_name, verbose=verbose, debug=debug
+                    filepath, absolute_path=absolute_path, name=name_resolver, verbose=verbose, debug=debug
                 )
                 if video is None:
                     # Fallback to scanning with absolute path
@@ -488,7 +486,7 @@ def download(
                         video = scan_video_path(
                             filepath,
                             absolute_path=True,
-                            name=file_name,
+                            name=name_resolver,
                             verbose=verbose,
                             debug=debug,
                         )
@@ -659,7 +657,7 @@ def download(
 def scan_video_path(
     filepath: str | os.PathLike[str],
     *,
-    name: str | None = None,
+    name: str | NameResolver | None = None,
     absolute_path: bool = False,
     verbose: int = 0,
     debug: bool = False,
@@ -669,11 +667,13 @@ def scan_video_path(
     # Take the absolute path, and only if the path exists
     if absolute_path and exists:
         filepath = os.path.abspath(filepath)
+    # Resolve the name for this specific file, after the conversion to absolute path
+    file_name = name(filepath) if isinstance(name, NameResolver) else name
     # Used for print
-    filepath_or_name = f'{filepath} ({name})' if name else filepath
+    filepath_or_name = f'{filepath} ({file_name})' if file_name else filepath
 
     try:
-        video = scan_path(filepath, name=name)
+        video = scan_path(filepath, name=file_name)
 
     except GuessingError as e:
         logger.exception(

--- a/src/subliminal/cli/commands/download_best.py
+++ b/src/subliminal/cli/commands/download_best.py
@@ -333,21 +333,10 @@ REFINER = click.Choice(['ALL', *sorted(refiner_manager.names())])
     help=(
         'Name used instead of the path name for guessing information about the file. '
         'If used with multiple paths or a directory, `name` is passed to ALL the files. '
-        'NAME may also be a sed-like substitution `s/pattern/replacement/flags` '
-        '(flags `g` and `i` are supported), applied to each file name individually. '
-        'Or, when --name-pattern is given, NAME is used as a template whose '
-        r'back-references (\1, \2, ...) are filled from the match on each file name.'
-    ),
-)
-@click.option(
-    '--name-pattern',
-    type=click.STRING,
-    metavar='PATTERN',
-    default=None,
-    help=(
-        'Regular expression matched against each file name to capture groups that are '
-        r'substituted into the --name template (\1, \2, ...). Ignored when --name is '
-        'a sed-like substitution expression.'
+        'NAME may also be a sed-like substitution `s/pattern/replacement/flags`, applied '
+        r'to each file name individually: back-references (\1, \2, ...) are available in '
+        'the replacement, `&` is a literal character and the `g` (replace all) and `i` '
+        '(case-insensitive) flags are supported.'
     ),
 )
 @click.option('-v', '--verbose', count=True, help='Increase verbosity.')
@@ -384,7 +373,6 @@ def download(
     archives: bool,
     use_absolute_path: str,
     name: str | None,
-    name_pattern: str | None,
     verbose: int,
     path: list[str],
 ) -> None:
@@ -406,9 +394,9 @@ def download(
     if not subtitle_format or subtitle_format in ['""', "''"]:
         subtitle_format = None
 
-    # build the per-file name resolver (static name, sed substitution or template + pattern)
+    # build the per-file name resolver (static name or sed-like substitution)
     try:
-        name_resolver = NameResolver(name, name_pattern)
+        name_resolver = NameResolver(name)
     except ValueError as e:
         raise click.BadParameter(str(e), param_hint='--name') from e
 

--- a/src/subliminal/utils.py
+++ b/src/subliminal/utils.py
@@ -76,6 +76,186 @@ def safely_guessit(name: str | None, options: dict[str, Any] | None = None) -> d
     return result
 
 
+def parse_sed_expression(expr: str) -> tuple[str, str, str] | None:
+    """Parse a sed-like substitution ``s<delim>pattern<delim>replacement<delim>flags``.
+
+    The delimiter is the character right after the leading ``s`` and may be any
+    non-alphanumeric, non-backslash, non-whitespace character (commonly ``/``).
+    A delimiter escaped with a backslash inside the pattern or the replacement is
+    treated as a literal delimiter character.
+
+    :param str expr: the expression to parse.
+    :return: ``(pattern, replacement, flags)`` or ``None`` if `expr` is not a
+        well-formed sed substitution.
+    :rtype: tuple of (str, str, str) or None
+    """
+    if len(expr) < 2 or expr[0] != 's':
+        return None
+    delim = expr[1]
+    if delim.isalnum() or delim == '\\' or delim.isspace():
+        return None
+
+    segments: list[str] = []
+    current: list[str] = []
+    i = 2
+    n = len(expr)
+    while i < n:
+        c = expr[i]
+        if c == '\\' and i + 1 < n:
+            nxt = expr[i + 1]
+            if nxt == delim:
+                # Unescape an escaped delimiter
+                current.append(delim)
+            else:
+                current.append(c)
+                current.append(nxt)
+            i += 2
+            continue
+        if c == delim:
+            segments.append(''.join(current))
+            current = []
+            i += 1
+            continue
+        current.append(c)
+        i += 1
+    segments.append(''.join(current))
+
+    # Expect exactly pattern, replacement and flags (i.e. three delimiters total)
+    if len(segments) != 3:
+        return None
+    return segments[0], segments[1], segments[2]
+
+
+def _sed_replacement_to_python(replacement: str) -> str:
+    r"""Translate a sed replacement string to the :func:`re.sub` replacement syntax.
+
+    Group back-references (``\\1`` … ``\\9``) are already compatible with
+    :func:`re.sub`. This mainly turns the sed whole-match reference ``&`` into
+    ``\\g<0>`` and ``\\&`` into a literal ``&``.
+
+    :param str replacement: the sed-style replacement string.
+    :return: an equivalent :func:`re.sub` replacement string.
+    :rtype: str
+    """
+    out: list[str] = []
+    i = 0
+    n = len(replacement)
+    while i < n:
+        c = replacement[i]
+        if c == '\\' and i + 1 < n:
+            nxt = replacement[i + 1]
+            if nxt == '&':
+                out.append('&')
+            else:
+                out.append('\\')
+                out.append(nxt)
+            i += 2
+            continue
+        if c == '&':
+            out.append('\\g<0>')
+            i += 1
+            continue
+        out.append(c)
+        i += 1
+    return ''.join(out)
+
+
+class NameResolver:
+    r"""Compute the name passed to guessit for each scanned file.
+
+    The behaviour is selected from the `name` and `name_pattern` inputs:
+
+    * **static** -- `name` is a plain string and `name_pattern` is not given: the
+      same `name` is used for every file (the historical behaviour).
+    * **sed** -- `name` is a ``s/pattern/replacement/flags`` substitution: the
+      substitution is applied to each file base name following sed semantics (the
+      unmatched part of the name is kept). Supported flags are ``g`` (replace all
+      occurrences instead of the first) and ``i`` (case-insensitive match).
+    * **template** -- `name_pattern` is a regular expression matched against each
+      file base name and `name` is a template containing back-references
+      (``\\1`` …): the template, with back-references filled from the match, is
+      the resulting name.
+
+    In the sed and template modes, a file whose base name does not match is left
+    untouched (``None`` is returned, and the original path is used as before).
+
+    :param str name: the ``--name`` value, may be ``None``.
+    :param str name_pattern: the ``--name-pattern`` regular expression, may be ``None``.
+    :raises ValueError: if a provided regular expression or sed expression is invalid.
+    """
+
+    def __init__(self, name: str | None = None, name_pattern: str | None = None) -> None:
+        self.name = name
+        self.name_pattern = name_pattern
+        self.mode = 'static'
+        self._regex: re.Pattern[str] | None = None
+        self._replacement = ''
+        self._count = 1
+
+        if name is None:
+            return
+
+        sed = parse_sed_expression(name)
+        if sed is not None:
+            if name_pattern:
+                logger.warning(
+                    '--name is a substitution expression, ignoring --name-pattern %r', name_pattern
+                )
+            pattern, replacement, flags = sed
+            unknown = set(flags) - set('gi')
+            if unknown:
+                msg = f'Unsupported flag(s) {"".join(sorted(unknown))!r} in name expression {name!r}'
+                raise ValueError(msg)
+            re_flags = re.IGNORECASE if 'i' in flags else 0
+            try:
+                self._regex = re.compile(pattern, re_flags)
+            except re.error as e:
+                msg = f'Invalid regular expression {pattern!r} in name expression {name!r}: {e}'
+                raise ValueError(msg) from e
+            self._replacement = _sed_replacement_to_python(replacement)
+            self._count = 0 if 'g' in flags else 1
+            self.mode = 'sed'
+            return
+
+        if name_pattern:
+            try:
+                self._regex = re.compile(name_pattern)
+            except re.error as e:
+                msg = f'Invalid regular expression {name_pattern!r} in --name-pattern: {e}'
+                raise ValueError(msg) from e
+            self._replacement = name
+            self.mode = 'template'
+
+    def __call__(self, filepath: str | os.PathLike[str]) -> str | None:
+        """Return the name to use for `filepath`, or ``None`` to use the path as-is."""
+        if self.mode == 'static' or self._regex is None:
+            return self.name
+
+        base = os.path.basename(os.fspath(filepath))
+
+        if self.mode == 'sed':
+            try:
+                new_name, count = self._regex.subn(self._replacement, base, count=self._count)
+            except re.error:
+                logger.exception('Failed to apply name expression %r to %r', self.name, base)
+                return None
+            if count == 0:
+                logger.warning('Name expression %r did not match %r', self.name, base)
+                return None
+            return new_name
+
+        # template mode
+        match = self._regex.search(base)
+        if match is None:
+            logger.warning('Name pattern %r did not match %r', self.name_pattern, base)
+            return None
+        try:
+            return match.expand(self._replacement)
+        except re.error:
+            logger.exception('Failed to expand name template %r for %r', self.name, base)
+            return None
+
+
 class none_passthrough(Generic[T, R]):
     """Decorator to pass-through None input values."""
 

--- a/src/subliminal/utils.py
+++ b/src/subliminal/utils.py
@@ -127,11 +127,12 @@ def parse_sed_expression(expr: str) -> tuple[str, str, str] | None:
 
 
 def _sed_replacement_to_python(replacement: str) -> str:
-    r"""Translate a sed replacement string to the :func:`re.sub` replacement syntax.
+    r"""Adapt a sed replacement string to the :func:`re.sub` replacement syntax.
 
-    Group back-references (``\\1`` … ``\\9``) are already compatible with
-    :func:`re.sub`. This mainly turns the sed whole-match reference ``&`` into
-    ``\\g<0>`` and ``\\&`` into a literal ``&``.
+    Group back-references (``\1`` … ``\9`` and ``\g<name>``) already match the
+    :func:`re.sub` syntax and are left untouched. Unlike sed, ``&`` is a literal
+    character here (it is *not* the whole match); an escaped ``\&`` is therefore
+    collapsed to a plain ``&`` so both spellings produce a literal ampersand.
 
     :param str replacement: the sed-style replacement string.
     :return: an equivalent :func:`re.sub` replacement string.
@@ -142,18 +143,9 @@ def _sed_replacement_to_python(replacement: str) -> str:
     n = len(replacement)
     while i < n:
         c = replacement[i]
-        if c == '\\' and i + 1 < n:
-            nxt = replacement[i + 1]
-            if nxt == '&':
-                out.append('&')
-            else:
-                out.append('\\')
-                out.append(nxt)
+        if c == '\\' and i + 1 < n and replacement[i + 1] == '&':
+            out.append('&')
             i += 2
-            continue
-        if c == '&':
-            out.append('\\g<0>')
-            i += 1
             continue
         out.append(c)
         i += 1
@@ -163,30 +155,27 @@ def _sed_replacement_to_python(replacement: str) -> str:
 class NameResolver:
     r"""Compute the name passed to guessit for each scanned file.
 
-    The behaviour is selected from the `name` and `name_pattern` inputs:
+    The behaviour is selected from the `name` input:
 
-    * **static** -- `name` is a plain string and `name_pattern` is not given: the
-      same `name` is used for every file (the historical behaviour).
+    * **static** -- `name` is a plain string: the same `name` is used for every
+      file (the historical behaviour).
     * **sed** -- `name` is a ``s/pattern/replacement/flags`` substitution: the
       substitution is applied to each file base name following sed semantics (the
-      unmatched part of the name is kept). Supported flags are ``g`` (replace all
-      occurrences instead of the first) and ``i`` (case-insensitive match).
-    * **template** -- `name_pattern` is a regular expression matched against each
-      file base name and `name` is a template containing back-references
-      (``\\1`` …): the template, with back-references filled from the match, is
-      the resulting name.
+      unmatched part of the name is kept). Back-references (``\1`` …) are
+      available in the replacement, ``&`` is a literal character and the
+      supported flags are ``g`` (replace all occurrences instead of the first)
+      and ``i`` (case-insensitive match).
 
-    In the sed and template modes, a file whose base name does not match is left
-    untouched (``None`` is returned, and the original path is used as before).
+    In the sed mode, a file whose base name does not match is left untouched
+    (``None`` is returned, and the original path is used as before).
 
     :param str name: the ``--name`` value, may be ``None``.
-    :param str name_pattern: the ``--name-pattern`` regular expression, may be ``None``.
-    :raises ValueError: if a provided regular expression or sed expression is invalid.
+    :raises ValueError: if the sed expression contains an invalid regular
+        expression or an unsupported flag.
     """
 
-    def __init__(self, name: str | None = None, name_pattern: str | None = None) -> None:
+    def __init__(self, name: str | None = None) -> None:
         self.name = name
-        self.name_pattern = name_pattern
         self.mode = 'static'
         self._regex: re.Pattern[str] | None = None
         self._replacement = ''
@@ -196,35 +185,24 @@ class NameResolver:
             return
 
         sed = parse_sed_expression(name)
-        if sed is not None:
-            if name_pattern:
-                logger.warning(
-                    '--name is a substitution expression, ignoring --name-pattern %r', name_pattern
-                )
-            pattern, replacement, flags = sed
-            unknown = set(flags) - set('gi')
-            if unknown:
-                msg = f'Unsupported flag(s) {"".join(sorted(unknown))!r} in name expression {name!r}'
-                raise ValueError(msg)
-            re_flags = re.IGNORECASE if 'i' in flags else 0
-            try:
-                self._regex = re.compile(pattern, re_flags)
-            except re.error as e:
-                msg = f'Invalid regular expression {pattern!r} in name expression {name!r}: {e}'
-                raise ValueError(msg) from e
-            self._replacement = _sed_replacement_to_python(replacement)
-            self._count = 0 if 'g' in flags else 1
-            self.mode = 'sed'
+        if sed is None:
+            # plain static name, used as-is for every file
             return
 
-        if name_pattern:
-            try:
-                self._regex = re.compile(name_pattern)
-            except re.error as e:
-                msg = f'Invalid regular expression {name_pattern!r} in --name-pattern: {e}'
-                raise ValueError(msg) from e
-            self._replacement = name
-            self.mode = 'template'
+        pattern, replacement, flags = sed
+        unknown = set(flags) - set('gi')
+        if unknown:
+            msg = f'Unsupported flag(s) {"".join(sorted(unknown))!r} in name expression {name!r}'
+            raise ValueError(msg)
+        re_flags = re.IGNORECASE if 'i' in flags else 0
+        try:
+            self._regex = re.compile(pattern, re_flags)
+        except re.error as e:
+            msg = f'Invalid regular expression {pattern!r} in name expression {name!r}: {e}'
+            raise ValueError(msg) from e
+        self._replacement = _sed_replacement_to_python(replacement)
+        self._count = 0 if 'g' in flags else 1
+        self.mode = 'sed'
 
     def __call__(self, filepath: str | os.PathLike[str]) -> str | None:
         """Return the name to use for `filepath`, or ``None`` to use the path as-is."""
@@ -232,28 +210,15 @@ class NameResolver:
             return self.name
 
         base = os.path.basename(os.fspath(filepath))
-
-        if self.mode == 'sed':
-            try:
-                new_name, count = self._regex.subn(self._replacement, base, count=self._count)
-            except re.error:
-                logger.exception('Failed to apply name expression %r to %r', self.name, base)
-                return None
-            if count == 0:
-                logger.warning('Name expression %r did not match %r', self.name, base)
-                return None
-            return new_name
-
-        # template mode
-        match = self._regex.search(base)
-        if match is None:
-            logger.warning('Name pattern %r did not match %r', self.name_pattern, base)
-            return None
         try:
-            return match.expand(self._replacement)
+            new_name, count = self._regex.subn(self._replacement, base, count=self._count)
         except re.error:
-            logger.exception('Failed to expand name template %r for %r', self.name, base)
+            logger.exception('Failed to apply name expression %r to %r', self.name, base)
             return None
+        if count == 0:
+            logger.warning('Name expression %r did not match %r', self.name, base)
+            return None
+        return new_name
 
 
 class none_passthrough(Generic[T, R]):

--- a/src/subliminal/utils.py
+++ b/src/subliminal/utils.py
@@ -22,7 +22,7 @@ from .exceptions import ServiceUnavailable
 
 if TYPE_CHECKING:
     from collections.abc import Callable, Sequence, Set
-    from typing import TypedDict, TypeGuard
+    from typing import Literal, TypedDict, TypeGuard
 
     S = TypeVar('S')
 
@@ -76,6 +76,11 @@ def safely_guessit(name: str | None, options: dict[str, Any] | None = None) -> d
     return result
 
 
+def unescape_delimiter(string: str, delimiter: str) -> str:
+    """Unescape delimiter."""
+    return string.replace(f'\\{delimiter}', delimiter)
+
+
 def split_esc(string: str, delimiter: str) -> Iterator[str]:
     """Split the string by the non-escaped delimiter.
 
@@ -88,19 +93,19 @@ def split_esc(string: str, delimiter: str) -> Iterator[str]:
     while j < ln:
         # Delimiter found
         if string[j : j + dln] == delimiter:
-            yield string[i:j]
+            yield unescape_delimiter(string[i:j], delimiter)
             j += dln
             i = j
         # Escaped character
         elif string[j] == '\\':
             if j + 1 >= ln:
-                yield string[i:j]
+                yield unescape_delimiter(string[i:j], delimiter)
                 return
             j += 2
         # Other character
         else:
             j += 1
-    yield string[i:j]
+    yield unescape_delimiter(string[i:j], delimiter)
 
 
 def parse_sed_expression(expr: str) -> tuple[str, str, str] | None:
@@ -135,7 +140,7 @@ class NameResolver:
     The behaviour is selected from the `name` input:
 
     * **static** -- `name` is a plain string: the same `name` is used for every
-      file (the historical behaviour).
+      file.
     * **sed** -- `name` is a ``s/pattern/replacement/flags`` substitution: the
       substitution is applied to each file path following sed semantics (the
       unmatched part of the path is kept). Back-references (``\1`` …) are
@@ -152,14 +157,14 @@ class NameResolver:
     """
 
     name: str | None
-    mode: str
+    _mode: Literal['static', 'sed']
     _regex: re.Pattern[str] | None
     _replacement: str
     _count: int
 
     def __init__(self, name: str | None = None) -> None:
         self.name = name
-        self.mode = 'static'
+        self._mode = 'static'
         self._regex: re.Pattern[str] | None = None
         self._replacement = ''
         self._count = 1
@@ -185,11 +190,16 @@ class NameResolver:
             raise ValueError(msg) from e
         self._replacement = replacement
         self._count = 0 if 'g' in flags else 1
-        self.mode = 'sed'
+        self._mode = 'sed'
+
+    @property
+    def mode(self) -> Literal['static', 'sed']:
+        """Name resolver mode."""
+        return self._mode
 
     def __call__(self, filepath: str | os.PathLike[str]) -> str | None:
         """Return the name to use for `filepath`, or ``None`` to use the path as-is."""
-        if self.mode == 'static' or self._regex is None:
+        if self._mode == 'static' or self._regex is None:
             return self.name
 
         path = os.fspath(filepath)

--- a/src/subliminal/utils.py
+++ b/src/subliminal/utils.py
@@ -8,7 +8,7 @@ import os
 import platform
 import re
 import socket
-from collections.abc import Iterable
+from collections.abc import Iterable, Iterator
 from datetime import datetime, timedelta, timezone
 from types import GeneratorType
 from typing import TYPE_CHECKING, Any, Generic, TypeVar, cast, overload
@@ -76,6 +76,33 @@ def safely_guessit(name: str | None, options: dict[str, Any] | None = None) -> d
     return result
 
 
+def split_esc(string: str, delimiter: str) -> Iterator[str]:
+    """Split the string by the non-escaped delimiter.
+
+    Return an iterator of the string parts.
+    """
+    dln = len(delimiter)
+    ln = len(string)
+    i = 0
+    j = 0
+    while j < ln:
+        # Delimiter found
+        if string[j : j + dln] == delimiter:
+            yield string[i:j]
+            j += dln
+            i = j
+        # Escaped character
+        elif string[j] == '\\':
+            if j + 1 >= ln:
+                yield string[i:j]
+                return
+            j += 2
+        # Other character
+        else:
+            j += 1
+    yield string[i:j]
+
+
 def parse_sed_expression(expr: str) -> tuple[str, str, str] | None:
     """Parse a sed-like substitution ``s<delim>pattern<delim>replacement<delim>flags``.
 
@@ -95,61 +122,11 @@ def parse_sed_expression(expr: str) -> tuple[str, str, str] | None:
     if delim.isalnum() or delim == '\\' or delim.isspace():
         return None
 
-    segments: list[str] = []
-    current: list[str] = []
-    i = 2
-    n = len(expr)
-    while i < n:
-        c = expr[i]
-        if c == '\\' and i + 1 < n:
-            nxt = expr[i + 1]
-            if nxt == delim:
-                # Unescape an escaped delimiter
-                current.append(delim)
-            else:
-                current.append(c)
-                current.append(nxt)
-            i += 2
-            continue
-        if c == delim:
-            segments.append(''.join(current))
-            current = []
-            i += 1
-            continue
-        current.append(c)
-        i += 1
-    segments.append(''.join(current))
-
+    segments = list(split_esc(expr[2:], delim))
     # Expect exactly pattern, replacement and flags (i.e. three delimiters total)
     if len(segments) != 3:
         return None
     return segments[0], segments[1], segments[2]
-
-
-def _sed_replacement_to_python(replacement: str) -> str:
-    r"""Adapt a sed replacement string to the :func:`re.sub` replacement syntax.
-
-    Group back-references (``\1`` … ``\9`` and ``\g<name>``) already match the
-    :func:`re.sub` syntax and are left untouched. Unlike sed, ``&`` is a literal
-    character here (it is *not* the whole match); an escaped ``\&`` is therefore
-    collapsed to a plain ``&`` so both spellings produce a literal ampersand.
-
-    :param str replacement: the sed-style replacement string.
-    :return: an equivalent :func:`re.sub` replacement string.
-    :rtype: str
-    """
-    out: list[str] = []
-    i = 0
-    n = len(replacement)
-    while i < n:
-        c = replacement[i]
-        if c == '\\' and i + 1 < n and replacement[i + 1] == '&':
-            out.append('&')
-            i += 2
-            continue
-        out.append(c)
-        i += 1
-    return ''.join(out)
 
 
 class NameResolver:
@@ -160,19 +137,25 @@ class NameResolver:
     * **static** -- `name` is a plain string: the same `name` is used for every
       file (the historical behaviour).
     * **sed** -- `name` is a ``s/pattern/replacement/flags`` substitution: the
-      substitution is applied to each file base name following sed semantics (the
-      unmatched part of the name is kept). Back-references (``\1`` …) are
-      available in the replacement, ``&`` is a literal character and the
-      supported flags are ``g`` (replace all occurrences instead of the first)
-      and ``i`` (case-insensitive match).
+      substitution is applied to each file path following sed semantics (the
+      unmatched part of the path is kept). Back-references (``\1`` …) are
+      available in the replacement, ``&`` is a literal character (unlike in sed)
+      and the supported flags are ``g`` (replace all occurrences instead of the
+      first) and ``i`` (case-insensitive match).
 
-    In the sed mode, a file whose base name does not match is left untouched
+    In the sed mode, a file whose path does not match is left untouched
     (``None`` is returned, and the original path is used as before).
 
     :param str name: the ``--name`` value, may be ``None``.
     :raises ValueError: if the sed expression contains an invalid regular
         expression or an unsupported flag.
     """
+
+    name: str | None
+    mode: str
+    _regex: re.Pattern[str] | None
+    _replacement: str
+    _count: int
 
     def __init__(self, name: str | None = None) -> None:
         self.name = name
@@ -200,7 +183,7 @@ class NameResolver:
         except re.error as e:
             msg = f'Invalid regular expression {pattern!r} in name expression {name!r}: {e}'
             raise ValueError(msg) from e
-        self._replacement = _sed_replacement_to_python(replacement)
+        self._replacement = replacement
         self._count = 0 if 'g' in flags else 1
         self.mode = 'sed'
 
@@ -209,14 +192,14 @@ class NameResolver:
         if self.mode == 'static' or self._regex is None:
             return self.name
 
-        base = os.path.basename(os.fspath(filepath))
+        path = os.fspath(filepath)
         try:
-            new_name, count = self._regex.subn(self._replacement, base, count=self._count)
+            new_name, count = self._regex.subn(self._replacement, path, count=self._count)
         except re.error:
-            logger.exception('Failed to apply name expression %r to %r', self.name, base)
+            logger.exception('Failed to apply name expression %r to %r', self.name, path)
             return None
         if count == 0:
-            logger.warning('Name expression %r did not match %r', self.name, base)
+            logger.warning('Name expression %r did not match %r', self.name, path)
             return None
         return new_name
 

--- a/tests/cli/test_download.py
+++ b/tests/cli/test_download.py
@@ -571,6 +571,32 @@ def test_cli_download_name_sed(cli_runner: CliRunner, monkeypatch: pytest.Monkey
         assert ('YP-1R-01x05-720p.mkv', 'My Little Pony S01E05.mkv') in captured
 
 
+def test_cli_download_name_static(cli_runner: CliRunner, monkeypatch: pytest.MonkeyPatch) -> None:
+    import subliminal.cli.commands.download_best as dl
+
+    captured: list[tuple[str, str | None]] = []
+    orig_scan_path = dl.scan_path
+
+    def spy_scan_path(filepath: str, *, name: str | None = None) -> object:
+        captured.append((os.path.basename(os.fspath(filepath)), name))
+        return orig_scan_path(filepath, name=name)
+
+    monkeypatch.setattr(dl, 'scan_path', spy_scan_path)
+
+    # a static name starting with 's' and containing non-alphanumeric characters,
+    # to check it is not mistaken for a sed-like substitution
+    static_name = 's.w.a.t.2017.s01e01.720p.hdtv.x264-killers.mkv'
+    with cli_runner.isolated_filesystem():
+        result = cli_runner.run(
+            subliminal_cli,
+            ['download', '-l', 'en', '-p', 'podnapisi', '--name', static_name, 'badly-named-video.mkv'],
+        )
+
+        assert result.exit_code == 0
+        # the same static name is passed to every file
+        assert ('badly-named-video.mkv', static_name) in captured
+
+
 def test_cli_download_name_ampersand(cli_runner: CliRunner, monkeypatch: pytest.MonkeyPatch) -> None:
     import subliminal.cli.commands.download_best as dl
 

--- a/tests/cli/test_download.py
+++ b/tests/cli/test_download.py
@@ -571,7 +571,7 @@ def test_cli_download_name_sed(cli_runner: CliRunner, monkeypatch: pytest.Monkey
         assert ('YP-1R-01x05-720p.mkv', 'My Little Pony S01E05.mkv') in captured
 
 
-def test_cli_download_name_template(cli_runner: CliRunner, monkeypatch: pytest.MonkeyPatch) -> None:
+def test_cli_download_name_ampersand(cli_runner: CliRunner, monkeypatch: pytest.MonkeyPatch) -> None:
     import subliminal.cli.commands.download_best as dl
 
     captured: list[tuple[str, str | None]] = []
@@ -592,15 +592,14 @@ def test_cli_download_name_template(cli_runner: CliRunner, monkeypatch: pytest.M
                 'en',
                 '-p',
                 'podnapisi',
-                '--name-pattern',
-                r'.*_-_([0-9]+)_.*',
                 '--name',
-                r'Panty & Stocking S01E\1.mkv',
+                r's/.*_-_([0-9]+)_.*/Panty & Stocking S01E\1.mkv/',
                 'Garterbelt_-_07_xyz.mkv',
             ],
         )
 
         assert result.exit_code == 0
+        # the literal ampersand in the title is preserved
         assert ('Garterbelt_-_07_xyz.mkv', 'Panty & Stocking S01E07.mkv') in captured
 
 

--- a/tests/cli/test_download.py
+++ b/tests/cli/test_download.py
@@ -538,3 +538,102 @@ def test_cli_download_with_generated_config(cli_runner: CliRunner) -> None:
         # collect files recursively
         files = [os.fspath(p.relative_to(td)) for p in Path(td).rglob('*')]
         assert subtitle_filename in files
+
+
+def test_cli_download_name_sed(cli_runner: CliRunner, monkeypatch: pytest.MonkeyPatch) -> None:
+    import subliminal.cli.commands.download_best as dl
+
+    captured: list[tuple[str, str | None]] = []
+    orig_scan_path = dl.scan_path
+
+    def spy_scan_path(filepath: str, *, name: str | None = None) -> object:
+        captured.append((os.path.basename(os.fspath(filepath)), name))
+        return orig_scan_path(filepath, name=name)
+
+    monkeypatch.setattr(dl, 'scan_path', spy_scan_path)
+
+    with cli_runner.isolated_filesystem():
+        result = cli_runner.run(
+            subliminal_cli,
+            [
+                'download',
+                '-l',
+                'en',
+                '-p',
+                'podnapisi',
+                '--name',
+                r's/.*YP-1R-([0-9]+)x([0-9]+).*/My Little Pony S\1E\2.mkv/',
+                'YP-1R-01x05-720p.mkv',
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert ('YP-1R-01x05-720p.mkv', 'My Little Pony S01E05.mkv') in captured
+
+
+def test_cli_download_name_template(cli_runner: CliRunner, monkeypatch: pytest.MonkeyPatch) -> None:
+    import subliminal.cli.commands.download_best as dl
+
+    captured: list[tuple[str, str | None]] = []
+    orig_scan_path = dl.scan_path
+
+    def spy_scan_path(filepath: str, *, name: str | None = None) -> object:
+        captured.append((os.path.basename(os.fspath(filepath)), name))
+        return orig_scan_path(filepath, name=name)
+
+    monkeypatch.setattr(dl, 'scan_path', spy_scan_path)
+
+    with cli_runner.isolated_filesystem():
+        result = cli_runner.run(
+            subliminal_cli,
+            [
+                'download',
+                '-l',
+                'en',
+                '-p',
+                'podnapisi',
+                '--name-pattern',
+                r'.*_-_([0-9]+)_.*',
+                '--name',
+                r'Panty & Stocking S01E\1.mkv',
+                'Garterbelt_-_07_xyz.mkv',
+            ],
+        )
+
+        assert result.exit_code == 0
+        assert ('Garterbelt_-_07_xyz.mkv', 'Panty & Stocking S01E07.mkv') in captured
+
+
+def test_cli_download_name_no_match_falls_back(cli_runner: CliRunner, monkeypatch: pytest.MonkeyPatch) -> None:
+    import subliminal.cli.commands.download_best as dl
+
+    captured: list[tuple[str, str | None]] = []
+    orig_scan_path = dl.scan_path
+
+    def spy_scan_path(filepath: str, *, name: str | None = None) -> object:
+        captured.append((os.path.basename(os.fspath(filepath)), name))
+        return orig_scan_path(filepath, name=name)
+
+    monkeypatch.setattr(dl, 'scan_path', spy_scan_path)
+
+    video_name = 'Marvels.Agents.of.S.H.I.E.L.D.S02E06.720p.HDTV.x264-KILLERS.mkv'
+    with cli_runner.isolated_filesystem():
+        result = cli_runner.run(
+            subliminal_cli,
+            ['download', '-l', 'en', '-p', 'podnapisi', '--name', r's/NOPE-([0-9]+)/E\1/', video_name],
+        )
+
+        assert result.exit_code == 0
+        # name could not be resolved, fall back to scanning the path as-is
+        assert (video_name, None) in captured
+
+
+def test_cli_download_name_invalid_expression(cli_runner: CliRunner) -> None:
+    with cli_runner.isolated_filesystem():
+        result = cli_runner.run(
+            subliminal_cli,
+            ['download', '-l', 'en', '-p', 'podnapisi', '--name', 's/(/x/', 'foo.mkv'],
+        )
+
+        assert result.exit_code == 2
+        assert 'Invalid value for --name' in result.err

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -10,6 +10,7 @@ import requests
 
 from subliminal.exceptions import ServiceUnavailable
 from subliminal.utils import (
+    NameResolver,
     clip,
     creation_date,
     decorate_imdb_id,
@@ -21,6 +22,7 @@ from subliminal.utils import (
     matches_extended_title,
     merge_extend_and_ignore_unions,
     modification_date,
+    parse_sed_expression,
     safely_guessit,
     sanitize,
     sanitize_id,
@@ -364,3 +366,79 @@ def test_clip(value: float, minimum: float | None, maximum: float | None, expect
 def test_trim_pattern(string: str, patterns: str | Sequence[str], sep: str, expected: tuple[str, str]) -> None:
     res = trim_pattern(string, patterns, sep=sep)
     assert res == expected
+
+
+@pytest.mark.parametrize(
+    ('expr', 'expected'),
+    [
+        ('s/a/b/', ('a', 'b', '')),
+        ('s/a/b/gi', ('a', 'b', 'gi')),
+        (r's/a\/b/c/', ('a/b', 'c', '')),  # escaped delimiter inside pattern
+        ('s|a|b|', ('a', 'b', '')),  # alternative delimiter
+        (r's/.*S(\d+)E(\d+).*/S\1E\2/', (r'.*S(\d+)E(\d+).*', r'S\1E\2', '')),
+        ('s/a/b', None),  # missing closing delimiter
+        ('s/a/b/c/d', None),  # too many segments
+        ('show.s01.e01.mkv', None),  # plain name with several dots
+        ('My Show S01E01.mkv', None),  # plain name
+        ('sea/b/c', None),  # delimiter is alphanumeric
+        ('', None),
+    ],
+)
+def test_parse_sed_expression(expr: str, expected: tuple[str, str, str] | None) -> None:
+    assert parse_sed_expression(expr) == expected
+
+
+def test_name_resolver_static() -> None:
+    resolver = NameResolver('My Show S01E01.mkv')
+    assert resolver.mode == 'static'
+    # same name returned for every file
+    assert resolver('whatever.mkv') == 'My Show S01E01.mkv'
+    assert resolver('other.mkv') == 'My Show S01E01.mkv'
+
+
+def test_name_resolver_none() -> None:
+    resolver = NameResolver(None)
+    assert resolver('whatever.mkv') is None
+
+
+def test_name_resolver_sed() -> None:
+    resolver = NameResolver(r's/.*YP-1R-([0-9]+)x([0-9]+).*/My Little Pony S\1E\2.mkv/')
+    assert resolver.mode == 'sed'
+    assert resolver('/path/to/YP-1R-01x05-720p.mkv') == 'My Little Pony S01E05.mkv'
+    # non-matching file falls back to None
+    assert resolver('unrelated.mkv') is None
+
+
+def test_name_resolver_sed_flags() -> None:
+    # without g, only the first occurrence is replaced
+    assert NameResolver('s/a/X/')('aaa.mkv') == 'Xaa.mkv'
+    # g replaces all occurrences
+    assert NameResolver('s/a/X/g')('aaa.mkv') == 'XXX.mkv'
+    # i is case-insensitive
+    assert NameResolver('s/a/X/gi')('AaA.mkv') == 'XXX.mkv'
+
+
+def test_name_resolver_sed_whole_match() -> None:
+    # sed & references the whole match, \& is a literal &
+    assert NameResolver('s/[0-9]+/[&]/')('ep12.mkv') == 'ep[12].mkv'
+    assert NameResolver(r's/[0-9]+/\&/')('ep12.mkv') == 'ep&.mkv'
+
+
+def test_name_resolver_template() -> None:
+    resolver = NameResolver(r'Panty & Stocking S01E\1.mkv', r'.*_-_([0-9]+)_.*')
+    assert resolver.mode == 'template'
+    assert resolver('Garterbelt_-_07_xyz.mkv') == 'Panty & Stocking S01E07.mkv'
+    # non-matching file falls back to None
+    assert resolver('Garterbelt.mkv') is None
+
+
+def test_name_resolver_invalid_sed_flag() -> None:
+    with pytest.raises(ValueError, match='Unsupported flag'):
+        NameResolver('s/a/b/x')
+
+
+def test_name_resolver_invalid_regex() -> None:
+    with pytest.raises(ValueError, match='Invalid regular expression'):
+        NameResolver('s/(/x/')
+    with pytest.raises(ValueError, match='Invalid regular expression'):
+        NameResolver(r'Show \1.mkv', '(')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -29,6 +29,7 @@ from subliminal.utils import (
     sanitize_release_group,
     split_esc,
     trim_pattern,
+    unescape_delimiter,
 )
 
 if TYPE_CHECKING:
@@ -369,12 +370,22 @@ def test_trim_pattern(string: str, patterns: str | Sequence[str], sep: str, expe
     assert res == expected
 
 
+def test_unescape_delimiter() -> None:
+    string = r'unescape_\/delim'
+    delim = '/'
+    out = unescape_delimiter(string, delim)
+
+    expected = 'unescape_/delim'
+    assert out == expected
+
+
 @pytest.mark.parametrize(
     ('string', 'delimiter', 'expected'),
     [
         ('a/b/', '/', ['a', 'b', '']),
         ('a/b', '/', ['a', 'b']),
-        (r'a\/b/c/', '/', [r'a\/b', 'c', '']),  # escaped delimiter is not split on
+        (r'a\/b/c/', '/', ['a/b', 'c', '']),  # escaped delimiter is not split on
+        (r'a/b\//c', '/', ['a', 'b/', 'c']),  # escaped delimiter
         (r'a\1/b/', '/', [r'a\1', 'b', '']),  # escaped non-delimiter is kept
         ('a/b\\', '/', ['a', 'b']),  # trailing backslash
         ('', '/', ['']),
@@ -389,7 +400,7 @@ def test_split_esc(string: str, delimiter: str, expected: list[str]) -> None:
     [
         ('s/a/b/', ('a', 'b', '')),
         ('s/a/b/gi', ('a', 'b', 'gi')),
-        (r's/a\/b/c/', (r'a\/b', 'c', '')),  # escaped delimiter inside pattern, backslash is kept
+        (r's/a\/b/c/', ('a/b', 'c', '')),  # escaped delimiter inside pattern, unescaped
         ('s|a|b|', ('a', 'b', '')),  # alternative delimiter
         (r's/.*S(\d+)E(\d+).*/S\1E\2/', (r'.*S(\d+)E(\d+).*', r'S\1E\2', '')),
         ('s/a/b', None),  # missing closing delimiter

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -418,18 +418,24 @@ def test_name_resolver_sed_flags() -> None:
     assert NameResolver('s/a/X/gi')('AaA.mkv') == 'XXX.mkv'
 
 
-def test_name_resolver_sed_whole_match() -> None:
-    # sed & references the whole match, \& is a literal &
-    assert NameResolver('s/[0-9]+/[&]/')('ep12.mkv') == 'ep[12].mkv'
+def test_name_resolver_sed_ampersand_is_literal() -> None:
+    # unlike sed, & is a literal character (not the whole match)
+    assert NameResolver('s/[0-9]+/[&]/')('ep12.mkv') == 'ep[&].mkv'
+    # an escaped \& also yields a literal &
     assert NameResolver(r's/[0-9]+/\&/')('ep12.mkv') == 'ep&.mkv'
-
-
-def test_name_resolver_template() -> None:
-    resolver = NameResolver(r'Panty & Stocking S01E\1.mkv', r'.*_-_([0-9]+)_.*')
-    assert resolver.mode == 'template'
+    # so a real-world title with & needs no escaping
+    resolver = NameResolver(r's/.*_-_([0-9]+)_.*/Panty & Stocking S01E\1.mkv/')
     assert resolver('Garterbelt_-_07_xyz.mkv') == 'Panty & Stocking S01E07.mkv'
     # non-matching file falls back to None
     assert resolver('Garterbelt.mkv') is None
+
+
+def test_name_resolver_bad_group_reference() -> None:
+    # the pattern compiles, but the replacement references a missing group: the
+    # substitution fails at call time and the file is left untouched
+    resolver = NameResolver(r's/(a)/X\2Y/')
+    assert resolver.mode == 'sed'
+    assert resolver('aaa.mkv') is None
 
 
 def test_name_resolver_invalid_sed_flag() -> None:
@@ -440,5 +446,3 @@ def test_name_resolver_invalid_sed_flag() -> None:
 def test_name_resolver_invalid_regex() -> None:
     with pytest.raises(ValueError, match='Invalid regular expression'):
         NameResolver('s/(/x/')
-    with pytest.raises(ValueError, match='Invalid regular expression'):
-        NameResolver(r'Show \1.mkv', '(')

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -27,6 +27,7 @@ from subliminal.utils import (
     sanitize,
     sanitize_id,
     sanitize_release_group,
+    split_esc,
     trim_pattern,
 )
 
@@ -369,16 +370,32 @@ def test_trim_pattern(string: str, patterns: str | Sequence[str], sep: str, expe
 
 
 @pytest.mark.parametrize(
+    ('string', 'delimiter', 'expected'),
+    [
+        ('a/b/', '/', ['a', 'b', '']),
+        ('a/b', '/', ['a', 'b']),
+        (r'a\/b/c/', '/', [r'a\/b', 'c', '']),  # escaped delimiter is not split on
+        (r'a\1/b/', '/', [r'a\1', 'b', '']),  # escaped non-delimiter is kept
+        ('a/b\\', '/', ['a', 'b']),  # trailing backslash
+        ('', '/', ['']),
+    ],
+)
+def test_split_esc(string: str, delimiter: str, expected: list[str]) -> None:
+    assert list(split_esc(string, delimiter)) == expected
+
+
+@pytest.mark.parametrize(
     ('expr', 'expected'),
     [
         ('s/a/b/', ('a', 'b', '')),
         ('s/a/b/gi', ('a', 'b', 'gi')),
-        (r's/a\/b/c/', ('a/b', 'c', '')),  # escaped delimiter inside pattern
+        (r's/a\/b/c/', (r'a\/b', 'c', '')),  # escaped delimiter inside pattern, backslash is kept
         ('s|a|b|', ('a', 'b', '')),  # alternative delimiter
         (r's/.*S(\d+)E(\d+).*/S\1E\2/', (r'.*S(\d+)E(\d+).*', r'S\1E\2', '')),
         ('s/a/b', None),  # missing closing delimiter
         ('s/a/b/c/d', None),  # too many segments
         ('show.s01.e01.mkv', None),  # plain name with several dots
+        ('s.w.a.t.2017.s01e01.mkv', None),  # plain name starting with 's' and a non-alphanumeric character
         ('My Show S01E01.mkv', None),  # plain name
         ('sea/b/c', None),  # delimiter is alphanumeric
         ('', None),
@@ -409,6 +426,13 @@ def test_name_resolver_sed() -> None:
     assert resolver('unrelated.mkv') is None
 
 
+def test_name_resolver_sed_matches_full_path() -> None:
+    # the substitution is applied to the whole path, so it can match parent directories
+    resolver = NameResolver(r's#.*Season ([0-9]+)/Episode ([0-9]+).*#My Show S\1E\2.mkv#')
+    assert resolver('/videos/My Show/Season 02/Episode 05.mkv') == 'My Show S02E05.mkv'
+    assert resolver('Episode 05.mkv') is None
+
+
 def test_name_resolver_sed_flags() -> None:
     # without g, only the first occurrence is replaced
     assert NameResolver('s/a/X/')('aaa.mkv') == 'Xaa.mkv'
@@ -421,8 +445,8 @@ def test_name_resolver_sed_flags() -> None:
 def test_name_resolver_sed_ampersand_is_literal() -> None:
     # unlike sed, & is a literal character (not the whole match)
     assert NameResolver('s/[0-9]+/[&]/')('ep12.mkv') == 'ep[&].mkv'
-    # an escaped \& also yields a literal &
-    assert NameResolver(r's/[0-9]+/\&/')('ep12.mkv') == 'ep&.mkv'
+    # \& is not unescaped, it is passed as-is to re.sub which keeps it verbatim
+    assert NameResolver(r's/[0-9]+/\&/')('ep12.mkv') == r'ep\&.mkv'
     # so a real-world title with & needs no escaping
     resolver = NameResolver(r's/.*_-_([0-9]+)_.*/Panty & Stocking S01E\1.mkv/')
     assert resolver('Garterbelt_-_07_xyz.mkv') == 'Panty & Stocking S01E07.mkv'


### PR DESCRIPTION
Allow `--name` to rewrite each scanned file's name individually instead of passing one static name to every file, removing the need for shell loops. Now `--name 's/pattern/replacement/flags'` applies a sed-style substitution to each file name (back-references \1.., whole-match &, flags g and i).

Files that don't match are scanned as-is. Logic lives in a testable NameResolver in subliminal.utils. Invalid regex/flags raise a click BadParameter. Adds unit and CLI integration tests, docs and changelog.