### PR TITLE
fix(opensubtitlescom): prevent pagination errors from discarding collected results

### DIFF
--- a/changelog.d/1373.provider.rst
+++ b/changelog.d/1373.provider.rst
@@ -1,0 +1,1 @@
+Stop the opensubtitlescom pagination when a page fails and keep the subtitles already found

--- a/src/subliminal/providers/opensubtitlescom.py
+++ b/src/subliminal/providers/opensubtitlescom.py
@@ -13,12 +13,14 @@ from typing import TYPE_CHECKING, Any, ClassVar, cast
 from babelfish import Language, language_converters  # type: ignore[import-untyped]
 from dogpile.cache.api import NO_VALUE
 from requests import Response, Session
+from requests.exceptions import RequestException
 
 from subliminal import __short_version__
 from subliminal.cache import region
 from subliminal.exceptions import (
     AuthenticationError,
     ConfigurationError,
+    DiscardingError,
     DownloadLimitExceeded,
     NotInitializedProviderError,
     ProviderError,
@@ -527,8 +529,11 @@ class OpenSubtitlesComProvider(Provider):
         try:
             r = self.session.get(self.server_url + path, params=params, timeout=self.timeout)
             r = checked(r)
-        except ProviderError:
-            logger.exception('An error occurred')
+        except RequestException as error:
+            logger.debug('Request to %r failed: %s', path, error)
+            raise OpenSubtitlesComError(str(error)) from error
+        except ProviderError as error:
+            logger.debug('Request to %r failed: %s', path, error)
             if raises:
                 raise
             return {}
@@ -543,7 +548,19 @@ class OpenSubtitlesComProvider(Provider):
             ext_params = {'page': page, **params}
             logger.info('Searching subtitles %r', ext_params)
             # GET request and add page information
-            response = self.api_get('subtitles', ext_params)
+            try:
+                response = self.api_get('subtitles', ext_params)
+            # If an iteration fails after results were collected, the generator fails and the caller gets no results.
+            # To prevent that from happening, we don't treat errors as failures if some results are already collected.
+            # An error is raised only if the first page failed, or if it is a `DiscardingError`.
+            # A `DiscardingError` means the provider is unusable.
+            except DiscardingError:
+                raise
+            except ProviderError:
+                if page == 1:
+                    raise
+                logger.warning('Pagination stopped at page %d', page)
+                break
             if not response or not response['data']:
                 break
             yield from response['data']

--- a/tests/providers/test_opensubtitlescom.py
+++ b/tests/providers/test_opensubtitlescom.py
@@ -1,10 +1,13 @@
 import os
+from typing import Any
+from unittest.mock import MagicMock, patch
 
 import pytest
+import requests
 from babelfish import Language  # type: ignore[import-untyped]
 from vcr import VCR  # type: ignore[import-untyped]
 
-from subliminal.exceptions import ConfigurationError
+from subliminal.exceptions import ConfigurationError, ServiceUnavailable
 from subliminal.providers.opensubtitlescom import (
     OpenSubtitlesComError,
     OpenSubtitlesComProvider,
@@ -471,3 +474,50 @@ def test_query_max_result_pages(movies: dict[str, Movie]) -> None:
     with OpenSubtitlesComProvider(USERNAME, PASSWORD, max_result_pages=1) as provider:
         subtitles = provider.query(languages, query=query)
     assert len(subtitles) < len(all_subtitles)
+
+
+def test_search_keeps_results_when_a_page_fails() -> None:
+    """Pagination stops at the failing page and keeps the results already found."""
+
+    def api_get(path: str, params: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
+        if params['page'] == 3:
+            msg = 'Bad Request'
+            raise OpenSubtitlesComError(msg)
+        return {'data': [{'id': params['page']}], 'total_pages': 100}
+
+    provider = OpenSubtitlesComProvider(USERNAME, PASSWORD)
+    with patch.object(provider, 'api_get', side_effect=api_get):
+        results = list(provider._search(query='Man of Steel'))
+
+    assert [result['id'] for result in results] == [1, 2]
+
+
+def test_search_does_not_swallow_a_discarding_error() -> None:
+    """An error that discards the provider is raised, even in the middle of the pagination."""
+
+    def api_get(path: str, params: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
+        if params['page'] == 3:
+            raise ServiceUnavailable
+        return {'data': [{'id': params['page']}], 'total_pages': 100}
+
+    provider = OpenSubtitlesComProvider(USERNAME, PASSWORD)
+    with patch.object(provider, 'api_get', side_effect=api_get), pytest.raises(ServiceUnavailable):
+        list(provider._search(query='Man of Steel'))
+
+
+def test_search_keeps_results_when_the_connection_fails() -> None:
+    """A connection error stops the pagination, like an error status does."""
+
+    def get(url: str, params: dict[str, Any], timeout: int) -> MagicMock:
+        if params['page'] == 3:
+            raise requests.ConnectionError
+        response = MagicMock(status_code=200)
+        response.json.return_value = {'data': [{'id': params['page']}], 'total_pages': 100}
+        return response
+
+    provider = OpenSubtitlesComProvider(USERNAME, PASSWORD)
+    provider.initialize()
+    with patch.object(provider.session, 'get', side_effect=get):
+        results = list(provider._search(query='Man of Steel'))
+
+    assert [result['id'] for result in results] == [1, 2]


### PR DESCRIPTION
Fixes #1373 - a bug that caused opensubtitles.com search pagination errors to discard all results collected on the pages that succeeded. The fix prevents errors from being re-raised if some results have already been collected by previous iterations.