### PR TITLE
Add a ProviderResult class to keep track of queries to providers

### DIFF
--- a/changelog.d/1381.change.rst
+++ b/changelog.d/1381.change.rst
@@ -1,0 +1,1 @@
+add ProviderResult class to keep track of queries to providers

--- a/src/subliminal/core.py
+++ b/src/subliminal/core.py
@@ -9,6 +9,7 @@ import os
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
+from enum import Enum, auto
 from typing import TYPE_CHECKING, Any
 
 from babelfish import Language  # type: ignore[import-untyped]
@@ -16,7 +17,7 @@ from babelfish import Language  # type: ignore[import-untyped]
 from subliminal.utils import safely_guessit
 
 from .archives import ARCHIVE_ERRORS, ARCHIVE_EXTENSIONS, is_supported_archive, scan_archive
-from .exceptions import ArchiveError, DiscardingError, ProviderQueryError
+from .exceptions import ArchiveError, DiscardingError
 from .extensions import (
     discarded_episode_refiners,
     discarded_movie_refiners,
@@ -43,6 +44,16 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+class ProviderResultStatus(Enum):
+    """The status of the result of a query to a provider."""
+
+    OK = auto()
+    UNSUPPORTED_VIDEO = auto()
+    UNSUPPORTED_LANGUAGES = auto()
+    FAILURE = auto()
+    OUTAGE = auto()
+
+
 @dataclass
 class ProviderResult:
     """Result of asking a provider to list subtitles for the video."""
@@ -51,7 +62,23 @@ class ProviderResult:
     video: Video
     languages: set[Language]
     subtitles: list[Subtitle] = field(default_factory=list)
-    exception: Exception | None = None
+    status: ProviderResultStatus = ProviderResultStatus.OK
+
+    def ok(self) -> bool:
+        """Check if the result is valid and triggered no error."""
+        return self.status == ProviderResultStatus.OK
+
+    def unsupported(self) -> bool:
+        """Check if the video or language was unsupported by the provider."""
+        return self.status in [ProviderResultStatus.UNSUPPORTED_VIDEO, ProviderResultStatus.UNSUPPORTED_LANGUAGES]
+
+    def failure(self) -> bool:
+        """Check if provider failed to return a result because of an error."""
+        return self.status == ProviderResultStatus.FAILURE
+
+    def outage(self) -> bool:
+        """Check if the query triggered an error that requires discarding the provider."""
+        return self.status == ProviderResultStatus.OUTAGE
 
 
 class ProviderPool:
@@ -148,24 +175,25 @@ class ProviderPool:
 
         # check video validity
         if not provider_manager[provider].plugin.check(video):  # type: ignore[attr-defined]
-            msg = f'Skipping provider {provider}: not a valid provider for this video type'
-            logger.info(msg)
-            return ProviderResult(provider, video, languages, subtitles=[], exception=ProviderQueryError(msg))
+            logger.info('Skipping provider %r: not a valid provider for this video type', provider)
+            return ProviderResult(provider, video, languages, status=ProviderResultStatus.UNSUPPORTED_VIDEO)
 
         # check supported languages
         provider_languages = provider_manager[provider].plugin.check_languages(languages)  # type: ignore[attr-defined]
         if not provider_languages:
-            msg = f'Skipping provider {provider}: not a valid provider for the query languages'
-            logger.info(msg)
-            return ProviderResult(provider, video, languages, subtitles=[], exception=ProviderQueryError(msg))
+            logger.info('Skipping provider %r: not a valid provider for the query languages', provider)
+            return ProviderResult(provider, video, languages, status=ProviderResultStatus.UNSUPPORTED_LANGUAGES)
 
         # list subtitles
         logger.info('Listing subtitles with provider %r and languages %r', provider, provider_languages)
         try:
             subtitles = self[provider].list_subtitles(video, provider_languages)
+        except DiscardingError as e:
+            handle_exception(e, f'Provider {provider}')
+            return ProviderResult(provider, video, languages, status=ProviderResultStatus.OUTAGE)
         except Exception as e:  # noqa: BLE001  # pragma: no cover
             handle_exception(e, f'Provider {provider}')
-            return ProviderResult(provider, video, languages, subtitles=[], exception=e)
+            return ProviderResult(provider, video, languages, status=ProviderResultStatus.FAILURE)
 
         return ProviderResult(provider, video, languages, subtitles=subtitles)
 
@@ -190,7 +218,7 @@ class ProviderPool:
 
             # list subtitles
             provider_result = self.list_subtitles_provider(name, video, languages)
-            if isinstance(provider_result.exception, DiscardingError):
+            if provider_result.outage():
                 logger.info('Discarding provider %s', name)
                 self.discarded_providers.add(name)
                 continue
@@ -219,9 +247,11 @@ class ProviderPool:
             self[subtitle.provider_name].download_subtitle(subtitle)
         except ARCHIVE_ERRORS:  # type: ignore[misc]  # pragma: no cover
             logger.exception('Bad archive for subtitle %r', subtitle)
-        except Exception as e:  # noqa: BLE001
+        except DiscardingError as e:
             handle_exception(e, f'Discarding provider {subtitle.provider_name}')
             self.discarded_providers.add(subtitle.provider_name)
+        except Exception as e:  # noqa: BLE001
+            handle_exception(e, f'Failed downloading subtitle with provider {subtitle.provider_name}')
 
         # check subtitle validity
         if not subtitle.is_valid():
@@ -353,7 +383,7 @@ class AsyncProviderPool(ProviderPool):
             )
             for provider_result in executor_map:
                 # discard provider that failed
-                if isinstance(provider_result.exception, DiscardingError):
+                if provider_result.outage():
                     logger.info('Discarding provider %s', provider_result.provider)
                     self.discarded_providers.add(provider_result.provider)
                     continue

--- a/src/subliminal/core.py
+++ b/src/subliminal/core.py
@@ -8,6 +8,7 @@ import operator
 import os
 from collections import defaultdict
 from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, field
 from typing import TYPE_CHECKING, Any
 
 from babelfish import Language  # type: ignore[import-untyped]
@@ -15,7 +16,7 @@ from babelfish import Language  # type: ignore[import-untyped]
 from subliminal.utils import safely_guessit
 
 from .archives import ARCHIVE_ERRORS, ARCHIVE_EXTENSIONS, is_supported_archive, scan_archive
-from .exceptions import ArchiveError, DiscardingError
+from .exceptions import ArchiveError, DiscardingError, ProviderQueryError
 from .extensions import (
     discarded_episode_refiners,
     discarded_movie_refiners,
@@ -40,6 +41,17 @@ if TYPE_CHECKING:
     from subliminal.subtitle import Subtitle
 
 logger = logging.getLogger(__name__)
+
+
+@dataclass
+class ProviderResult:
+    """Result of asking a provider to list subtitles for the video."""
+
+    provider: str
+    video: Video
+    languages: list[Language]
+    subtitles: list[Subtitle] = field(default_factory=list)
+    exception: Exception | None = None
 
 
 class ProviderPool:
@@ -117,7 +129,7 @@ class ProviderPool:
     def __iter__(self) -> Iterator[str]:
         return iter(self.initialized_providers)
 
-    def list_subtitles_provider(self, provider: str, video: Video, languages: Set[Language]) -> list[Subtitle] | None:
+    def list_subtitles_provider(self, provider: str, video: Video, languages: Set[Language]) -> ProviderResult:
         """List subtitles with a single provider.
 
         The video and languages are checked against the provider.
@@ -133,29 +145,26 @@ class ProviderPool:
         """
         # check video validity
         if not provider_manager[provider].plugin.check(video):  # type: ignore[attr-defined]
-            logger.info('Skipping provider %r: not a valid video', provider)
-            return []
+            msg = f'Skipping provider {provider}: not a valid provider for this video type'
+            logger.info(msg)
+            return ProviderResult(provider, video, languages, subtitles=[], exception=ProviderQueryError(msg))
 
         # check supported languages
         provider_languages = provider_manager[provider].plugin.check_languages(languages)  # type: ignore[attr-defined]
         if not provider_languages:
-            logger.info('Skipping provider %r: no language to search for', provider)
-            return []
+            msg = f'Skipping provider {provider}: not a valid provider for the query languages'
+            logger.info(msg)
+            return ProviderResult(provider, video, languages, subtitles=[], exception=ProviderQueryError(msg))
 
         # list subtitles
         logger.info('Listing subtitles with provider %r and languages %r', provider, provider_languages)
         try:
             subtitles = self[provider].list_subtitles(video, provider_languages)
-        except DiscardingError as e:
-            handle_exception(e, f'Provider {provider}')
-            # return None to discard this provider with a known error
-            return None
         except Exception as e:  # noqa: BLE001  # pragma: no cover
             handle_exception(e, f'Provider {provider}')
-            # return [] so the provider is not discarded with unknown error
-            return []
+            return ProviderResult(provider, video, languages, subtitles=[], exception=e)
 
-        return subtitles
+        return ProviderResult(provider, video, languages, subtitles=subtitles)
 
     def list_subtitles(self, video: Video, languages: Set[Language]) -> list[Subtitle]:
         """List subtitles.
@@ -177,14 +186,14 @@ class ProviderPool:
                 continue
 
             # list subtitles
-            provider_subtitles = self.list_subtitles_provider(name, video, languages)
-            if provider_subtitles is None:
+            provider_result = self.list_subtitles_provider(name, video, languages)
+            if isinstance(provider_result.exception, DiscardingError):
                 logger.info('Discarding provider %s', name)
                 self.discarded_providers.add(name)
                 continue
 
             # add the subtitles
-            subtitles.extend(provider_subtitles)
+            subtitles.extend(provider_result.subtitles)
 
         return subtitles
 
@@ -324,15 +333,6 @@ class AsyncProviderPool(ProviderPool):
         #: Maximum number of threads to use
         self.max_workers = max_workers or len(self.providers)
 
-    def list_subtitles_provider_tuple(
-        self,
-        provider: str,
-        video: Video,
-        languages: Set[Language],
-    ) -> tuple[str, list[Subtitle] | None]:
-        """List subtitles with a single provider, multi-threaded."""
-        return provider, super().list_subtitles_provider(provider, video, languages)
-
     def list_subtitles(self, video: Video, languages: Set[Language]) -> list[Subtitle]:
         """List subtitles, multi-threaded."""
         subtitles: list[Subtitle] = []
@@ -343,20 +343,20 @@ class AsyncProviderPool(ProviderPool):
 
         with ThreadPoolExecutor(self.max_workers) as executor:
             executor_map = executor.map(
-                self.list_subtitles_provider_tuple,
+                self.list_subtitles_provider,
                 self.providers,
                 itertools.repeat(video, len(self.providers)),
                 itertools.repeat(languages, len(self.providers)),
             )
-            for provider, provider_subtitles in executor_map:
+            for provider_result in executor_map:
                 # discard provider that failed
-                if provider_subtitles is None:
-                    logger.info('Discarding provider %s', provider)
-                    self.discarded_providers.add(provider)
+                if isinstance(provider_result.exception, DiscardingError):
+                    logger.info('Discarding provider %s', provider_result.provider)
+                    self.discarded_providers.add(provider_result.provider)
                     continue
 
                 # add subtitles
-                subtitles.extend(provider_subtitles)
+                subtitles.extend(provider_result.subtitles)
 
         return subtitles
 

--- a/src/subliminal/core.py
+++ b/src/subliminal/core.py
@@ -250,8 +250,8 @@ class ProviderPool:
         except DiscardingError as e:
             handle_exception(e, f'Discarding provider {subtitle.provider_name}')
             self.discarded_providers.add(subtitle.provider_name)
-        except Exception as e:  # noqa: BLE001
-            handle_exception(e, f'Failed downloading subtitle with provider {subtitle.provider_name}')
+        except Exception as e:  # noqa: BLE001  # pragma: no cover
+            handle_exception(e, f'Failed to download subtitle with provider {subtitle.provider_name}')
 
         # check subtitle validity
         if not subtitle.is_valid():

--- a/src/subliminal/core.py
+++ b/src/subliminal/core.py
@@ -49,7 +49,7 @@ class ProviderResult:
 
     provider: str
     video: Video
-    languages: list[Language]
+    languages: set[Language]
     subtitles: list[Subtitle] = field(default_factory=list)
     exception: Exception | None = None
 
@@ -143,6 +143,9 @@ class ProviderPool:
         :rtype: list of :class:`~subliminal.subtitle.Subtitle` or None
 
         """
+        # make sure the type is correct
+        languages = set(languages)
+
         # check video validity
         if not provider_manager[provider].plugin.check(video):  # type: ignore[attr-defined]
             msg = f'Skipping provider {provider}: not a valid provider for this video type'

--- a/src/subliminal/exceptions.py
+++ b/src/subliminal/exceptions.py
@@ -19,6 +19,12 @@ class GuessingError(Error, ValueError):
     pass
 
 
+class ProviderQueryError(Error):
+    """Exception raised when a query to a provider is invalid."""
+
+    pass
+
+
 class ProviderError(Error):
     """Exception raised by providers."""
 

--- a/src/subliminal/exceptions.py
+++ b/src/subliminal/exceptions.py
@@ -19,12 +19,6 @@ class GuessingError(Error, ValueError):
     pass
 
 
-class ProviderQueryError(Error):
-    """Exception raised when a query to a provider is invalid."""
-
-    pass
-
-
 class ProviderError(Error):
     """Exception raised by providers."""
 

--- a/tests/providers/test_providers.py
+++ b/tests/providers/test_providers.py
@@ -58,15 +58,6 @@ def test_provider_pool_iter() -> None:
 
 
 @pytest.mark.usefixtures('_mock_providers')
-def test_provider_pool_list_subtitles_provider(episodes: dict[str, Episode]) -> None:
-    pool = ProviderPool()
-    subtitles = pool.list_subtitles_provider('tvsubtitles', episodes['bbt_s07e05'], {Language('eng')})
-    assert subtitles == ['tvsubtitles']  # type: ignore[comparison-overlap]
-    assert provider_manager['tvsubtitles'].plugin.initialize.called  # type: ignore[attr-defined]
-    assert provider_manager['tvsubtitles'].plugin.list_subtitles.called  # type: ignore[attr-defined]
-
-
-@pytest.mark.usefixtures('_mock_providers')
 def test_provider_pool_list_subtitles(episodes: dict[str, Episode]) -> None:
     pool = ProviderPool()
     subtitles = pool.list_subtitles(episodes['bbt_s07e05'], {Language('eng')})
@@ -83,15 +74,6 @@ def test_provider_pool_list_subtitles(episodes: dict[str, Episode]) -> None:
         provider_s = cast('str', provider)
         assert provider_manager[provider_s].plugin.initialize.called  # type: ignore[attr-defined]
         assert provider_manager[provider_s].plugin.list_subtitles.called  # type: ignore[attr-defined]
-
-
-@pytest.mark.usefixtures('_mock_providers')
-def test_async_provider_pool_list_subtitles_provider(episodes: dict[str, Episode]) -> None:
-    pool = AsyncProviderPool()
-    subtitles = pool.list_subtitles_provider_tuple('tvsubtitles', episodes['bbt_s07e05'], {Language('eng')})
-    assert subtitles == ('tvsubtitles', ['tvsubtitles'])  # type: ignore[comparison-overlap]
-    assert provider_manager['tvsubtitles'].plugin.initialize.called  # type: ignore[attr-defined]
-    assert provider_manager['tvsubtitles'].plugin.list_subtitles.called  # type: ignore[attr-defined]
 
 
 @pytest.mark.usefixtures('_mock_providers')

--- a/tests/test_provider_pool.py
+++ b/tests/test_provider_pool.py
@@ -111,7 +111,7 @@ def test_provider_pool_list_subtitles_provider(
     assert provider_result.video == episode
     assert provider_result.languages == languages
     assert provider_result.subtitles == ['tvsubtitles']  # type: ignore[comparison-overlap]
-    assert provider_result.exception is None
+    assert provider_result.ok()
     assert provider_manager['tvsubtitles'].plugin.initialize.called  # type: ignore[attr-defined]
     assert provider_manager['tvsubtitles'].plugin.list_subtitles.called  # type: ignore[attr-defined]
 
@@ -503,7 +503,7 @@ def test_download_best_subtitles_wrong_fps(episodes: dict[str, Episode]) -> None
 def test_download_bad_subtitle(movies: dict[str, Movie]) -> None:
     pool = ProviderPool()
     provider_result = pool.list_subtitles_provider('opensubtitlescom', movies['man_of_steel'], {Language('tur')})
-    assert provider_result.exception is None
+    assert provider_result.ok()
     assert len(provider_result.subtitles) >= 1
     subtitle = provider_result.subtitles[0]
 

--- a/tests/test_provider_pool.py
+++ b/tests/test_provider_pool.py
@@ -103,9 +103,15 @@ def test_provider_pool_list_subtitles_provider(
     episodes: dict[str, Episode],
     provider_manager: RegistrableExtensionManager,
 ) -> None:
+    episode = episodes['bbt_s07e05']
+    languages = {Language('eng')}
     pool = ProviderPool()
-    subtitles = pool.list_subtitles_provider('tvsubtitles', episodes['bbt_s07e05'], {Language('eng')})
-    assert subtitles == ['tvsubtitles']  # type: ignore[comparison-overlap]
+    provider_result = pool.list_subtitles_provider('tvsubtitles', episode, languages)
+    assert provider_result.provider == 'tvsubtitles'
+    assert provider_result.video == episode
+    assert provider_result.languages == languages
+    assert provider_result.subtitles == ['tvsubtitles']  # type: ignore[comparison-overlap]
+    assert provider_result.exception is None
     assert provider_manager['tvsubtitles'].plugin.initialize.called  # type: ignore[attr-defined]
     assert provider_manager['tvsubtitles'].plugin.list_subtitles.called  # type: ignore[attr-defined]
 
@@ -127,18 +133,6 @@ def test_provider_pool_list_subtitles(
         provider_s = cast('str', provider)
         assert provider_manager[provider_s].plugin.initialize.called  # type: ignore[attr-defined]
         assert provider_manager[provider_s].plugin.list_subtitles.called  # type: ignore[attr-defined]
-
-
-@pytest.mark.usefixtures('_mock_providers')
-def test_async_provider_pool_list_subtitles_provider(
-    episodes: dict[str, Episode],
-    provider_manager: RegistrableExtensionManager,
-) -> None:
-    pool = AsyncProviderPool()
-    subtitles = pool.list_subtitles_provider_tuple('tvsubtitles', episodes['bbt_s07e05'], {Language('eng')})
-    assert subtitles == ('tvsubtitles', ['tvsubtitles'])  # type: ignore[comparison-overlap]
-    assert provider_manager['tvsubtitles'].plugin.initialize.called  # type: ignore[attr-defined]
-    assert provider_manager['tvsubtitles'].plugin.list_subtitles.called  # type: ignore[attr-defined]
 
 
 @pytest.mark.usefixtures('_mock_providers')
@@ -508,10 +502,10 @@ def test_download_best_subtitles_wrong_fps(episodes: dict[str, Episode]) -> None
 
 def test_download_bad_subtitle(movies: dict[str, Movie]) -> None:
     pool = ProviderPool()
-    subtitles = pool.list_subtitles_provider('opensubtitlescom', movies['man_of_steel'], {Language('tur')})
-    assert subtitles is not None
-    assert len(subtitles) >= 1
-    subtitle = subtitles[0]
+    provider_result = pool.list_subtitles_provider('opensubtitlescom', movies['man_of_steel'], {Language('tur')})
+    assert provider_result.exception is None
+    assert len(provider_result.subtitles) >= 1
+    subtitle = provider_result.subtitles[0]
 
     # The subtitle has no content
     pool.download_subtitle(subtitle)

--- a/tests/test_provider_pool.py
+++ b/tests/test_provider_pool.py
@@ -112,6 +112,9 @@ def test_provider_pool_list_subtitles_provider(
     assert provider_result.languages == languages
     assert provider_result.subtitles == ['tvsubtitles']  # type: ignore[comparison-overlap]
     assert provider_result.ok()
+    assert not provider_result.unsupported()
+    assert not provider_result.failure()
+    assert not provider_result.outage()
     assert provider_manager['tvsubtitles'].plugin.initialize.called  # type: ignore[attr-defined]
     assert provider_manager['tvsubtitles'].plugin.list_subtitles.called  # type: ignore[attr-defined]
 


### PR DESCRIPTION
First step to solve #1374 

Keep track of the query and result (list of subtitles or exception) of the `ProviderPool.list_subtitles_provider` method, to be used downstream to keep track of discarded or failed providers.

