### PR TITLE
feat(omdb): backfill missing video title and year from the IMDB id

### DIFF
--- a/changelog.d/1375.refiner.rst
+++ b/changelog.d/1375.refiner.rst
@@ -1,0 +1,1 @@
+omdb: use the IMDB id to backfill missing title and year metadata

--- a/src/subliminal/refiners/omdb.py
+++ b/src/subliminal/refiners/omdb.py
@@ -209,8 +209,18 @@ class OMDBClient:
 
 def refine_episode(client: OMDBClient, video: Episode, *, force: bool = False, **kwargs: Any) -> dict[str, Any]:
     """Refine an Episode by searching `OMDb API <https://omdbapi.com/>`_."""
+    series_imdb_id = video.external_ids.get('series_imdb_id')
+
+    if series_imdb_id and not video.series:
+        result = client.search_by_id(series_imdb_id, is_movie=False)
+        if not result:
+            logger.warning('No results for series with IMDB id %r', series_imdb_id)
+            return {}
+        logger.debug('Found series %r', result)
+        return {'series': result['Title'], 'year': split_year_omdb(result['Year'])}
+
     # exit if the information is complete
-    if not force and video.external_ids.get('series_imdb_id') and video.external_ids.get('imdb_id'):  # pragma: no cover
+    if not force and series_imdb_id and video.external_ids.get('imdb_id'):  # pragma: no cover
         logger.debug('No need to search, IMDB ids already exist for the video.')
         return {}
 
@@ -252,8 +262,18 @@ def refine_episode(client: OMDBClient, video: Episode, *, force: bool = False, *
 
 def refine_movie(client: OMDBClient, video: Movie, *, force: bool = False, **kwargs: Any) -> dict[str, Any]:
     """Refine a Movie by searching `OMDb API <https://omdbapi.com/>`_."""
+    imdb_id = video.external_ids.get('imdb_id')
+
+    if imdb_id and not video.title:
+        result = client.search_by_id(imdb_id, is_movie=True)
+        if not result:
+            logger.warning('No results for movie with IMDB id %r', imdb_id)
+            return {}
+        logger.debug('Found movie %r', result)
+        return {'title': result['Title'], 'year': split_year_omdb(result['Year'])}
+
     # exit if the information is complete
-    if not force and video.external_ids.get('imdb_id'):  # pragma: no cover
+    if not force and imdb_id:  # pragma: no cover
         logger.debug('No need to search, IMDB ids already exist for the video.')
         return {}
 
@@ -311,6 +331,11 @@ def refine(video: Video, *, apikey: str | None = None, force: bool = False, **kw
       * :attr:`~subliminal.video.Movie.title`
       * :attr:`~subliminal.video.Movie.year`
       * :attr:`~subliminal.video.Episode.external_ids`, keys 'imdb_id'
+
+    Depending on the metadata of the video, the refiner backfills:
+
+      * the IMDB id, if the title is present
+      * the title and the year, if the IMDB id is present
 
     :param Video video: the Video to refine.
     :param (str | None) apikey: a personal API key to use OMDb.

--- a/tests/cassettes/omdb/test_refine_episode_from_series_imdb_id.yaml
+++ b/tests/cassettes/omdb/test_refine_episode_from_series_imdb_id.yaml
@@ -1,0 +1,57 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - Subliminal/2.7
+    method: GET
+    uri: https://www.omdbapi.com/?r=json&v=1&apikey=7a541ee4&i=tt1723760&plot=short&type=series
+  response:
+    body:
+      string: "{\"Title\":\"Dallas\",\"Year\":\"2012\u20132014\",\"Rated\":\"TV-14\",\"Released\":\"13
+        Jun 2012\",\"Runtime\":\"33S min\",\"Genre\":\"Drama, Romance\",\"Director\":\"N/A\",\"Writer\":\"Cynthia
+        Cidre, David Jacobs\",\"Actors\":\"Josh Henderson, Jesse Metcalfe, Jordana
+        Brewster\",\"Plot\":\"The next generation of the Ewing family, cousins John
+        Ross Ewing and Christopher Ewing, clash over the family's oil business and
+        vast fortune.\",\"Language\":\"English\",\"Country\":\"United States\",\"Awards\":\"10
+        nominations total\",\"Poster\":\"https://m.media-amazon.com/images/M/MV5BMjE5NTExNDc5MF5BMl5BanBnXkFtZTcwMjc1NzAwOQ@@._V1_SX300.jpg\",\"Ratings\":[{\"Source\":\"Internet
+        Movie Database\",\"Value\":\"7.2/10\"}],\"Metascore\":\"N/A\",\"imdbRating\":\"7.2\",\"imdbVotes\":\"10,973\",\"imdbID\":\"tt1723760\",\"Type\":\"series\",\"totalSeasons\":\"3\",\"Response\":\"True\"}"
+    headers:
+      CF-RAY:
+      - a2b0c5a1df19c3bd-WAW
+      Cache-Control:
+      - public, max-age=3600
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 14 Aug 2026 14:50:27 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-allow-origin:
+      - '*'
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '780'
+      expires:
+      - Fri, 14 Aug 2026 15:50:27 GMT
+      last-modified:
+      - Fri, 14 Aug 2026 14:50:27 GMT
+      vary:
+      - '*'
+      x-aspnet-version:
+      - 4.0.30319
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/omdb/test_refine_episode_from_unknown_series_imdb_id.yaml
+++ b/tests/cassettes/omdb/test_refine_episode_from_unknown_series_imdb_id.yaml
@@ -1,0 +1,50 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - Subliminal/2.7
+    method: GET
+    uri: https://www.omdbapi.com/?r=json&v=1&apikey=7a541ee4&i=tt9999999&plot=short&type=series
+  response:
+    body:
+      string: '{"Response":"False","Error":"Error getting data."}'
+    headers:
+      CF-RAY:
+      - a2b0c602dc3c3452-WAW
+      Cache-Control:
+      - public, max-age=3600
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 14 Aug 2026 14:50:43 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-allow-origin:
+      - '*'
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '50'
+      expires:
+      - Fri, 14 Aug 2026 15:50:43 GMT
+      last-modified:
+      - Fri, 14 Aug 2026 14:50:43 GMT
+      vary:
+      - '*'
+      x-aspnet-version:
+      - 4.0.30319
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/omdb/test_refine_movie_from_imdb_id.yaml
+++ b/tests/cassettes/omdb/test_refine_movie_from_imdb_id.yaml
@@ -1,0 +1,58 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - Subliminal/2.7
+    method: GET
+    uri: https://www.omdbapi.com/?r=json&v=1&apikey=7a541ee4&i=tt0770828&plot=short&type=movie
+  response:
+    body:
+      string: '{"Title":"Man of Steel","Year":"2013","Rated":"PG-13","Released":"14
+        Jun 2013","Runtime":"143 min","Genre":"Action, Adventure, Sci-Fi","Director":"Zack
+        Snyder","Writer":"David S. Goyer, Christopher Nolan, Jerry Siegel","Actors":"Henry
+        Cavill, Amy Adams, Michael Shannon","Plot":"An alien child is evacuated from
+        his dying world and sent to Earth to live among humans. His peace is threatened
+        when other survivors of his home planet invade Earth.","Language":"English","Country":"United
+        Kingdom, United States","Awards":"Nominated for 1 BAFTA Award. 7 wins & 46
+        nominations total","Poster":"https://m.media-amazon.com/images/M/MV5BMTk5ODk1NDkxMF5BMl5BanBnXkFtZTcwNTA5OTY0OQ@@._V1_QL75_UY562_CR0,0,380,562_.jpg","Ratings":[{"Source":"Internet
+        Movie Database","Value":"7.1/10"},{"Source":"Rotten Tomatoes","Value":"56%"},{"Source":"Metacritic","Value":"55/100"}],"Metascore":"55","imdbRating":"7.1","imdbVotes":"865,769","imdbID":"tt0770828","Type":"movie","DVD":"N/A","BoxOffice":"$291,045,518","Production":"N/A","Website":"N/A","Response":"True"}'
+    headers:
+      CF-RAY:
+      - a2b0b7859a10ef99-WAW
+      Cache-Control:
+      - public, max-age=3600
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 14 Aug 2026 14:40:49 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-allow-origin:
+      - '*'
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '1046'
+      expires:
+      - Fri, 14 Aug 2026 15:40:49 GMT
+      last-modified:
+      - Fri, 14 Aug 2026 14:40:49 GMT
+      vary:
+      - '*'
+      x-aspnet-version:
+      - 4.0.30319
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/omdb/test_refine_movie_from_unknown_imdb_id.yaml
+++ b/tests/cassettes/omdb/test_refine_movie_from_unknown_imdb_id.yaml
@@ -1,0 +1,50 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Connection:
+      - keep-alive
+      User-Agent:
+      - Subliminal/2.7
+    method: GET
+    uri: https://www.omdbapi.com/?r=json&v=1&apikey=7a541ee4&i=tt9999999&plot=short&type=movie
+  response:
+    body:
+      string: '{"Response":"False","Error":"Error getting data."}'
+    headers:
+      CF-RAY:
+      - a2b0ba78fed91bf9-WAW
+      Cache-Control:
+      - public, max-age=3600
+      Connection:
+      - keep-alive
+      Content-Type:
+      - application/json; charset=utf-8
+      Date:
+      - Fri, 14 Aug 2026 14:42:50 GMT
+      Server:
+      - cloudflare
+      Transfer-Encoding:
+      - chunked
+      access-control-allow-origin:
+      - '*'
+      cf-cache-status:
+      - DYNAMIC
+      content-length:
+      - '50'
+      expires:
+      - Fri, 14 Aug 2026 15:42:50 GMT
+      last-modified:
+      - Fri, 14 Aug 2026 14:42:50 GMT
+      vary:
+      - '*'
+      x-aspnet-version:
+      - 4.0.30319
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/refiners/test_omdb.py
+++ b/tests/refiners/test_omdb.py
@@ -172,6 +172,61 @@ def test_refine_movie(movies: dict[str, Movie]) -> None:
 
 @pytest.mark.integration
 @vcr.use_cassette
+def test_refine_episode_from_series_imdb_id(episodes: dict[str, Episode]) -> None:
+    """The series and the year come from the series IMDB id when the series is missing."""
+    original_episode = episodes['dallas_2012_s01e03']
+    episode = Episode(
+        original_episode.name,
+        '',
+        original_episode.season,
+        original_episode.episodes,
+        external_ids={'series_imdb_id': original_episode.external_ids['series_imdb_id']},
+    )
+    refine(episode, apikey=TEST_OMDB_API_KEY)
+    assert episode.series == original_episode.series
+    assert episode.year == original_episode.year
+
+
+@pytest.mark.integration
+@vcr.use_cassette
+def test_refine_episode_from_unknown_series_imdb_id(episodes: dict[str, Episode]) -> None:
+    """The episode does not change when OMDb does not know the series IMDB id."""
+    original_episode = episodes['dallas_2012_s01e03']
+    episode = Episode(
+        original_episode.name,
+        '',
+        original_episode.season,
+        original_episode.episodes,
+        external_ids={'series_imdb_id': 'tt9999999'},
+    )
+    refine(episode, apikey=TEST_OMDB_API_KEY)
+    assert episode.series == ''
+    assert episode.year is None
+
+
+@pytest.mark.integration
+@vcr.use_cassette
+def test_refine_movie_from_imdb_id(movies: dict[str, Movie]) -> None:
+    """The title and the year come from the IMDB id when the movie has no title."""
+    original_movie = movies['man_of_steel']
+    movie = Movie(original_movie.name, '', external_ids=dict(original_movie.external_ids))
+    refine(movie, apikey=TEST_OMDB_API_KEY)
+    assert movie.title == original_movie.title
+    assert movie.year == original_movie.year
+
+
+@pytest.mark.integration
+@vcr.use_cassette
+def test_refine_movie_from_unknown_imdb_id(movies: dict[str, Movie]) -> None:
+    """The movie does not change when OMDb does not know the IMDB id."""
+    movie = Movie(movies['man_of_steel'].name, '', external_ids={'imdb_id': 'tt9999999'})
+    refine(movie, apikey=TEST_OMDB_API_KEY)
+    assert movie.title == ''
+    assert movie.year is None
+
+
+@pytest.mark.integration
+@vcr.use_cassette
 def test_refine_movie_guess_alternative_title(movies: dict[str, Movie]) -> None:
     original_movie = movies['jack_reacher_never_go_back']
     movie = Movie.fromname(original_movie.name)


### PR DESCRIPTION
Resolves #1375

The omdb refiner searched in one direction only: given a title, it returned an IMDB id. So a video with an IMDB id and no title kept the empty title.

Now the refiner searches by the IMDB id when the title is missing. It backfills the title and the year.

This feature is 100% backward compatible, and it does not affect CLI users. For people who use subliminal as a library, it populates fields that were left empty before. It does not break the contract: `refine()` still returns a `Video`.
