### PR TITLE
OpenSubtitlesCom: download with the api key when no account is configured

### DIFF
--- a/changelog.d/1379.provider.rst
+++ b/changelog.d/1379.provider.rst
@@ -1,0 +1,1 @@
+Fix ``opensubtitlescom`` downloads when an api key is configured without a username and password. ``download_subtitle`` required a login token, but the download endpoint accepts the ``Api-Key`` header on its own, so key-only configurations raised ``AuthenticationError`` on every download.

--- a/src/subliminal/providers/opensubtitlescom.py
+++ b/src/subliminal/providers/opensubtitlescom.py
@@ -307,6 +307,30 @@ def requires_auth(func: C) -> C:
     return cast('C', wrapper)
 
 
+def requires_auth_if_credentials(func: C) -> C:
+    """Decorator for methods that only need a token when credentials were configured.
+
+    :meth:`OpenSubtitlesComProvider.initialize` sets the ``Api-Key`` header on every
+    request, and some endpoints accept it on its own. Requiring a token for those
+    would reject an api-key-only configuration that the API itself allows, and
+    :meth:`OpenSubtitlesComProvider.login` does not even attempt a login without both
+    a username and a password.
+
+    When credentials *are* configured, authentication is still required, so a wrong
+    password raises instead of silently falling back to the anonymous quota.
+    """
+    authenticated = requires_auth(func)
+
+    @wraps(func)
+    def wrapper(self: OpenSubtitlesComProvider, *args: Any, **kwargs: Any) -> Any:
+        if not self.username or not self.password:
+            return func(self, *args, **kwargs)
+
+        return authenticated(self, *args, **kwargs)
+
+    return cast('C', wrapper)
+
+
 class OpenSubtitlesComProvider(Provider):
     """OpenSubtitles.com Provider.
 
@@ -699,7 +723,7 @@ class OpenSubtitlesComProvider(Provider):
             sort_by_download_count=True,
         )
 
-    @requires_auth
+    @requires_auth_if_credentials
     def download_subtitle(self, subtitle: OpenSubtitlesComSubtitle) -> None:
         """Download the content of the subtitle."""
         if not self.session:

--- a/tests/providers/test_opensubtitlescom.py
+++ b/tests/providers/test_opensubtitlescom.py
@@ -1,10 +1,11 @@
 import os
+from types import SimpleNamespace
 
 import pytest
 from babelfish import Language  # type: ignore[import-untyped]
 from vcr import VCR  # type: ignore[import-untyped]
 
-from subliminal.exceptions import ConfigurationError
+from subliminal.exceptions import AuthenticationError, ConfigurationError
 from subliminal.providers.opensubtitlescom import (
     OpenSubtitlesComError,
     OpenSubtitlesComProvider,
@@ -471,3 +472,45 @@ def test_query_max_result_pages(movies: dict[str, Movie]) -> None:
     with OpenSubtitlesComProvider(USERNAME, PASSWORD, max_result_pages=1) as provider:
         subtitles = provider.query(languages, query=query)
     assert len(subtitles) < len(all_subtitles)
+
+
+def test_download_subtitle_with_apikey_only(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Downloading with an api key and no account does not require a token."""
+    provider = OpenSubtitlesComProvider(apikey='fake-apikey')
+    provider.initialize()
+    assert provider.token is None
+
+    subtitle = OpenSubtitlesComSubtitle(language=Language('eng'), subtitle_id='1', file_id=42)
+
+    monkeypatch.setattr(
+        provider,
+        'api_post',
+        lambda path, body: {'link': 'https://example.invalid/subtitle.srt', 'remaining': 99},
+    )
+    monkeypatch.setattr(
+        provider.session,
+        'get',
+        lambda *args, **kwargs: SimpleNamespace(content=b'1\n00:00:01,000 --> 00:00:02,000\nSubtitle\n'),
+    )
+
+    provider.download_subtitle(subtitle)
+
+    assert subtitle.content is not None
+
+
+def test_download_subtitle_with_credentials_still_requires_auth(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Configured credentials that cannot log in still raise, rather than downloading anonymously."""
+    provider = OpenSubtitlesComProvider(USERNAME, 'lanimilbus', apikey='fake-apikey')
+    provider.initialize()
+
+    def unreachable(*args: object, **kwargs: object) -> None:
+        pytest.fail('the download endpoint must not be reached without a token')
+
+    # a login that fails to obtain a token, without touching the network
+    monkeypatch.setattr(provider, 'login', lambda **kwargs: None)
+    monkeypatch.setattr(provider, 'api_post', unreachable)
+
+    subtitle = OpenSubtitlesComSubtitle(language=Language('eng'), subtitle_id='1', file_id=42)
+
+    with pytest.raises(AuthenticationError):
+        provider.download_subtitle(subtitle)


### PR DESCRIPTION
## Problem

`OpenSubtitlesComProvider` accepts an api key with no username or password, but every download made in that configuration fails:

```
subliminal.exceptions.AuthenticationError: Cannot authenticate with username and password
```

`download_subtitle` is decorated with `@requires_auth`, which demands a token. `login()` will not attempt one without both a username and a password:

```python
if not self.username or not self.password:
    logger.info('Cannot log in, a username and password must be provided')
    return
```

So `check_token()` stays false, `requires_auth` raises, and `ProviderPool` discards the provider. Searching works, since `list_subtitles` is not decorated, so the failure looks like "hundreds of candidates found, none downloadable". Via `download_best_subtitles` it surfaces only as an empty result, indistinguishable from a video that genuinely has no subtitles. (Related: #1374.)

The `/download` endpoint does not need a token. `initialize()` already sets the `Api-Key` header on the session, and that alone is accepted:

```
POST https://api.opensubtitles.com/api/v1/download   {"file_id": ...}
200 -> {"link": "...", "file_name": "...", "requests": 1, "remaining": 99}
```

So the key-only path is rejected by the client for a requirement the API does not impose.

## Change

Adds `requires_auth_if_credentials` and applies it to `download_subtitle` only.

- No username or password configured: call through, relying on the `Api-Key` header.
- Credentials configured: delegate to `requires_auth` unchanged, so a wrong password still raises rather than silently falling back to the anonymous quota.

The condition mirrors `login()`'s own guard, so authentication is skipped in exactly the cases where `login()` would decline to attempt it.

`requires_auth` itself is untouched, and `user_infos` keeps it. That endpoint describes a logged-in account and has no meaningful key-only behaviour, so loosening the decorator globally would have been wrong.

## Tests

Two unit tests, no cassette and no network, so they need no credentials in CI:

- `test_download_subtitle_with_apikey_only` — an api-key-only provider reaches the download endpoint and sets subtitle content.
- `test_download_subtitle_with_credentials_still_requires_auth` — a configured account that cannot obtain a token still raises `AuthenticationError`, and the download endpoint is asserted unreachable.

Existing tests in `tests/providers/test_opensubtitlescom.py` pass unchanged.

## Compatibility

No signature or configuration changes. Behaviour with credentials is identical. The only difference is that a key-only configuration, which is already constructible and already documented as supported by `apikey`, now works for downloads instead of raising.
